### PR TITLE
feat: configure PostHog reverse proxy to bypass ad blockers

### DIFF
--- a/surfsense_web/instrumentation-client.ts
+++ b/surfsense_web/instrumentation-client.ts
@@ -2,7 +2,10 @@ import posthog from "posthog-js";
 
 if (process.env.NEXT_PUBLIC_POSTHOG_KEY) {
 	posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY, {
-		api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
+		// Use reverse proxy to bypass ad blockers
+		api_host: "/ingest",
+		// Required for toolbar and other UI features to work correctly
+		ui_host: "https://us.posthog.com",
 		defaults: "2025-11-30",
 		// Disable automatic pageview capture, as we capture manually with PostHogProvider
 		// This ensures proper pageview tracking with Next.js client-side navigation

--- a/surfsense_web/next.config.ts
+++ b/surfsense_web/next.config.ts
@@ -31,6 +31,27 @@ const nextConfig: NextConfig = {
 		}
 		return config;
 	},
+
+	// PostHog reverse proxy configuration
+	// This helps bypass ad blockers by routing requests through your domain
+	async rewrites() {
+		return [
+			{
+				source: "/ingest/static/:path*",
+				destination: "https://us-assets.i.posthog.com/static/:path*",
+			},
+			{
+				source: "/ingest/:path*",
+				destination: "https://us.i.posthog.com/:path*",
+			},
+			{
+				source: "/ingest/decide",
+				destination: "https://us.i.posthog.com/decide",
+			},
+		];
+	},
+	// Required for PostHog reverse proxy to work correctly
+	skipTrailingSlashRedirect: true,
 };
 
 // Wrap the config with MDX and next-intl plugins


### PR DESCRIPTION
<!--- Summarize your pull request in a few sentences -->

## Description
<!--- Clearly describe what has changed in this pull request -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If this PR relates to an open issue, please link to the issue here: FIX #123 -->
FIX #


## Screenshots
<!-- If applicable, add screenshots or images to demonstrate the changes visually -->

## API Changes
<!-- Document any API changes if applicable -->
- [ ] This PR includes API changes

## Change Type
<!--- Indicate what kind(s) of changes this PR includes: -->
- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Dependency/Build system
- [ ] Breaking change
- [ ] Other (specify):

## Testing Performed
<!--- Briefly describe how you have tested these changes and what verification was performed -->
- [ ] Tested locally
- [ ] Manual/QA verification

## Checklist
<!--- Please confirm the following by marking with an 'x' as appropriate -->
- [ ] Follows project coding standards and conventions
- [ ] Documentation updated as needed
- [ ] Dependencies updated as needed
- [ ] No lint/build errors or new warnings
- [ ] All relevant tests are passing

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR configures a PostHog reverse proxy to bypass ad blockers by routing analytics requests through the application's own domain instead of directly to PostHog servers. The configuration adds URL rewrite rules in `next.config.ts` to proxy requests from `/ingest` to PostHog's servers, and updates the PostHog client initialization to use the local `/ingest` endpoint instead of the external PostHog host. This approach helps prevent ad blockers from interfering with analytics collection while maintaining full PostHog functionality.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/next.config.ts` |
| 2 | `surfsense_web/instrumentation-client.ts` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/c66ba135622914b0caf00201e136163b3f1054559d024ab278556383a0f7833c/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=630)
<!-- RECURSEML_SUMMARY:END -->