### PR TITLE
feat: Moved searchconnectors association from user to searchspace

### DIFF
--- a/surfsense_backend/alembic/versions/23_associate_connectors_with_search_spaces.py
+++ b/surfsense_backend/alembic/versions/23_associate_connectors_with_search_spaces.py
@@ -1,0 +1,159 @@
+"""Associate SearchSourceConnector with SearchSpace instead of User
+
+Revision ID: '23'
+Revises: '22'
+Create Date: 2025-01-10 12:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "23"
+down_revision: str | None = "22"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """
+    Add search_space_id to SearchSourceConnector and update unique constraint.
+
+    Changes:
+    1. Add search_space_id column (nullable initially)
+    2. Populate search_space_id with user's first search space
+    3. Make search_space_id NOT NULL
+    4. Add foreign key constraint
+    5. Drop old unique constraint (user_id, connector_type)
+    6. Add new unique constraint (search_space_id, user_id, connector_type)
+    """
+
+    from sqlalchemy import inspect
+
+    conn = op.get_bind()
+    inspector = inspect(conn)
+
+    # Get existing columns
+    columns = [col["name"] for col in inspector.get_columns("search_source_connectors")]
+
+    # Step 1: Add search_space_id column as nullable first (if it doesn't exist)
+    if "search_space_id" not in columns:
+        op.add_column(
+            "search_source_connectors",
+            sa.Column("search_space_id", sa.Integer(), nullable=True),
+        )
+
+    # Step 2: Populate search_space_id with each user's first search space
+    # This ensures existing connectors are assigned to a valid search space
+    op.execute(
+        """
+        UPDATE search_source_connectors ssc
+        SET search_space_id = (
+            SELECT id 
+            FROM searchspaces ss 
+            WHERE ss.user_id = ssc.user_id 
+            ORDER BY ss.created_at ASC 
+            LIMIT 1
+        )
+        WHERE search_space_id IS NULL
+        """
+    )
+
+    # Step 3: Make search_space_id NOT NULL
+    op.alter_column(
+        "search_source_connectors",
+        "search_space_id",
+        nullable=False,
+    )
+
+    # Step 4: Add foreign key constraint (if it doesn't exist)
+    foreign_keys = [
+        fk["name"] for fk in inspector.get_foreign_keys("search_source_connectors")
+    ]
+    if "fk_search_source_connectors_search_space_id" not in foreign_keys:
+        op.create_foreign_key(
+            "fk_search_source_connectors_search_space_id",
+            "search_source_connectors",
+            "searchspaces",
+            ["search_space_id"],
+            ["id"],
+            ondelete="CASCADE",
+        )
+
+    # Step 5: Drop the old unique constraint (user_id, connector_type) if it exists
+    unique_constraints = [
+        uc["name"]
+        for uc in inspector.get_unique_constraints("search_source_connectors")
+    ]
+    if "uq_user_connector_type" in unique_constraints:
+        op.drop_constraint(
+            "uq_user_connector_type",
+            "search_source_connectors",
+            type_="unique",
+        )
+
+    # Step 6: Create new unique constraint (search_space_id, user_id, connector_type) if it doesn't exist
+    if "uq_searchspace_user_connector_type" not in unique_constraints:
+        op.create_unique_constraint(
+            "uq_searchspace_user_connector_type",
+            "search_source_connectors",
+            ["search_space_id", "user_id", "connector_type"],
+        )
+
+
+def downgrade() -> None:
+    """
+    Revert SearchSourceConnector association back to User only.
+
+    WARNING: This downgrade may result in data loss if multiple connectors
+    of the same type exist for a user across different search spaces.
+    """
+
+    from sqlalchemy import inspect
+
+    conn = op.get_bind()
+    inspector = inspect(conn)
+
+    # Get existing constraints and columns
+    unique_constraints = [
+        uc["name"]
+        for uc in inspector.get_unique_constraints("search_source_connectors")
+    ]
+    foreign_keys = [
+        fk["name"] for fk in inspector.get_foreign_keys("search_source_connectors")
+    ]
+    columns = [col["name"] for col in inspector.get_columns("search_source_connectors")]
+
+    # Step 1: Drop the new unique constraint if it exists
+    if "uq_searchspace_user_connector_type" in unique_constraints:
+        op.drop_constraint(
+            "uq_searchspace_user_connector_type",
+            "search_source_connectors",
+            type_="unique",
+        )
+
+    # Step 2: Recreate the old unique constraint (user_id, connector_type) if it doesn't exist
+    # NOTE: This will fail if there are duplicate (user_id, connector_type) combinations
+    # Manual cleanup may be required before downgrading
+    if "uq_user_connector_type" not in unique_constraints:
+        op.create_unique_constraint(
+            "uq_user_connector_type",
+            "search_source_connectors",
+            ["user_id", "connector_type"],
+        )
+
+    # Step 3: Drop the foreign key constraint if it exists
+    if "fk_search_source_connectors_search_space_id" in foreign_keys:
+        op.drop_constraint(
+            "fk_search_source_connectors_search_space_id",
+            "search_source_connectors",
+            type_="foreignkey",
+        )
+
+    # Step 4: Drop the search_space_id column if it exists
+    if "search_space_id" in columns:
+        op.drop_column("search_source_connectors", "search_space_id")

--- a/surfsense_backend/alembic/versions/24_fix_null_chat_types.py
+++ b/surfsense_backend/alembic/versions/24_fix_null_chat_types.py
@@ -1,0 +1,39 @@
+"""Fix NULL chat types by setting them to QNA
+
+Revision ID: 24
+Revises: 23
+Create Date: 2025-01-10 14:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "24"
+down_revision: str | None = "23"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """
+    Fix any chats with NULL type values by setting them to QNA.
+    This handles edge cases from previous migrations where type values were not properly migrated.
+    """
+    # Update any NULL type values to QNA (the default chat type)
+    op.execute(
+        """
+        UPDATE chats
+        SET type = 'QNA'
+        WHERE type IS NULL
+        """
+    )
+
+
+def downgrade() -> None:
+    """
+    No downgrade necessary - we can't restore NULL values as we don't know which ones were NULL.
+    """
+    pass

