### PR TITLE
fix: removed checks that were not checked

### DIFF
--- a/surfsense_backend/app/utils/validators.py
+++ b/surfsense_backend/app/utils/validators.py
@@ -524,20 +524,20 @@ def validate_connector_config(connector_type: str | Any, config: dict[str, Any])
             "required": ["CLICKUP_API_TOKEN"],
             "validators": {}
         },
-        "GOOGLE_CALENDAR_CONNECTOR": {
-            "required": ["token", "refresh_token", "token_uri", "client_id", "expiry", "scopes", "client_secret"],
-            "validators": {},
-            "allow_none_or_empty": False  # Special flag for Google connectors
-        },
-        "GOOGLE_GMAIL_CONNECTOR": {
-            "required": ["token", "refresh_token", "token_uri", "client_id", "expiry", "scopes", "client_secret"],
-            "validators": {},
-            "allow_none_or_empty": False
-        },
-        "AIRTABLE_CONNECTOR": {
-            "required": ["AIRTABLE_API_KEY", "AIRTABLE_BASE_ID"],
-            "validators": {}
-        },
+        # "GOOGLE_CALENDAR_CONNECTOR": {
+        #     "required": ["token", "refresh_token", "token_uri", "client_id", "expiry", "scopes", "client_secret"],
+        #     "validators": {},
+        #     "allow_none_or_empty": False  # Special flag for Google connectors
+        # },
+        # "GOOGLE_GMAIL_CONNECTOR": {
+        #     "required": ["token", "refresh_token", "token_uri", "client_id", "expiry", "scopes", "client_secret"],
+        #     "validators": {},
+        #     "allow_none_or_empty": False
+        # },
+        # "AIRTABLE_CONNECTOR": {
+        #     "required": ["AIRTABLE_API_KEY", "AIRTABLE_BASE_ID"],
+        #     "validators": {}
+        # },
         "LUMA_CONNECTOR": {
             "required": ["LUMA_API_KEY"],
             "validators": {}


### PR DESCRIPTION
- fuck this hacktoberfest


<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR comments out validation rules for three connectors (`GOOGLE_CALENDAR_CONNECTOR`, `GOOGLE_GMAIL_CONNECTOR`, and `AIRTABLE_CONNECTOR`) in the validators configuration, effectively disabling their validation checks. The PR description suggests these validators were not being properly checked or were causing issues.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_backend/app/utils/validators.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/42bde86accda208a5a859a188ad0ff8c7970f98a20ee9966575ca0ae2522ee82/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=379)
<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Relaxed configuration validation by disabling strict checks for Google Calendar, Gmail, and Airtable connectors. Configs for these connectors are now accepted without required-key enforcement.
  - Luma connector validation remains unchanged.
  - Note: Misconfigured fields for the affected connectors may no longer be flagged during setup; review your settings to ensure accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->