### PR TITLE
roadmap(1.3): Update citation prompt to use new whole document structure

### DIFF
--- a/surfsense_backend/app/agents/researcher/prompts.py
+++ b/surfsense_backend/app/agents/researcher/prompts.py
@@ -16,7 +16,7 @@ You are an expert research assistant specializing in generating contextually rel
 
 <input>
 - chat_history: Provided in XML format within <chat_history> tags, containing <user> and <assistant> message pairs that show the chronological conversation flow. This provides context about what has already been discussed.
-- available_documents: Provided in XML format within <documents> tags, containing individual <document> elements with <metadata> (source_id, source_type) and <content> sections. This helps understand what information is accessible for answering potential follow-up questions.
+- available_documents: Provided in XML format within <documents> tags, containing individual <document> elements with <document_metadata> and <document_content> sections. Each document contains multiple `<chunk id='...'>...</chunk>` blocks inside <document_content>. This helps understand what information is accessible for answering potential follow-up questions.
 </input>
 
 <output_format>

--- a/surfsense_backend/app/agents/researcher/qna_agent/default_prompts.py
+++ b/surfsense_backend/app/agents/researcher/qna_agent/default_prompts.py
@@ -78,32 +78,53 @@ DEFAULT_QNA_CITATION_INSTRUCTIONS = """
 <citation_instructions>
 CRITICAL CITATION REQUIREMENTS:
 
-1. For EVERY piece of information you include from the documents, add a citation in the format [citation:knowledge_source_id] where knowledge_source_id is the source_id from the document's metadata.
+1. For EVERY piece of information you include from the documents, add a citation in the format [citation:chunk_id] where chunk_id is the exact value from the `<chunk id='...'>` tag inside `<document_content>`.
 2. Make sure ALL factual statements from the documents have proper citations.
-3. If multiple documents support the same point, include all relevant citations [citation:source_id1], [citation:source_id2].
-4. You MUST use the exact source_id value from each document's metadata for citations. Do not create your own citation numbers.
-5. Every citation MUST be in the format [citation:knowledge_source_id] where knowledge_source_id is the exact source_id value.
-6. Never modify or change the source_id - always use the original values exactly as provided in the metadata.
+3. If multiple chunks support the same point, include all relevant citations [citation:chunk_id1], [citation:chunk_id2].
+4. You MUST use the exact chunk_id values from the `<chunk id='...'>` attributes. Do not create your own citation numbers.
+5. Every citation MUST be in the format [citation:chunk_id] where chunk_id is the exact chunk id value.
+6. Never modify or change the chunk_id - always use the original values exactly as provided in the chunk tags.
 7. Do not return citations as clickable links.
 8. Never format citations as markdown links like "([citation:5](https://example.com))". Always use plain square brackets only.
-9. Citations must ONLY appear as [citation:source_id] or [citation:source_id1], [citation:source_id2] format - never with parentheses, hyperlinks, or other formatting.
-10. Never make up source IDs. Only use source_id values that are explicitly provided in the document metadata.
-11. If you are unsure about a source_id, do not include a citation rather than guessing or making one up.
+9. Citations must ONLY appear as [citation:chunk_id] or [citation:chunk_id1], [citation:chunk_id2] format - never with parentheses, hyperlinks, or other formatting.
+10. Never make up chunk IDs. Only use chunk_id values that are explicitly provided in the `<chunk id='...'>` tags.
+11. If you are unsure about a chunk_id, do not include a citation rather than guessing or making one up.
+
+<document_structure_example>
+The documents you receive are structured like this:
+
+<document>
+<document_metadata>
+  <document_id>42</document_id>
+  <document_type>GITHUB_CONNECTOR</document_type>
+  <title><![CDATA[Some repo / file / issue title]]></title>
+  <url><![CDATA[https://example.com]]></url>
+  <metadata_json><![CDATA[{{"any":"other metadata"}}]]></metadata_json>
+</document_metadata>
+
+<document_content>
+  <chunk id='123'><![CDATA[First chunk text...]]></chunk>
+  <chunk id='124'><![CDATA[Second chunk text...]]></chunk>
+</document_content>
+</document>
+
+IMPORTANT: You MUST cite using the chunk ids (e.g. 123, 124). Do NOT cite document_id.
+</document_structure_example>
 
 <citation_format>
-- Every fact from the documents must have a citation in the format [citation:knowledge_source_id] where knowledge_source_id is the EXACT source_id from the document's metadata
+- Every fact from the documents must have a citation in the format [citation:chunk_id] where chunk_id is the EXACT id value from a `<chunk id='...'>` tag
 - Citations should appear at the end of the sentence containing the information they support
-- Multiple citations should be separated by commas: [citation:source_id1], [citation:source_id2], [citation:source_id3]
+- Multiple citations should be separated by commas: [citation:chunk_id1], [citation:chunk_id2], [citation:chunk_id3]
 - No need to return references section. Just citations in answer.
-- NEVER create your own citation format - use the exact source_id values from the documents in the [citation:source_id] format
+- NEVER create your own citation format - use the exact chunk_id values from the documents in the [citation:chunk_id] format
 - NEVER format citations as clickable links or as markdown links like "([citation:5](https://example.com))". Always use plain square brackets only
-- NEVER make up source IDs if you are unsure about the source_id. It is better to omit the citation than to guess
+- NEVER make up chunk IDs if you are unsure about the chunk_id. It is better to omit the citation than to guess
 </citation_format>
 
 <citation_examples>
 CORRECT citation formats:
 - [citation:5]
-- [citation:source_id1], [citation:source_id2], [citation:source_id3]
+- [citation:chunk_id1], [citation:chunk_id2], [citation:chunk_id3]
 
 INCORRECT citation formats (DO NOT use):
 - Using parentheses and markdown links: ([citation:5](https://github.com/MODSetter/SurfSense))


### PR DESCRIPTION
- Modified the document extraction and citation formatting to accommodate a new structure that includes a `chunks` list for each document.
- Enhanced the citation format to reference `chunk_id` instead of `source_id`, ensuring accurate citations in the UI.
- Updated various components, including the connector service and reranker service, to handle the new document format and maintain compatibility with existing functionalities.
- Improved documentation and comments to reflect changes in the data structure and citation requirements.

<!--- Summarize your pull request in a few sentences -->

## Description
<!--- Clearly describe what has changed in this pull request -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If this PR relates to an open issue, please link to the issue here: FIX #123 -->
FIX https://github.com/MODSetter/SurfSense/issues/551


## Screenshots
<!-- If applicable, add screenshots or images to demonstrate the changes visually -->

## API Changes
<!-- Document any API changes if applicable -->
- [ ] This PR includes API changes

## Change Type
<!--- Indicate what kind(s) of changes this PR includes: -->
- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [x] Refactoring
- [ ] Documentation
- [ ] Dependency/Build system
- [x] Breaking change
- [ ] Other (specify):

## Testing Performed
<!--- Briefly describe how you have tested these changes and what verification was performed -->
- [x] Tested locally
- [x] Manual/QA verification

## Checklist
<!--- Please confirm the following by marking with an 'x' as appropriate -->
- [x] Follows project coding standards and conventions
- [ ] Documentation updated as needed
- [ ] Dependencies updated as needed
- [ ] No lint/build errors or new warnings
- [x] All relevant tests are passing

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR refactors the document retrieval and citation system to support a new document-grouped structure. Previously, the system worked with individual chunks and cited them using `source_id`. The new structure groups chunks under documents and cites using real database `chunk_id` values from `<chunk id='...'>` XML tags. The changes span the entire retrieval pipeline: hybrid search now returns document-grouped results with a `chunks` list, the citation prompt instructs the LLM to use chunk IDs instead of source IDs, the reranker service preserves the new structure, the connector service was refactored to build chunk-level sources from document-grouped data, and various formatting utilities were updated to output the new XML format. This is marked as a breaking change and addresses issue #551.

⏱️ Estimated Review Time: 1-3 hours

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_backend/app/agents/researcher/prompts.py` |
| 2 | `surfsense_backend/app/agents/researcher/qna_agent/default_prompts.py` |
| 3 | `surfsense_backend/app/agents/researcher/utils.py` |
| 4 | `surfsense_backend/app/retriever/chunks_hybrid_search.py` |
| 5 | `surfsense_backend/app/retriever/documents_hybrid_search.py` |
| 6 | `surfsense_backend/app/services/reranker_service.py` |
| 7 | `surfsense_backend/app/services/connector_service.py` |
| 8 | `surfsense_backend/app/agents/researcher/nodes.py` |
| 9 | `surfsense_backend/app/agents/researcher/qna_agent/nodes.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/f60ee06b45221836bc6097d18733362dee86e756b3d3e2d227f1cb09e006048c/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=581)
<!-- RECURSEML_SUMMARY:END -->