--- a/surfsense_backend/app/agents/researcher/nodes.py
+++ b/surfsense_backend/app/agents/researcher/nodes.py
@@ -1010,7 +1010,10 @@ async def fetch_relevant_documents(
                         source_object,
                         tavily_chunks,
                     ) = await connector_service.search_tavily(
-                        user_query=reformulated_query, user_id=user_id, top_k=top_k
+                        user_query=reformulated_query,
+                        user_id=user_id,
+                        search_space_id=search_space_id,
+                        top_k=top_k,
                     )
 
                     # Add to sources and raw documents
@@ -1037,6 +1040,7 @@ async def fetch_relevant_documents(
                     ) = await connector_service.search_linkup(
                         user_query=reformulated_query,
                         user_id=user_id,
+                        search_space_id=search_space_id,
                         mode=linkup_mode,
                     )
 

--- a/surfsense_backend/app/connectors/google_calendar_connector.py
+++ b/surfsense_backend/app/connectors/google_calendar_connector.py
@@ -31,15 +31,20 @@ class GoogleCalendarConnector:
         credentials: Credentials,
         session: AsyncSession,
         user_id: str,
+        connector_id: int | None = None,
     ):
         """
         Initialize the GoogleCalendarConnector class.
         Args:
             credentials: Google OAuth Credentials object
+            session: Database session for updating connector
+            user_id: User ID (kept for backward compatibility)
+            connector_id: Optional connector ID for direct updates
         """
         self._credentials = credentials
         self._session = session
         self._user_id = user_id
