### PR TITLE
Fix: expand/collapse on full button click

### DIFF
--- a/surfsense_web/components/sidebar/nav-main.tsx
+++ b/surfsense_web/components/sidebar/nav-main.tsx
@@ -62,23 +62,27 @@ export function NavMain({ items }: { items: NavItem[] }) {
 			<SidebarMenu>
 				{memoizedItems.map((item, index) => {
 					const translatedTitle = translateTitle(item.title);
+					const hasSub = !!item.items?.length;
 					return (
 						<Collapsible key={`${item.title}-${index}`} asChild defaultOpen={item.isActive}>
 							<SidebarMenuItem>
-								<SidebarMenuButton
-									asChild
-									tooltip={translatedTitle}
-									isActive={item.isActive}
-									aria-label={`${translatedTitle}${item.items?.length ? " with submenu" : ""}`}
-								>
-									<a href={item.url}>
-										<item.icon />
-										<span>{translatedTitle}</span>
-									</a>
-								</SidebarMenuButton>
-
-								{item.items?.length ? (
+								{hasSub ? (
+									// When the item has children, make the whole row a collapsible trigger
 									<>
+										<CollapsibleTrigger asChild>
+											<SidebarMenuButton
+												asChild
+												tooltip={translatedTitle}
+												isActive={item.isActive}
+												aria-label={`${translatedTitle} with submenu`}
+											>
+												<button type="button" className="flex items-center gap-2 w-full text-left">
+													<item.icon />
+													<span>{translatedTitle}</span>
+												</button>
+											</SidebarMenuButton>
+										</CollapsibleTrigger>
+
 										<CollapsibleTrigger asChild>
 											<SidebarMenuAction
 												className="data-[state=open]:rotate-90 transition-transform duration-200"
@@ -88,6 +92,7 @@ export function NavMain({ items }: { items: NavItem[] }) {
 												<span className="sr-only">Toggle submenu</span>
 											</SidebarMenuAction>
 										</CollapsibleTrigger>
+
 										<CollapsibleContent className="data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:slide-out-to-top-2 data-[state=open]:slide-in-from-top-2 duration-200">
 											<SidebarMenuSub>
 												{item.items?.map((subItem, subIndex) => {
@@ -105,7 +110,20 @@ export function NavMain({ items }: { items: NavItem[] }) {
 											</SidebarMenuSub>
 										</CollapsibleContent>
 									</>
-								) : null}
+								) : (
+									// Leaf item: treat as a normal link
+									<SidebarMenuButton
+										asChild
+										tooltip={translatedTitle}
+										isActive={item.isActive}
+										aria-label={translatedTitle}
+									>
+										<a href={item.url}>
+											<item.icon />
+											<span>{translatedTitle}</span>
+										</a>
+									</SidebarMenuButton>
+								)}
 							</SidebarMenuItem>
 						</Collapsible>
 					);


### PR DESCRIPTION
<!--- Summarize your pull request in a few sentences -->
This PR updates the sidebar navigation so that the entire "Documents" and "Connectors" buttons toggle their submenus, instead of requiring users to click only the small arrow icon.

## Description
Replaced the `CollapsibleTrigger` placement in `nav-main.tsx` to wrap the entire button element (`SidebarMenuButton`) rather than just the arrow action.  
Now, clicking anywhere on the menu item expands or collapses its submenu, improving usability and consistency.

## Motivation and Context
Previously, only the arrow icon triggered submenu expansion, which was unintuitive and inconsistent with typical sidebar behavior.  
This change improves accessibility and user experience without affecting other sidebar functionality.

FIX # (if an issue exists)

## Screenshots
<img width="376" height="1121" alt="image" src="https://github.com/user-attachments/assets/a2270048-a821-4157-9f39-ac8898263f67" />


## API Changes
- [x] This PR does **not** include API changes

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Dependency/Build system
- [ ] Breaking change
- [ ] Other:

## Testing Performed
- [x] Tested locally in development container
- [x] Verified sidebar expand/collapse behavior for both Documents and Connectors items

## Checklist
- [x] Follows project coding standards and conventions  
- [x] No lint/build errors or new warnings  
- [x] Tested locally and verified expected behavior  

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes the sidebar navigation interaction so that clicking anywhere on the "Documents" and "Connectors" menu items expands or collapses their submenus, instead of requiring users to click only on the small arrow icon. The change restructures the `CollapsibleTrigger` to wrap the entire `SidebarMenuButton` for items with submenus, while maintaining the original behavior for leaf items without submenus. This improves usability and makes the interface more intuitive.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/components/sidebar/nav-main.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/4355e8ab848f1701f605ec7d38c97456cdf36f076ed50c54f39c19c4e0397273/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=443)
<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Navigation menu items with submenus are now collapsible with toggle indicators showing open/closed state.

* **Improvements**
  * Enhanced accessibility with improved navigation labels and visual feedback for submenu interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->