### PR TITLE
Add boto3 dependency for AWS Bedrock LLM Provider to pyproject.toml

### DIFF
--- a/surfsense_backend/pyproject.toml
+++ b/surfsense_backend/pyproject.toml
@@ -49,6 +49,7 @@ dependencies = [
     "redis>=5.2.1",
     "chonkie[all]>=1.4.0",
     "firecrawl-py>=4.9.0",
+    "boto3>=1.35.0"
 ]
 
 [dependency-groups]


### PR DESCRIPTION
<!--- Summarize your pull request in a few sentences -->

## Description
Added boto3>=1.35.0 to the project dependencies in pyproject.toml. This library is required by LiteLLM to authenticate and interact with AWS Bedrock services.

## Motivation and Context
When configuring AWS Bedrock as an LLM provider through the SurfSense onboarding UI, users encountered the error:
  ModuleNotFoundError: No module named 'boto3'
  This occurred because LiteLLM requires boto3 to handle AWS Bedrock authentication and API calls, but the package was not included in the project dependencies.
FIX #


## Screenshots
<!-- If applicable, add screenshots or images to demonstrate the changes visually -->

## API Changes
<!-- Document any API changes if applicable -->
No API changes - this is a dependency addition only.

## Change Type
<!--- Indicate what kind(s) of changes this PR includes: -->
- [x] Bug fix
- [] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [x] Dependency/Build system
- [ ] Breaking change
- [ ] Other (specify):

## Testing Performed
<!--- Briefly describe how you have tested these changes and what verification was performed -->
- [x] Tested locally
- [x] Manual/QA verification
- [x]  Verified by:
  1. Rebuilding the backend Docker container with the new dependency
  2. Confirming boto3 imports successfully inside the container
  3. Successfully adding AWS Bedrock as an LLM provider through the onboarding UI

## Checklist
<!--- Please confirm the following by marking with an 'x' as appropriate -->
- [x] Follows project coding standards and conventions
- [ ] Documentation updated as needed
- [x] Dependencies updated as needed
- [x] No lint/build errors or new warnings
- [x] All relevant tests are passing

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds `boto3>=1.35.0` as a project dependency to fix a `ModuleNotFoundError` that users encountered when configuring AWS Bedrock as an LLM provider. The boto3 library is required by LiteLLM for AWS Bedrock authentication and API interactions.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_backend/pyproject.toml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/66c370678e6834972c5d3fdda18e014a5d82430d099e0f6a310b1073e9e45b66/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=544)
<!-- RECURSEML_SUMMARY:END -->