### PR TITLE
Add eye toggle button for API Key and Password fields on Sign In page…

### DIFF
--- a/surfsense_web/app/(home)/login/LocalLoginForm.tsx
+++ b/surfsense_web/app/(home)/login/LocalLoginForm.tsx
@@ -4,11 +4,13 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
+import { Eye, EyeOff } from "lucide-react";
 import { getAuthErrorDetails, isNetworkError, shouldRetry } from "@/lib/auth-errors";
 
 export function LocalLoginForm() {
 	const [username, setUsername] = useState("");
 	const [password, setPassword] = useState("");
+	const [showPassword, setShowPassword] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 	const [errorTitle, setErrorTitle] = useState<string | null>(null);
 	const [isLoading, setIsLoading] = useState(false);
@@ -189,26 +191,36 @@ export function LocalLoginForm() {
 					/>
 				</div>
 
-				<div>
+		<div>
 					<label
 						htmlFor="password"
 						className="block text-sm font-medium text-gray-700 dark:text-gray-300"
 					>
 						Password
 					</label>
+				<div className="relative">
 					<input
 						id="password"
-						type="password"
+						type={showPassword ? "text" : "password"}
 						required
 						value={password}
 						onChange={(e) => setPassword(e.target.value)}
-						className={`mt-1 block w-full rounded-md border px-3 py-2 shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 dark:bg-gray-800 dark:text-white transition-colors ${
+						className={`mt-1 block w-full rounded-md border pr-10 px-3 py-2 shadow-sm focus:outline-none focus:ring-2 focus:ring-offset-2 dark:bg-gray-800 dark:text-white transition-colors ${
 							error
 								? "border-red-300 focus:border-red-500 focus:ring-red-500 dark:border-red-700"
 								: "border-gray-300 focus:border-blue-500 focus:ring-blue-500 dark:border-gray-700"
 						}`}
 						disabled={isLoading}
 					/>
+					<button
+						type="button"
+						onClick={() => setShowPassword((prev) => !prev)}
+						className="absolute inset-y-0 right-0 flex items-center pr-3 mt-1 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+						aria-label={showPassword ? "Hide password" : "Show password"}
+					>
+						{showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+					</button>
+				</div>
 				</div>
 
 				<button


### PR DESCRIPTION
I added an eye toggle to the Password field on LocalLoginForm.tsx, with accessible labels and stable layout. I didn’t find an API Key field on the Sign In page; if there’s a different location for it, point me to the file and I’ll add the same toggle there.
Changes:
surfsense_web/app/(home)/login/LocalLoginForm.tsx: Added showPassword state, imported Eye/EyeOff from lucide-react, wrapped the password input in a relative container, and added a button to toggle type between password and text. No linter errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added password visibility toggle to the login form, enabling users to show or hide their password input while logging in.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds a password visibility toggle button to the Sign In page, allowing users to show or hide their password input. The implementation includes an eye icon button (using `lucide-react` icons) positioned within the password field, with proper accessibility labels and state management to toggle between password and text input types.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/app/(home)/login/LocalLoginForm.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/44710148fd89cda2deb4c96063b3549a0c2d7e6ccb3a69e688242cc225c6f9b4/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=422)
<!-- RECURSEML_SUMMARY:END -->