### PR TITLE
fix: add OLLAMA_BASE_URL support to backend config

### DIFF
--- a/surfsense_backend/.env.example
+++ b/surfsense_backend/.env.example
@@ -132,3 +132,6 @@ UVICORN_LOG_LEVEL=info
 # UVICORN_UDS=""
 # UVICORN_FD=""
 # UVICORN_ROOT_PATH=""
+
+# Ollama Configuration
+# OLLAMA_BASE_URL=http://host.docker.internal:11434

--- a/surfsense_backend/app/config/__init__.py
+++ b/surfsense_backend/app/config/__init__.py
@@ -163,6 +163,7 @@ class Config:
     # Azure OpenAI credentials from environment variables
     AZURE_OPENAI_ENDPOINT = os.getenv("AZURE_OPENAI_ENDPOINT")
     AZURE_OPENAI_API_KEY = os.getenv("AZURE_OPENAI_API_KEY")
+    OLLAMA_BASE_URL = os.getenv("OLLAMA_BASE_URL")
 
     # Pass Azure credentials to embeddings when using Azure OpenAI
     embedding_kwargs = {}
@@ -170,6 +171,8 @@ class Config:
         embedding_kwargs["azure_endpoint"] = AZURE_OPENAI_ENDPOINT
     if AZURE_OPENAI_API_KEY:
         embedding_kwargs["azure_api_key"] = AZURE_OPENAI_API_KEY
+    if OLLAMA_BASE_URL:
+        embedding_kwargs["base_url"] = OLLAMA_BASE_URL
 
     embedding_model_instance = AutoEmbeddings.get_embeddings(
         EMBEDDING_MODEL,


### PR DESCRIPTION
Fixes #587. Adds support for OLLAMA_BASE_URL environment variable to allow connection to external Ollama instances for embeddings, which fixes connection refused errors during document and YouTube video uploads in Docker.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds support for the `OLLAMA_BASE_URL` environment variable to enable connections to external Ollama instances for embeddings. This resolves connection refused errors that occur during document and YouTube video uploads when running in Docker environments by allowing users to specify a custom Ollama endpoint (e.g., `http://host.docker.internal:11434`).

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_backend/.env.example` |
| 2 | `surfsense_backend/app/config/__init__.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/5eae15f6c52fd09b08626506efe2e14114786142fc4e10b4e761f9b7aa5118c2/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=605)
<!-- RECURSEML_SUMMARY:END -->