+        self._connector_id = connector_id
         self.service = None
 
     async def _get_credentials(
@@ -84,17 +89,25 @@ class GoogleCalendarConnector:
                 self._credentials.refresh(Request())
                 # Update the connector config in DB
                 if self._session:
-                    result = await self._session.execute(
-                        select(SearchSourceConnector).filter(
-                            SearchSourceConnector.user_id == self._user_id,
-                            SearchSourceConnector.connector_type
-                            == SearchSourceConnectorType.GOOGLE_CALENDAR_CONNECTOR,
+                    # Use connector_id if available, otherwise fall back to user_id query
+                    if self._connector_id:
+                        result = await self._session.execute(
+                            select(SearchSourceConnector).filter(
+                                SearchSourceConnector.id == self._connector_id
+                            )
                         )
-                    )
+                    else:
+                        result = await self._session.execute(
+                            select(SearchSourceConnector).filter(
+                                SearchSourceConnector.user_id == self._user_id,
+                                SearchSourceConnector.connector_type
+                                == SearchSourceConnectorType.GOOGLE_CALENDAR_CONNECTOR,
+                            )
+                        )
                     connector = result.scalars().first()
                     if connector is None:
                         raise RuntimeError(
-                            "GOOGLE_CALENDAR_CONNECTOR connector not found for current user; cannot persist refreshed token."
+                            "GOOGLE_CALENDAR_CONNECTOR connector not found; cannot persist refreshed token."
                         )
                     connector.config = json.loads(self._credentials.to_json())
                     flag_modified(connector, "config")

--- a/surfsense_backend/app/routes/airtable_add_connector_route.py
+++ b/surfsense_backend/app/routes/airtable_add_connector_route.py
@@ -217,9 +217,10 @@ async def airtable_callback(
             scope=token_json.get("scope"),
         )
 
-        # Check if connector already exists for this user
+        # Check if connector already exists for this search space and user
         existing_connector_result = await session.execute(
             select(SearchSourceConnector).filter(
+                SearchSourceConnector.search_space_id == space_id,
                 SearchSourceConnector.user_id == user_id,
                 SearchSourceConnector.connector_type
                 == SearchSourceConnectorType.AIRTABLE_CONNECTOR,
@@ -232,7 +233,9 @@ async def airtable_callback(
             existing_connector.config = credentials.to_dict()
             existing_connector.name = "Airtable Connector"
             existing_connector.is_indexable = True
-            logger.info(f"Updated existing Airtable connector for user {user_id}")
+            logger.info(
+                f"Updated existing Airtable connector for user {user_id} in space {space_id}"
+            )
         else:
             # Create new connector
             new_connector = SearchSourceConnector(
@@ -240,10 +243,13 @@ async def airtable_callback(
                 connector_type=SearchSourceConnectorType.AIRTABLE_CONNECTOR,
                 is_indexable=True,
                 config=credentials.to_dict(),
+                search_space_id=space_id,
                 user_id=user_id,
             )
             session.add(new_connector)
-            logger.info(f"Created new Airtable connector for user {user_id}")
+            logger.info(
+                f"Created new Airtable connector for user {user_id} in space {space_id}"
+            )
 
         try:
             await session.commit()

--- a/surfsense_backend/app/routes/google_calendar_add_connector_route.py
+++ b/surfsense_backend/app/routes/google_calendar_add_connector_route.py
@@ -105,9 +105,10 @@ async def calendar_callback(
         creds_dict = json.loads(creds.to_json())
 
         try:
-            # Check if a connector with the same type already exists for this user
+            # Check if a connector with the same type already exists for this search space and user
             result = await session.execute(
                 select(SearchSourceConnector).filter(
+                    SearchSourceConnector.search_space_id == space_id,
                     SearchSourceConnector.user_id == user_id,
                     SearchSourceConnector.connector_type
                     == SearchSourceConnectorType.GOOGLE_CALENDAR_CONNECTOR,
@@ -117,12 +118,13 @@ async def calendar_callback(
             if existing_connector:
                 raise HTTPException(
                     status_code=409,
-                    detail="A GOOGLE_CALENDAR_CONNECTOR connector already exists. Each user can have only one connector of each type.",
+                    detail="A GOOGLE_CALENDAR_CONNECTOR connector already exists in this search space. Each search space can have only one connector of each type per user.",
                 )
             db_connector = SearchSourceConnector(
                 name="Google Calendar Connector",
                 connector_type=SearchSourceConnectorType.GOOGLE_CALENDAR_CONNECTOR,
                 config=creds_dict,
+                search_space_id=space_id,
                 user_id=user_id,
                 is_indexable=True,
             )

--- a/surfsense_backend/app/routes/google_gmail_add_connector_route.py
+++ b/surfsense_backend/app/routes/google_gmail_add_connector_route.py
@@ -104,9 +104,10 @@ async def gmail_callback(
         creds_dict = json.loads(creds.to_json())
 
         try:
-            # Check if a connector with the same type already exists for this user
+            # Check if a connector with the same type already exists for this search space and user
             result = await session.execute(
                 select(SearchSourceConnector).filter(
+                    SearchSourceConnector.search_space_id == space_id,
                     SearchSourceConnector.user_id == user_id,
                     SearchSourceConnector.connector_type
                     == SearchSourceConnectorType.GOOGLE_GMAIL_CONNECTOR,
@@ -116,12 +117,13 @@ async def gmail_callback(
             if existing_connector:
                 raise HTTPException(
                     status_code=409,
-                    detail="A GOOGLE_GMAIL_CONNECTOR connector already exists. Each user can have only one connector of each type.",
+                    detail="A GOOGLE_GMAIL_CONNECTOR connector already exists in this search space. Each search space can have only one connector of each type per user.",
                 )
             db_connector = SearchSourceConnector(
                 name="Google Gmail Connector",
                 connector_type=SearchSourceConnectorType.GOOGLE_GMAIL_CONNECTOR,
                 config=creds_dict,
+                search_space_id=space_id,
                 user_id=user_id,
                 is_indexable=True,
             )

--- a/surfsense_backend/app/schemas/search_source_connector.py
+++ b/surfsense_backend/app/schemas/search_source_connector.py
@@ -224,6 +224,7 @@ class SearchSourceConnectorUpdate(BaseModel):
 
 
 class SearchSourceConnectorRead(SearchSourceConnectorBase, IDModel, TimestampModel):
+    search_space_id: int
     user_id: uuid.UUID
 
     model_config = ConfigDict(from_attributes=True)

--- a/surfsense_backend/app/tasks/connector_indexers/google_calendar_indexer.py
+++ b/surfsense_backend/app/tasks/connector_indexers/google_calendar_indexer.py
@@ -113,7 +113,10 @@ async def index_google_calendar_events(
         )
 
         calendar_client = GoogleCalendarConnector(
-            credentials=credentials, session=session, user_id=user_id
+            credentials=credentials,
+            session=session,
+            user_id=user_id,
+            connector_id=connector_id,
         )
 
         # Calculate date range

--- a/surfsense_backend/app/tasks/connector_indexers/google_gmail_indexer.py
+++ b/surfsense_backend/app/tasks/connector_indexers/google_gmail_indexer.py
@@ -127,7 +127,9 @@ async def index_google_gmail_messages(
         )
 
         # Initialize Google gmail connector
-        gmail_connector = GoogleGmailConnector(credentials, session, user_id)
+        gmail_connector = GoogleGmailConnector(
+            credentials, session, user_id, connector_id
+        )
 
         # Fetch recent Google gmail messages
         logger.info(f"Fetching recent emails for connector {connector_id}")

--- a/surfsense_web/app/dashboard/[search_space_id]/connectors/(manage)/page.tsx
+++ b/surfsense_web/app/dashboard/[search_space_id]/connectors/(manage)/page.tsx
@@ -65,7 +65,7 @@ export default function ConnectorsPage() {
 	const today = new Date();
 
 	const { connectors, isLoading, error, deleteConnector, indexConnector } =
-		useSearchSourceConnectors();
+		useSearchSourceConnectors(false, parseInt(searchSpaceId));
 	const [connectorToDelete, setConnectorToDelete] = useState<number | null>(null);
 	const [indexingConnectorId, setIndexingConnectorId] = useState<number | null>(null);
 	const [datePickerOpen, setDatePickerOpen] = useState(false);
@@ -366,12 +366,7 @@ export default function ConnectorsPage() {
 										</Button>
 									</PopoverTrigger>
 									<PopoverContent className="w-auto p-0" align="start">
-										<Calendar
-											mode="single"
-											selected={endDate}
-											onSelect={setEndDate}
-											initialFocus
-										/>
+										<Calendar mode="single" selected={endDate} onSelect={setEndDate} initialFocus />
 									</PopoverContent>
 								</Popover>
 							</div>

--- a/surfsense_web/app/dashboard/[search_space_id]/connectors/[connector_id]/page.tsx
+++ b/surfsense_web/app/dashboard/[search_space_id]/connectors/[connector_id]/page.tsx
@@ -83,7 +83,7 @@ export default function EditConnectorPage() {
 	const searchSpaceId = params.search_space_id as string;
 	const connectorId = parseInt(params.connector_id as string, 10);
 
-	const { connectors, updateConnector } = useSearchSourceConnectors();
+	const { connectors, updateConnector } = useSearchSourceConnectors(false, parseInt(searchSpaceId));
 	const [connector, setConnector] = useState<SearchSourceConnector | null>(null);
 	const [isLoading, setIsLoading] = useState(true);
 	const [isSubmitting, setIsSubmitting] = useState(false);

--- a/surfsense_web/app/dashboard/[search_space_id]/connectors/add/airtable-connector/page.tsx
+++ b/surfsense_web/app/dashboard/[search_space_id]/connectors/add/airtable-connector/page.tsx
@@ -30,10 +30,10 @@ export default function AirtableConnectorPage() {
 	const [isConnecting, setIsConnecting] = useState(false);
 	const [doesConnectorExist, setDoesConnectorExist] = useState(false);
 
-	const { fetchConnectors } = useSearchSourceConnectors();
+	const { fetchConnectors } = useSearchSourceConnectors(true, parseInt(searchSpaceId));
 
 	useEffect(() => {
-		fetchConnectors().then((data) => {
+		fetchConnectors(parseInt(searchSpaceId)).then((data) => {
 			const connector = data.find(
 				(c: SearchSourceConnector) => c.connector_type === EnumConnectorName.AIRTABLE_CONNECTOR
 			);

--- a/surfsense_web/app/dashboard/[search_space_id]/connectors/add/clickup-connector/page.tsx
+++ b/surfsense_web/app/dashboard/[search_space_id]/connectors/add/clickup-connector/page.tsx
@@ -69,7 +69,7 @@ export default function ClickUpConnectorPage() {
 				last_indexed_at: null,
 			};
 
-			await createConnector(connectorData);
+			await createConnector(connectorData, parseInt(searchSpaceId));
 
 			toast.success("ClickUp connector created successfully!");
 			router.push(`/dashboard/${searchSpaceId}/connectors`);

--- a/surfsense_web/app/dashboard/[search_space_id]/connectors/add/confluence-connector/page.tsx
+++ b/surfsense_web/app/dashboard/[search_space_id]/connectors/add/confluence-connector/page.tsx
@@ -77,17 +77,20 @@ export default function ConfluenceConnectorPage() {
 	const onSubmit = async (values: ConfluenceConnectorFormValues) => {
 		setIsSubmitting(true);
 		try {
-			await createConnector({
-				name: values.name,
-				connector_type: EnumConnectorName.CONFLUENCE_CONNECTOR,
-				config: {
-					CONFLUENCE_BASE_URL: values.base_url,
-					CONFLUENCE_EMAIL: values.email,
-					CONFLUENCE_API_TOKEN: values.api_token,
+			await createConnector(
+				{
+					name: values.name,
+					connector_type: EnumConnectorName.CONFLUENCE_CONNECTOR,
+					config: {
+						CONFLUENCE_BASE_URL: values.base_url,
+						CONFLUENCE_EMAIL: values.email,
+						CONFLUENCE_API_TOKEN: values.api_token,
+					},
+					is_indexable: true,
+					last_indexed_at: null,
 				},
-				is_indexable: true,
-				last_indexed_at: null,
-			});
+				parseInt(searchSpaceId)
+			);
 
 			toast.success("Confluence connector created successfully!");
 

--- a/surfsense_web/app/dashboard/[search_space_id]/connectors/add/discord-connector/page.tsx
+++ b/surfsense_web/app/dashboard/[search_space_id]/connectors/add/discord-connector/page.tsx
@@ -73,15 +73,18 @@ export default function DiscordConnectorPage() {
 	const onSubmit = async (values: DiscordConnectorFormValues) => {
 		setIsSubmitting(true);
 		try {
-			await createConnector({
-				name: values.name,
-				connector_type: EnumConnectorName.DISCORD_CONNECTOR,
-				config: {
-					DISCORD_BOT_TOKEN: values.bot_token,
+			await createConnector(
+				{
+					name: values.name,
+					connector_type: EnumConnectorName.DISCORD_CONNECTOR,
+					config: {
+						DISCORD_BOT_TOKEN: values.bot_token,
+					},
+					is_indexable: true,
+					last_indexed_at: null,
 				},
-				is_indexable: true,
-				last_indexed_at: null,
-			});
+				parseInt(searchSpaceId)
+			);
 
 			toast.success("Discord connector created successfully!");
 			router.push(`/dashboard/${searchSpaceId}/connectors`);

--- a/surfsense_web/app/dashboard/[search_space_id]/connectors/add/github-connector/page.tsx
+++ b/surfsense_web/app/dashboard/[search_space_id]/connectors/add/github-connector/page.tsx
@@ -148,16 +148,19 @@ export default function GithubConnectorPage() {
 
 		setIsCreatingConnector(true);
 		try {
-			await createConnector({
-				name: connectorName, // Use the stored name
-				connector_type: EnumConnectorName.GITHUB_CONNECTOR,
-				config: {
-					GITHUB_PAT: validatedPat, // Use the stored validated PAT
-					repo_full_names: selectedRepos, // Add the selected repo names
+			await createConnector(
+				{
+					name: connectorName, // Use the stored name
+					connector_type: EnumConnectorName.GITHUB_CONNECTOR,
+					config: {
+						GITHUB_PAT: validatedPat, // Use the stored validated PAT
+						repo_full_names: selectedRepos, // Add the selected repo names
+					},
+					is_indexable: true,
+					last_indexed_at: null,
 				},
-				is_indexable: true,
-				last_indexed_at: null,
-			});
+				parseInt(searchSpaceId)
+			);
 
 			toast.success("GitHub connector created successfully!");
 			router.push(`/dashboard/${searchSpaceId}/connectors`);

--- a/surfsense_web/app/dashboard/[search_space_id]/connectors/add/google-calendar-connector/page.tsx
+++ b/surfsense_web/app/dashboard/[search_space_id]/connectors/add/google-calendar-connector/page.tsx
@@ -32,10 +32,10 @@ export default function GoogleCalendarConnectorPage() {
 	const [isConnecting, setIsConnecting] = useState(false);
 	const [doesConnectorExist, setDoesConnectorExist] = useState(false);
 
-	const { fetchConnectors } = useSearchSourceConnectors();
+	const { fetchConnectors } = useSearchSourceConnectors(true, parseInt(searchSpaceId));
 
 	useEffect(() => {
-		fetchConnectors().then((data) => {
+		fetchConnectors(parseInt(searchSpaceId)).then((data) => {
 			const connector = data.find(
 				(c: SearchSourceConnector) =>
 					c.connector_type === EnumConnectorName.GOOGLE_CALENDAR_CONNECTOR

--- a/surfsense_web/app/dashboard/[search_space_id]/connectors/add/google-gmail-connector/page.tsx
+++ b/surfsense_web/app/dashboard/[search_space_id]/connectors/add/google-gmail-connector/page.tsx
@@ -32,10 +32,10 @@ export default function GoogleGmailConnectorPage() {
 	const [isConnecting, setIsConnecting] = useState(false);
 	const [doesConnectorExist, setDoesConnectorExist] = useState(false);
 
-	const { fetchConnectors } = useSearchSourceConnectors();
+	const { fetchConnectors } = useSearchSourceConnectors(true, parseInt(searchSpaceId));
 
 	useEffect(() => {
-		fetchConnectors().then((data) => {
+		fetchConnectors(parseInt(searchSpaceId)).then((data) => {
 			const connector = data.find(
 				(c: SearchSourceConnector) => c.connector_type === EnumConnectorName.GOOGLE_GMAIL_CONNECTOR
 			);

--- a/surfsense_web/app/dashboard/[search_space_id]/connectors/add/jira-connector/page.tsx
+++ b/surfsense_web/app/dashboard/[search_space_id]/connectors/add/jira-connector/page.tsx
@@ -90,17 +90,20 @@ export default function JiraConnectorPage() {
 	const onSubmit = async (values: JiraConnectorFormValues) => {
 		setIsSubmitting(true);
 		try {
-			await createConnector({
-				name: values.name,
-				connector_type: EnumConnectorName.JIRA_CONNECTOR,
-				config: {
-					JIRA_BASE_URL: values.base_url,
-					JIRA_EMAIL: values.email,
-					JIRA_API_TOKEN: values.api_token,
+			await createConnector(
+				{
+					name: values.name,
+					connector_type: EnumConnectorName.JIRA_CONNECTOR,
+					config: {
+						JIRA_BASE_URL: values.base_url,
+						JIRA_EMAIL: values.email,
+						JIRA_API_TOKEN: values.api_token,
+					},
+					is_indexable: true,
+					last_indexed_at: null,
 				},
-				is_indexable: true,
-				last_indexed_at: null,
-			});
+				parseInt(searchSpaceId)
+			);
 
 			toast.success("Jira connector created successfully!");
 

--- a/surfsense_web/app/dashboard/[search_space_id]/connectors/add/linear-connector/page.tsx
+++ b/surfsense_web/app/dashboard/[search_space_id]/connectors/add/linear-connector/page.tsx
@@ -77,15 +77,18 @@ export default function LinearConnectorPage() {
 	const onSubmit = async (values: LinearConnectorFormValues) => {
 		setIsSubmitting(true);
 		try {
-			await createConnector({
-				name: values.name,
-				connector_type: EnumConnectorName.LINEAR_CONNECTOR,
-				config: {
-					LINEAR_API_KEY: values.api_key,
+			await createConnector(
+				{
+					name: values.name,
+					connector_type: EnumConnectorName.LINEAR_CONNECTOR,
+					config: {
+						LINEAR_API_KEY: values.api_key,
+					},
+					is_indexable: true,
+					last_indexed_at: null,
 				},
-				is_indexable: true,
-				last_indexed_at: null,
-			});
+				parseInt(searchSpaceId)
+			);
 
 			toast.success("Linear connector created successfully!");
 

--- a/surfsense_web/app/dashboard/[search_space_id]/connectors/add/linkup-api/page.tsx
+++ b/surfsense_web/app/dashboard/[search_space_id]/connectors/add/linkup-api/page.tsx
@@ -65,15 +65,18 @@ export default function LinkupApiPage() {
 	const onSubmit = async (values: LinkupApiFormValues) => {
 		setIsSubmitting(true);
 		try {
-			await createConnector({
-				name: values.name,
-				connector_type: EnumConnectorName.LINKUP_API,
-				config: {
-					LINKUP_API_KEY: values.api_key,
+			await createConnector(
+				{
+					name: values.name,
+					connector_type: EnumConnectorName.LINKUP_API,
+					config: {
+						LINKUP_API_KEY: values.api_key,
+					},
+					is_indexable: false,
+					last_indexed_at: null,
 				},
-				is_indexable: false,
-				last_indexed_at: null,
-			});
+				parseInt(searchSpaceId)
+			);
 
 			toast.success("Linkup API connector created successfully!");
 

--- a/surfsense_web/app/dashboard/[search_space_id]/connectors/add/luma-connector/page.tsx
+++ b/surfsense_web/app/dashboard/[search_space_id]/connectors/add/luma-connector/page.tsx
@@ -55,7 +55,10 @@ export default function LumaConnectorPage() {
 	const [isSubmitting, setIsSubmitting] = useState(false);
 	const [doesConnectorExist, setDoesConnectorExist] = useState(false);
 
-	const { fetchConnectors, createConnector } = useSearchSourceConnectors();
+	const { fetchConnectors, createConnector } = useSearchSourceConnectors(
+		true,
+		parseInt(searchSpaceId)
+	);
 
 	// Initialize the form
 	const form = useForm<LumaConnectorFormValues>({
@@ -67,7 +70,7 @@ export default function LumaConnectorPage() {
 	});
 
 	useEffect(() => {
-		fetchConnectors().then((data) => {
+		fetchConnectors(parseInt(searchSpaceId)).then((data) => {
 			const connector = data.find(
 				(c: SearchSourceConnector) => c.connector_type === EnumConnectorName.LUMA_CONNECTOR
 			);
@@ -81,15 +84,18 @@ export default function LumaConnectorPage() {
 	const onSubmit = async (values: LumaConnectorFormValues) => {
 		setIsSubmitting(true);
 		try {
-			await createConnector({
-				name: values.name,
-				connector_type: EnumConnectorName.LUMA_CONNECTOR,
-				config: {
-					LUMA_API_KEY: values.api_key,
+			await createConnector(
+				{
+					name: values.name,
+					connector_type: EnumConnectorName.LUMA_CONNECTOR,
+					config: {
+						LUMA_API_KEY: values.api_key,
+					},
+					is_indexable: true,
+					last_indexed_at: null,
 				},
-				is_indexable: true,
-				last_indexed_at: null,
-			});
+				parseInt(searchSpaceId)
+			);
 
 			toast.success("Luma connector created successfully!");
 

--- a/surfsense_web/app/dashboard/[search_space_id]/connectors/add/notion-connector/page.tsx
+++ b/surfsense_web/app/dashboard/[search_space_id]/connectors/add/notion-connector/page.tsx
@@ -72,15 +72,18 @@ export default function NotionConnectorPage() {
 	const onSubmit = async (values: NotionConnectorFormValues) => {
 		setIsSubmitting(true);
 		try {
-			await createConnector({
-				name: values.name,
-				connector_type: EnumConnectorName.NOTION_CONNECTOR,
-				config: {
-					NOTION_INTEGRATION_TOKEN: values.integration_token,
+			await createConnector(
+				{
+					name: values.name,
+					connector_type: EnumConnectorName.NOTION_CONNECTOR,
+					config: {
+						NOTION_INTEGRATION_TOKEN: values.integration_token,
+					},
+					is_indexable: true,
+					last_indexed_at: null,
 				},
-				is_indexable: true,
-				last_indexed_at: null,
-			});
+				parseInt(searchSpaceId)
+			);
 
 			toast.success("Notion connector created successfully!");
 

--- a/surfsense_web/app/dashboard/[search_space_id]/connectors/add/serper-api/page.tsx
+++ b/surfsense_web/app/dashboard/[search_space_id]/connectors/add/serper-api/page.tsx
@@ -65,15 +65,18 @@ export default function SerperApiPage() {
 	const onSubmit = async (values: SerperApiFormValues) => {
 		setIsSubmitting(true);
 		try {
-			await createConnector({
-				name: values.name,
-				connector_type: EnumConnectorName.SERPER_API,
-				config: {
-					SERPER_API_KEY: values.api_key,
+			await createConnector(
+				{
+					name: values.name,
+					connector_type: EnumConnectorName.SERPER_API,
+					config: {
+						SERPER_API_KEY: values.api_key,
+					},
+					is_indexable: false,
+					last_indexed_at: null,
 				},
-				is_indexable: false,
-				last_indexed_at: null,
-			});
+				parseInt(searchSpaceId)
+			);
 
 			toast.success("Serper API connector created successfully!");
 

--- a/surfsense_web/app/dashboard/[search_space_id]/connectors/add/slack-connector/page.tsx
+++ b/surfsense_web/app/dashboard/[search_space_id]/connectors/add/slack-connector/page.tsx
@@ -72,15 +72,18 @@ export default function SlackConnectorPage() {
 	const onSubmit = async (values: SlackConnectorFormValues) => {
 		setIsSubmitting(true);
 		try {
-			await createConnector({
-				name: values.name,
-				connector_type: EnumConnectorName.SLACK_CONNECTOR,
-				config: {
-					SLACK_BOT_TOKEN: values.bot_token,
+			await createConnector(
+				{
+					name: values.name,
+					connector_type: EnumConnectorName.SLACK_CONNECTOR,
+					config: {
+						SLACK_BOT_TOKEN: values.bot_token,
+					},
+					is_indexable: true,
+					last_indexed_at: null,
 				},
-				is_indexable: true,
-				last_indexed_at: null,
-			});
+				parseInt(searchSpaceId)
+			);
 
 			toast.success("Slack connector created successfully!");
 

--- a/surfsense_web/app/dashboard/[search_space_id]/connectors/add/tavily-api/page.tsx
+++ b/surfsense_web/app/dashboard/[search_space_id]/connectors/add/tavily-api/page.tsx
@@ -65,15 +65,18 @@ export default function TavilyApiPage() {
 	const onSubmit = async (values: TavilyApiFormValues) => {
 		setIsSubmitting(true);
 		try {
-			await createConnector({
-				name: values.name,
-				connector_type: EnumConnectorName.TAVILY_API,
-				config: {
-					TAVILY_API_KEY: values.api_key,
+			await createConnector(
+				{
+					name: values.name,
+					connector_type: EnumConnectorName.TAVILY_API,
+					config: {
+						TAVILY_API_KEY: values.api_key,
+					},
+					is_indexable: false,
+					last_indexed_at: null,
 				},
-				is_indexable: false,
-				last_indexed_at: null,
-			});
+				parseInt(searchSpaceId)
+			);
 
 			toast.success("Tavily API connector created successfully!");
 

--- a/surfsense_web/app/dashboard/[search_space_id]/podcasts/podcasts-client.tsx
+++ b/surfsense_web/app/dashboard/[search_space_id]/podcasts/podcasts-client.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { format } from "date-fns";
-import { AnimatePresence, motion, type Variants } from "framer-motion";
 import {
 	Calendar,
 	MoreHorizontal,
@@ -16,6 +15,7 @@ import {
 	VolumeX,
 	X,
 } from "lucide-react";
+import { AnimatePresence, motion, type Variants } from "motion/react";
 import Image from "next/image";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";

--- a/surfsense_web/components/chat/ChatInputGroup.tsx
+++ b/surfsense_web/components/chat/ChatInputGroup.tsx
@@ -124,19 +124,20 @@ const ConnectorSelector = React.memo(
 		onSelectionChange?: (connectorTypes: string[]) => void;
 		selectedConnectors?: string[];
 	}) => {
+		const { search_space_id } = useParams();
 		const [isOpen, setIsOpen] = useState(false);
 
 		const { connectorSourceItems, isLoading, isLoaded, fetchConnectors } =
-			useSearchSourceConnectors(true);
+			useSearchSourceConnectors(true, Number(search_space_id));
 
 		const handleOpenChange = useCallback(
 			(open: boolean) => {
 				setIsOpen(open);
 				if (open && !isLoaded) {
-					fetchConnectors();
+					fetchConnectors(Number(search_space_id));
 				}
 			},
-			[fetchConnectors, isLoaded]
+			[fetchConnectors, isLoaded, search_space_id]
 		);
 
 		const handleConnectorToggle = useCallback(

--- a/surfsense_web/hooks/use-connector-edit-page.ts
+++ b/surfsense_web/hooks/use-connector-edit-page.ts
@@ -18,7 +18,11 @@ import {
 
 export function useConnectorEditPage(connectorId: number, searchSpaceId: string) {
 	const router = useRouter();
-	const { connectors, updateConnector, isLoading: connectorsLoading } = useSearchSourceConnectors();
+	const {
+		connectors,
+		updateConnector,
+		isLoading: connectorsLoading,
+	} = useSearchSourceConnectors(false, parseInt(searchSpaceId));
 
 	// State managed by the hook
 	const [connector, setConnector] = useState<SearchSourceConnector | null>(null);


### PR DESCRIPTION
- Need to move llm configs to searchspace

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
feat: Moved searchconnectors association from user to searchspace

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If this PR relates to an open issue, please link to the issue here: FIX #123 -->
Big mistake while designing. Fixing this early is needed. 

## Changes Overview
<!-- List the primary changes/improvements made in this PR -->
- 

## Screenshots
<!-- If applicable, add screenshots or images to demonstrate the changes visually -->

## API Changes
<!-- Document any API changes if applicable -->
- [x] This PR includes API changes

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance improvement (non-breaking change which enhances performance)
- [ ] Documentation update
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Testing
<!-- Describe the tests that have been run to verify your changes -->
- [x] I have tested these changes locally
- [ ] I have added/updated unit tests
- [ ] I have added/updated integration tests

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project
- [ ] My change requires documentation updates
- [ ] I have updated the documentation accordingly
- [ ] My change requires dependency updates
- [ ] I have updated the dependencies accordingly
- [ ] My code builds clean without any errors or warnings
- [ ] All new and existing tests passed 

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR implements a **breaking architectural change** that migrates the `SearchSourceConnector` association from being user-scoped to search space-scoped. Previously, each user could have only one connector of each type across their entire account. Now, connectors are associated with specific search spaces, allowing users to have different connector configurations per search space. The change includes a database migration that populates existing connectors with the user's first search space, updates the unique constraint from `(user_id, connector_type)` to `(search_space_id, user_id, connector_type)`, and modifies all backend routes, services, and frontend components to pass `search_space_id` when creating, reading, updating, or querying connectors.

⏱️ Estimated Review Time: 1-3 hours

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_backend/alembic/versions/23_associate_connectors_with_search_spaces.py` |
| 2 | `surfsense_backend/app/db.py` |
| 3 | `surfsense_backend/app/schemas/search_source_connector.py` |
| 4 | `surfsense_backend/app/services/connector_service.py` |
| 5 | `surfsense_backend/app/routes/search_source_connectors_routes.py` |
| 6 | `surfsense_backend/app/routes/airtable_add_connector_route.py` |
| 7 | `surfsense_backend/app/routes/google_calendar_add_connector_route.py` |
| 8 | `surfsense_backend/app/routes/google_gmail_add_connector_route.py` |
| 9 | `surfsense_backend/app/routes/luma_add_connector_route.py` |
| 10 | `surfsense_backend/app/connectors/google_calendar_connector.py` |
| 11 | `surfsense_backend/app/connectors/google_gmail_connector.py` |
| 12 | `surfsense_backend/app/tasks/connector_indexers/google_calendar_indexer.py` |
| 13 | `surfsense_backend/app/tasks/connector_indexers/google_gmail_indexer.py` |
| 14 | `surfsense_backend/app/agents/researcher/nodes.py` |
| 15 | `surfsense_web/hooks/use-search-source-connectors.ts` |
| 16 | `surfsense_web/app/dashboard/[search_space_id]/connectors/(manage)/page.tsx` |
| 17 | `surfsense_web/app/dashboard/[search_space_id]/connectors/[connector_id]/page.tsx` |
| 18 | `surfsense_web/hooks/use-connector-edit-page.ts` |
| 19 | `surfsense_web/components/chat/ChatInputGroup.tsx` |
| 20 | `surfsense_web/app/dashboard/[search_space_id]/connectors/add/airtable-connector/page.tsx` |
| 21 | `surfsense_web/app/dashboard/[search_space_id]/connectors/add/google-calendar-connector/page.tsx` |
| 22 | `surfsense_web/app/dashboard/[search_space_id]/connectors/add/google-gmail-connector/page.tsx` |
| 23 | `surfsense_web/app/dashboard/[search_space_id]/connectors/add/luma-connector/page.tsx` |
| 24 | `surfsense_web/app/dashboard/[search_space_id]/connectors/add/clickup-connector/page.tsx` |
| 25 | `surfsense_web/app/dashboard/[search_space_id]/connectors/add/confluence-connector/page.tsx` |
| 26 | `surfsense_web/app/dashboard/[search_space_id]/connectors/add/discord-connector/page.tsx` |
| 27 | `surfsense_web/app/dashboard/[search_space_id]/connectors/add/github-connector/page.tsx` |
| 28 | `surfsense_web/app/dashboard/[search_space_id]/connectors/add/jira-connector/page.tsx` |
| 29 | `surfsense_web/app/dashboard/[search_space_id]/connectors/add/linear-connector/page.tsx` |
| 30 | `surfsense_web/app/dashboard/[search_space_id]/connectors/add/linkup-api/page.tsx` |
| 31 | `surfsense_web/app/dashboard/[search_space_id]/connectors/add/notion-connector/page.tsx` |
| 32 | `surfsense_web/app/dashboard/[search_space_id]/connectors/add/serper-api/page.tsx` |
| 33 | `surfsense_web/app/dashboard/[search_space_id]/connectors/add/slack-connector/page.tsx` |
| 34 | `surfsense_web/app/dashboard/[search_space_id]/connectors/add/tavily-api/page.tsx` |
| 35 | `surfsense_backend/alembic/versions/24_fix_null_chat_types.py` |
| 36 | `surfsense_web/app/dashboard/[search_space_id]/podcasts/podcasts-client.tsx` |
</details>

<details>
<summary>⚠️ Inconsistent Changes Detected</summary>

| File Path | Warning |
|-----------|---------|
| `surfsense_backend/alembic/versions/24_fix_null_chat_types.py` | This migration fixes NULL chat types by setting them to 'QNA', which is unrelated to the search connector migration. It appears to be a separate bug fix that should be in its own PR. |
| `surfsense_web/app/dashboard/[search_space_id]/podcasts/podcasts-client.tsx` | This file only changes an import statement from 'framer-motion' to 'motion/react', which is completely unrelated to the search connector association changes. |
</details>

[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/d5205ee5f1bce041bdf4e1dd124327b205041c45a7ac26fa9114845c9b6d7c8f/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=378)
<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Connectors are now scoped per search space across app and API (create, list, update, test, delete), enabling the same connector type in different spaces and clearer ownership checks.
  - Research and external search operations now honor the active search space context.

- Bug Fixes
  - Automatically fixes chats with missing type by setting them to QNA.

- Chores
  - Database migration to associate connectors with search spaces and update uniqueness constraints; connector responses now include search_space_id.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->