### PR TITLE
fix: sitemap

### DIFF
--- a/surfsense_web/app/sitemap.ts
+++ b/surfsense_web/app/sitemap.ts
@@ -3,43 +3,49 @@ import type { MetadataRoute } from "next";
 export default function sitemap(): MetadataRoute.Sitemap {
 	return [
 		{
-			url: "https://www.surfsense.net/",
+			url: "https://www.surfsense.com/",
 			lastModified: new Date(),
 			changeFrequency: "yearly",
 			priority: 1,
 		},
 		{
-			url: "https://www.surfsense.net/privacy",
+			url: "https://www.surfsense.com/contact",
+			lastModified: new Date(),
+			changeFrequency: "yearly",
+			priority: 1,
+		},
+		{
+			url: "https://www.surfsense.com/privacy",
 			lastModified: new Date(),
 			changeFrequency: "monthly",
 			priority: 0.9,
 		},
 		{
-			url: "https://www.surfsense.net/terms",
+			url: "https://www.surfsense.com/terms",
 			lastModified: new Date(),
 			changeFrequency: "monthly",
 			priority: 0.9,
 		},
 		{
-			url: "https://www.surfsense.net/docs",
+			url: "https://www.surfsense.com/docs",
 			lastModified: new Date(),
 			changeFrequency: "weekly",
 			priority: 0.9,
 		},
 		{
-			url: "https://www.surfsense.net/docs/installation",
+			url: "https://www.surfsense.com/docs/installation",
 			lastModified: new Date(),
 			changeFrequency: "weekly",
 			priority: 0.9,
 		},
 		{
-			url: "https://www.surfsense.net/docs/docker-installation",
+			url: "https://www.surfsense.com/docs/docker-installation",
 			lastModified: new Date(),
 			changeFrequency: "weekly",
 			priority: 0.9,
 		},
 		{
-			url: "https://www.surfsense.net/docs/manual-installation",
+			url: "https://www.surfsense.com/docs/manual-installation",
 			lastModified: new Date(),
 			changeFrequency: "weekly",
 			priority: 0.9,


### PR DESCRIPTION
fix: sitemap

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR updates the website sitemap configuration by changing the domain from `surfsense.net` to `surfsense.com` for all URLs. It also adds a new sitemap entry for the `/contact` page with yearly change frequency and priority 1.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/app/sitemap.ts` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/79cab53ddfdf048809b202ba78011f157a1fd8499d249c113a1367dba50a0d4a/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=347)
<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated sitemap URLs from surfsense.net to surfsense.com across all listed pages.
  * Added the Privacy page to the sitemap while keeping Contact and other key pages included.
  * Preserved existing update frequencies (e.g., weekly/monthly) and last modified metadata where applicable.
  * Ensures search engines index the correct domain and comprehensive set of pages without altering application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->