### PR TITLE
fix(auth): show clear message instead of error code on login failure

### DIFF
--- a/surfsense_backend/app/users.py
+++ b/surfsense_backend/app/users.py
@@ -88,9 +88,15 @@ class CustomBearerTransport(BearerTransport):
         else:
             return JSONResponse(model_dump(bearer_response))
 
+    async def get_login_failure_response(self) -> Response:
+        # 👇 This is the new part — gives a clear message instead of raw error code
+        return JSONResponse(
+            status_code=401,
+            content={"detail": "Wrong username or password"},
+        )
+
 
 bearer_transport = CustomBearerTransport(tokenUrl="auth/jwt/login")
-
 
 auth_backend = AuthenticationBackend(
     name="jwt",

--- a/surfsense_web/app/login/LocalLoginForm.tsx
+++ b/surfsense_web/app/login/LocalLoginForm.tsx
@@ -42,17 +42,21 @@ export function LocalLoginForm() {
 			const data = await response.json();
 
 			if (!response.ok) {
-				throw new Error(data.detail || "Failed to login");
+				// 👇 Instead of generic error, show backend’s message
+				setError(data.detail || "Wrong username or password");
+				return;
 			}
 
 			router.push(`/auth/callback?token=${data.access_token}`);
 		} catch (err) {
-			const errorMessage = err instanceof Error ? err.message : "An error occurred during login";
+			const errorMessage =
+				err instanceof Error ? err.message : "An error occurred during login";
 			setError(errorMessage);
 		} finally {
 			setIsLoading(false);
 		}
 	};
+
 
 	return (
 		<div className="w-full max-w-md">


### PR DESCRIPTION
## Description  
This PR improves the login experience by replacing confusing error codes with a clear message when authentication fails. Instead of showing a raw error response, users now see a friendly message that tells them their username or password is incorrect.  

## Motivation and Context  
Right now, entering wrong credentials results in a technical error code that doesn’t really help users understand what went wrong. This can be frustrating and unclear. With this change, users get a straightforward message so they know exactly what happened and can try again.  

FIX #322  

## Changes Overview  
- Updated login error handling to show `"Wrong username or password"` instead of a raw error code  
- Improved feedback flow for failed JWT authentication  
- Minor cleanup in error state handling for clarity  

## API Changes  
- [ ] This PR includes API changes  

## Types of changes  
- [x] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature  
- [ ] Performance improvement  
- [ ] Documentation update  
- [ ] Breaking change  

## Testing  
- [x] Tested locally with invalid credentials → correct message shown  
- [x] Tested with valid credentials → normal login flow works  

## Checklist:  
- [x] My code follows the code style of this project  
- [ ] My change requires documentation updates  
- [ ] I have updated the documentation accordingly  
- [ ] My change requires dependency updates  
- [ ] I have updated the dependencies accordingly  
- [x] My code builds clean without any errors or warnings  
- [x] All new and existing tests passed  

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR improves the user experience by replacing technical error codes with a clear, user-friendly message when authentication fails. The changes include adding a dedicated function for login failure responses in the backend that returns a consistent "Wrong username or password" message with a 401 status code, and updating the frontend login form to display this message directly to the user instead of throwing a generic error. These changes make the login flow more intuitive and help users understand exactly what went wrong when they enter incorrect credentials.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_backend/app/users.py` |
| 2 | `surfsense_web/app/login/LocalLoginForm.tsx` |
</details>



<!-- RECURSEML_SUMMARY:END -->

<!-- RECURSEML_ANALYSIS:START -->
## Review by RecurseML

 _🔍 Review performed on [40b5161..779ec59](https://github.com/MODSetter/SurfSense/compare/40b5161a52cc6d3e90a90bb8a69cb0aaca6bbf20...779ec599a2dbb4fa294ddb7b20546a6e1b36d7db)_

✨ No bugs found, your code is sparkling clean

<details>
<summary>✅ Files analyzed, no issues (2)</summary>

  • `surfsense_backend/app/users.py`
  • `surfsense_web/app/login/LocalLoginForm.tsx`
</details>

[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/bfe2329dd56b28d6d74602e5c1baa1cb2031303ff18c4c707914e60e684d087a/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=323)

[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)
<!-- RECURSEML_ANALYSIS:END -->