### PR TITLE
fix: saving document from browser extension fails

### DIFF
--- a/surfsense_backend/app/routes/documents_routes.py
+++ b/surfsense_backend/app/routes/documents_routes.py
@@ -71,8 +71,12 @@ async def create_documents(
                     "metadata": {
                         "VisitedWebPageTitle": individual_document.metadata.VisitedWebPageTitle,
                         "VisitedWebPageURL": individual_document.metadata.VisitedWebPageURL,
+                        "BrowsingSessionId": individual_document.metadata.BrowsingSessionId,
+                        "VisitedWebPageDateWithTimeInISOString": individual_document.metadata.VisitedWebPageDateWithTimeInISOString,
+                        "VisitedWebPageVisitDurationInMilliseconds": individual_document.metadata.VisitedWebPageVisitDurationInMilliseconds,
+                        "VisitedWebPageReffererURL": individual_document.metadata.VisitedWebPageReffererURL,
                     },
-                    "content": individual_document.content,
+                    "pageContent": individual_document.content,
                 }
                 process_extension_document_task.delay(
                     document_dict, request.search_space_id, str(user.id)

--- a/surfsense_backend/app/tasks/celery_tasks/document_tasks.py
+++ b/surfsense_backend/app/tasks/celery_tasks/document_tasks.py
@@ -69,10 +69,14 @@ async def _process_extension_document(
     class DocumentMetadata(BaseModel):
         VisitedWebPageTitle: str
         VisitedWebPageURL: str
+        BrowsingSessionId: str
+        VisitedWebPageDateWithTimeInISOString: str
+        VisitedWebPageReffererURL: str
+        VisitedWebPageVisitDurationInMilliseconds: str
 
     class IndividualDocument(BaseModel):
         metadata: DocumentMetadata
-        content: str
+        pageContent: str
 
     individual_document = IndividualDocument(**individual_document_dict)
 


### PR DESCRIPTION
Fix: saving document from browser extension fails due to missing and mismatch fields of backend data models.

## Description
Saving document from browser extension fails due to missing and mismatch fields of backend data models.

## Change Type
<!--- Indicate what kind(s) of changes this PR includes: -->
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Dependency/Build system
- [ ] Breaking change
- [ ] Other (specify):

## Testing Performed
<!--- Briefly describe how you have tested these changes and what verification was performed -->
- [*] Tested locally
- [ ] Manual/QA verification

## Checklist
<!--- Please confirm the following by marking with an 'x' as appropriate -->
- [x] Follows project coding standards and conventions
- [x] Documentation updated as needed
- [x] Dependencies updated as needed
- [x] No lint/build errors or new warnings
- [x] All relevant tests are passing

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a bug where saving documents from the browser extension was failing due to schema mismatches between the frontend and backend. The fix adds four missing metadata fields (`BrowsingSessionId`, `VisitedWebPageDateWithTimeInISOString`, `VisitedWebPageVisitDurationInMilliseconds`, `VisitedWebPageReffererURL`) and renames the `content` field to `pageContent` to align with the extension's data format.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_backend/app/tasks/celery_tasks/document_tasks.py` |
| 2 | `surfsense_backend/app/routes/documents_routes.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/5d42ae858ae33ade5eeff13ce64a12cc496276db2cb98b5a3234cc93915c2087/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=521)
<!-- RECURSEML_SUMMARY:END -->