### PR TITLE
announcement: vercel outage

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,15 @@ Check out our public roadmap and contribute your ideas or feedback:
 
 **View the Roadmap:** [SurfSense Roadmap on GitHub Projects](https://github.com/users/MODSetter/projects/2)
 
+## ⚠️ Important Announcement
+
+**AWS and Vercel are currently experiencing outages.** We deployed a major update to SurfSense last night and have updated our documentation accordingly with important setup and configuration changes. Unfortunately, these documentation updates cannot be deployed to our main site (surfsense.com) due to the ongoing outages.
+
+**Please view our documentation directly on GitHub:**  
+📚 [SurfSense Documentation](https://github.com/MODSetter/SurfSense/tree/main/surfsense_web/content/docs)
+
+We apologize for any inconvenience and appreciate your patience!
+
 ## How to get started?
 
 ### Installation Options


### PR DESCRIPTION
announcement: vercel outage

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds a temporary announcement to the README notifying users about ongoing AWS and Vercel outages that are preventing documentation deployment to the main site. The announcement directs users to view documentation directly on GitHub instead, explaining that recent major updates and documentation changes cannot be accessed on surfsense.com due to the outages.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `README.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/3b3256b759ef106f90cbcc33f5a5cf26eed99574161d90fbc2387614c71427d2/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=423)
<!-- RECURSEML_SUMMARY:END -->