### PR TITLE
Feat/GitHub actions docker publish

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,74 @@
+name: Docker Publish
+
+on:
+  push:
+    branches: [ "main" ]
+
+jobs:
+  build_and_push_backend:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push backend image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./surfsense_backend
+          file: ./surfsense_backend/Dockerfile
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/surfsense_backend:${{ github.sha }}
+          labels: |
+            org.opencontainers.image.source=${{ github.repositoryUrl }}
+            org.opencontainers.image.created=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
+            org.opencontainers.image.revision=${{ github.sha }}
+
+  build_and_push_frontend:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push frontend image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./surfsense_web
+          file: ./surfsense_web/Dockerfile
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/surfsense_web:${{ github.sha }}
+          labels: |
+            org.opencontainers.image.source=${{ github.repositoryUrl }}
+            org.opencontainers.image.created=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
+            org.opencontainers.image.revision=${{ github.sha }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -34,6 +34,7 @@ jobs:
           file: ./surfsense_backend/Dockerfile
           push: true
           tags: ghcr.io/${{ github.repository_owner }}/surfsense_backend:${{ github.sha }}
+          platforms: linux/amd64,linux/arm64
           labels: |
             org.opencontainers.image.source=${{ github.repositoryUrl }}
             org.opencontainers.image.created=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}
@@ -68,6 +69,7 @@ jobs:
           file: ./surfsense_web/Dockerfile
           push: true
           tags: ghcr.io/${{ github.repository_owner }}/surfsense_web:${{ github.sha }}
+          platforms: linux/amd64,linux/arm64
           labels: |
             org.opencontainers.image.source=${{ github.repositoryUrl }}
             org.opencontainers.image.created=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.created'] }}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR Adds Github Docker Registry CI Build thru GH Actions.

## Motivation and Context
Having the images ready to pull will simplify deployment at scale without requiring orgs to fork/build the application.

## Changes Overview
Adds GH Actions to build CI images for x86 and ARM64

## Types of changes
- [ ] New feature (non-breaking change which adds functionality)

## Testing
- [ ] I have tested these changes locally

## Checklist:
- [ ] My change requires documentation updates
- [ ] I have updated the documentation accordingly
- [ ] My code builds clean without any errors or warnings
- [ ] All new and existing tests passed 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Introduced automated workflows to build and publish backend and frontend Docker images for each push to the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->