### PR TITLE
Header button illumination persists after hover leave #433

### DIFF
--- a/surfsense_web/components/homepage/navbar.tsx
+++ b/surfsense_web/components/homepage/navbar.tsx
@@ -58,6 +58,7 @@ const DesktopNav = ({ navItems, isScrolled }: any) => {
 				{navItems.map((navItem: any, idx: number) => (
 					<Link
 						onMouseEnter={() => setHovered(idx)}
+						onMouseLeave={() => setHovered(null)}
 						className="relative px-4 py-2 text-neutral-600 dark:text-neutral-300"
 						key={`link=${idx}`}
 						href={navItem.link}


### PR DESCRIPTION
## Description

Fixed navbar hover state behavior where the highlight effect would remain active when moving the cursor away from navigation buttons but staying within the header area. Added `onMouseLeave` handler to individual nav items to ensure the hover state clears immediately when the cursor exits any button.

## Motivation and Context

The navigation bar had a UX issue where the hover highlight would "stick" to the last hovered button until the cursor completely left the header section. This created a confusing user experience where the visual feedback didn't match the actual cursor position.

**Root Cause**: The hover state (`hovered`) was only being cleared by the container's `onMouseLeave` event, which only fires when leaving the entire navigation area, not when moving between buttons or into empty space within the header.

**Solution**: Added individual `onMouseLeave` handlers to each nav item Link component to clear the hover state immediately when the cursor moves away from any button.

FIX #(issue_number_if_exists)

## Screenshots

**Before**: Hover highlight remained on "Home" button even after cursor moved away
<img width="2178" height="1169" alt="image" src="https://github.com/user-attachments/assets/bb50061a-1b08-4d87-9e10-bc42bfbdde2e" />



*(Note: If you can capture before/after screen recordings or GIFs showing the hover behavior, that would be ideal)*

## API Changes

- [ ] This PR includes API changes

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Dependency/Build system
- [ ] Breaking change
- [ ] Other (specify):

## Testing Performed

- [x] Tested locally
- [x] Manual/QA verification

**Testing Details**:
- Verified hover effect activates correctly when hovering over each nav item
- Confirmed hover effect clears immediately when moving cursor away from buttons
- Tested hover behavior when moving between different nav items
- Verified hover effect clears when moving to empty space within the header
- Tested on desktop viewport (mobile nav uses different component, unaffected)
- Verified both light and dark theme appearances

## Checklist

- [x] Follows project coding standards and conventions
- [x] Documentation updated as needed
- [x] Dependencies updated as needed
- [x] No lint/build errors or new warnings
- [x] All relevant tests are passing

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a UX bug in the navigation bar where the hover highlight effect would persist on buttons after the cursor moved away, as long as it remained within the header area. The fix adds an `onMouseLeave` handler to each navigation item to immediately clear the hover state when the cursor exits any button, ensuring visual feedback accurately matches cursor position.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/components/homepage/navbar.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed navigation item hover states to properly reset when the mouse leaves an item.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->