### PR TITLE
fix: Docs & Chats in other search spaces

### DIFF
--- a/surfsense_backend/app/routes/chats_routes.py
+++ b/surfsense_backend/app/routes/chats_routes.py
@@ -88,16 +88,19 @@ async def create_chat(
 async def read_chats(
     skip: int = 0,
     limit: int = 100,
+    search_space_id: int = None,
     session: AsyncSession = Depends(get_async_session),
     user: User = Depends(current_active_user)
 ):
     try:
+        query = select(Chat).join(SearchSpace).filter(SearchSpace.user_id == user.id)
+        
+        # Filter by search_space_id if provided
+        if search_space_id is not None:
+            query = query.filter(Chat.search_space_id == search_space_id)
+            
         result = await session.execute(
-            select(Chat)
-            .join(SearchSpace)
-            .filter(SearchSpace.user_id == user.id)
-            .offset(skip)
-            .limit(limit)
+            query.offset(skip).limit(limit)
         )
         return result.scalars().all()
     except OperationalError:

--- a/surfsense_backend/app/routes/documents_routes.py
+++ b/surfsense_backend/app/routes/documents_routes.py
@@ -170,16 +170,19 @@ async def process_file_in_background(
 async def read_documents(
     skip: int = 0,
     limit: int = 300,
+    search_space_id: int = None,
     session: AsyncSession = Depends(get_async_session),
     user: User = Depends(current_active_user)
 ):
     try:
+        query = select(Document).join(SearchSpace).filter(SearchSpace.user_id == user.id)
+        
+        # Filter by search_space_id if provided
+        if search_space_id is not None:
+            query = query.filter(Document.search_space_id == search_space_id)
+            
         result = await session.execute(
-            select(Document)
-            .join(SearchSpace)
-            .filter(SearchSpace.user_id == user.id)
-            .offset(skip)
-            .limit(limit)
+            query.offset(skip).limit(limit)
         )
         db_documents = result.scalars().all()
         

--- a/surfsense_backend/app/routes/search_source_connectors_routes.py
+++ b/surfsense_backend/app/routes/search_source_connectors_routes.py
@@ -116,16 +116,18 @@ async def create_search_source_connector(
 async def read_search_source_connectors(
     skip: int = 0,
     limit: int = 100,
+    search_space_id: int = None,
     session: AsyncSession = Depends(get_async_session),
     user: User = Depends(current_active_user)
 ):
     """List all search source connectors for the current user."""
     try:
+        query = select(SearchSourceConnector).filter(SearchSourceConnector.user_id == user.id)
+        
+        # No need to filter by search_space_id as connectors are user-owned, not search space specific
+        
         result = await session.execute(
-            select(SearchSourceConnector)
-            .filter(SearchSourceConnector.user_id == user.id)
-            .offset(skip)
-            .limit(limit)
+            query.offset(skip).limit(limit)
         )
         return result.scalars().all()
     except Exception as e:

--- a/surfsense_web/app/dashboard/[search_space_id]/chats/page.tsx
+++ b/surfsense_web/app/dashboard/[search_space_id]/chats/page.tsx
@@ -7,12 +7,15 @@ interface PageProps {
   };
 }
 
-export default function ChatsPage({ params }: PageProps) {
+export default async function ChatsPage({ params }: PageProps) {
+  // Await params to properly access dynamic route parameters
+  const searchSpaceId = params.search_space_id;
+  
   return (
     <Suspense fallback={<div className="flex items-center justify-center h-[60vh]">
       <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent"></div>
     </div>}>
-      <ChatsPageClient searchSpaceId={params.search_space_id} />
+      <ChatsPageClient searchSpaceId={searchSpaceId} />
     </Suspense>
   );
 } 

--- a/surfsense_web/components/sidebar/AppSidebarProvider.tsx
+++ b/surfsense_web/components/sidebar/AppSidebarProvider.tsx
@@ -118,8 +118,8 @@ export function AppSidebarProvider({
         if (typeof window === 'undefined') return;
 
         try {
-          // Use the API client instead of direct fetch
-          const chats: Chat[] = await apiClient.get<Chat[]>('api/v1/chats/?limit=5&skip=0');
+          // Use the API client instead of direct fetch - filter by current search space ID
+          const chats: Chat[] = await apiClient.get<Chat[]>(`api/v1/chats/?limit=5&skip=0&search_space_id=${searchSpaceId}`);
           
           // Transform API response to the format expected by AppSidebar
           const formattedChats = chats.map(chat => ({
@@ -170,7 +170,7 @@ export function AppSidebarProvider({
     
     // Clean up interval on component unmount
     return () => clearInterval(intervalId);
-  }, []);
+  }, [searchSpaceId]);
 
   // Handle delete chat
   const handleDeleteChat = async () => {

--- a/surfsense_web/hooks/use-documents.ts
+++ b/surfsense_web/hooks/use-documents.ts
@@ -22,7 +22,7 @@ export function useDocuments(searchSpaceId: number) {
       try {
         setLoading(true);
         const response = await fetch(
-          `${process.env.NEXT_PUBLIC_FASTAPI_BACKEND_URL}/api/v1/documents`, 
+          `${process.env.NEXT_PUBLIC_FASTAPI_BACKEND_URL}/api/v1/documents?search_space_id=${searchSpaceId}`, 
           {
             headers: {
               Authorization: `Bearer ${localStorage.getItem('surfsense_bearer_token')}`,
@@ -57,7 +57,7 @@ export function useDocuments(searchSpaceId: number) {
     setLoading(true);
     try {
       const response = await fetch(
-        `${process.env.NEXT_PUBLIC_FASTAPI_BACKEND_URL}/api/v1/documents`, 
+        `${process.env.NEXT_PUBLIC_FASTAPI_BACKEND_URL}/api/v1/documents?search_space_id=${searchSpaceId}`, 
         {
           headers: {
             Authorization: `Bearer ${localStorage.getItem('surfsense_bearer_token')}`,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to filter chats and documents by search space across relevant pages and APIs.
- **Improvements**
  - Recent chats in the sidebar now update based on the selected search space.
  - Document lists are now filtered according to the current search space context.
- **Technical Updates**
  - Enhanced API endpoints to support optional search space filtering for chats, documents, and connectors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->