### PR TITLE
feat: Implemented hero A/B test, added Contact Sales button

### DIFF
--- a/surfsense_web/components/homepage/hero-section.tsx
+++ b/surfsense_web/components/homepage/hero-section.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { useFeatureFlagVariantKey } from "@posthog/react";
 import { AnimatePresence, motion } from "motion/react";
 import Image from "next/image";
 import Link from "next/link";
@@ -33,6 +34,8 @@ const GoogleLogo = ({ className }: { className?: string }) => (
 export function HeroSection() {
 	const containerRef = useRef<HTMLDivElement>(null);
 	const parentRef = useRef<HTMLDivElement>(null);
+	const heroVariant = useFeatureFlagVariantKey("notebooklm_flag");
+	const isNotebookLMVariant = heroVariant === "notebooklm";
 
 	return (
 		<div
@@ -83,12 +86,22 @@ export function HeroSection() {
 
 			<h2 className="relative z-50 mx-auto mb-4 mt-4 max-w-4xl text-balance text-center text-3xl font-semibold tracking-tight text-gray-700 md:text-7xl dark:text-neutral-300">
 				<Balancer>
-					The AI Workspace{" "}
-					<div className="relative mx-auto inline-block w-max filter-[drop-shadow(0px_1px_3px_rgba(27,37,80,0.14))]">
-						<div className="text-black [text-shadow:0_0_rgba(0,0,0,0.1)] dark:text-white">
-							<span className="">Built for Teams</span>
+					{isNotebookLMVariant ? (
+						<div className="relative mx-auto inline-block w-max filter-[drop-shadow(0px_1px_3px_rgba(27,37,80,0.14))]">
+							<div className="text-black [text-shadow:0_0_rgba(0,0,0,0.1)] dark:text-white">
+								<span className="">NotebookLM for Teams</span>
+							</div>
 						</div>
-					</div>
+					) : (
+						<>
+							The AI Workspace{" "}
+							<div className="relative mx-auto inline-block w-max filter-[drop-shadow(0px_1px_3px_rgba(27,37,80,0.14))]">
+								<div className="text-black [text-shadow:0_0_rgba(0,0,0,0.1)] dark:text-white">
+									<span className="">Built for Teams</span>
+								</div>
+							</div>
+						</>
+					)}
 				</Balancer>
 			</h2>
 			{/* // TODO:aCTUAL DESCRITION */}
@@ -96,15 +109,10 @@ export function HeroSection() {
 				Connect any LLM to your internal knowledge sources and chat with it in real time alongside
 				your team.
 			</p>
-			<div className="mb-10 mt-8 flex w-full flex-col items-center justify-center gap-4 px-8 sm:flex-row md:mb-20">
-				<GetStartedButton />
-				{/* <Link
-					href="/pricing"
-					className="shadow-input group relative z-20 flex h-10 w-full cursor-pointer items-center justify-center space-x-2 rounded-lg bg-white p-px px-4 py-2 text-sm font-semibold leading-6 text-black no-underline transition duration-200 hover:-translate-y-0.5 sm:w-52 dark:bg-neutral-800 dark:text-white"
-				>
-					Start Free Trial
-				</Link> */}
-			</div>
+		<div className="mb-10 mt-8 flex w-full flex-col items-center justify-center gap-4 px-8 sm:flex-row md:mb-20">
+			<GetStartedButton />
+			<ContactSalesButton />
+		</div>
 			<div
 				ref={containerRef}
 				className="relative mx-auto max-w-7xl rounded-[32px] border border-neutral-200/50 bg-neutral-100 p-2 backdrop-blur-lg md:p-4 dark:border-neutral-700 dark:bg-neutral-800/50"
@@ -188,6 +196,21 @@ function GetStartedButton() {
 				className="group relative z-20 flex h-11 w-full cursor-pointer items-center justify-center gap-2 rounded-xl bg-black px-6 py-2.5 text-sm font-semibold text-white shadow-lg transition-shadow duration-300 hover:shadow-xl sm:w-56 dark:bg-white dark:text-black"
 			>
 				Get Started
+			</Link>
+		</motion.div>
+	);
+}
+
+function ContactSalesButton() {
+	return (
+		<motion.div whileHover={{ scale: 1.02, y: -2 }} whileTap={{ scale: 0.98 }}>
+			<Link
+				href="https://calendly.com/eric-surfsense/surfsense-meeting"
+				target="_blank"
+				rel="noopener noreferrer"
+				className="group relative z-20 flex h-11 w-full cursor-pointer items-center justify-center gap-2 rounded-xl bg-white px-6 py-2.5 text-sm font-semibold text-neutral-700 shadow-lg ring-1 ring-neutral-200/50 transition-shadow duration-300 hover:shadow-xl sm:w-56 dark:bg-neutral-900 dark:text-neutral-200 dark:ring-neutral-700/50"
+			>
+				Contact Sales
 			</Link>
 		</motion.div>
 	);

--- a/surfsense_web/components/providers/PostHogProvider.tsx
+++ b/surfsense_web/components/providers/PostHogProvider.tsx
@@ -3,6 +3,7 @@
 import { PostHogProvider as PHProvider } from "@posthog/react";
 import posthog from "posthog-js";
 import type { ReactNode } from "react";
+import "../../instrumentation-client";
 import { PostHogIdentify } from "./PostHogIdentify";
 
 interface PostHogProviderProps {
@@ -10,8 +11,8 @@ interface PostHogProviderProps {
 }
 
 export function PostHogProvider({ children }: PostHogProviderProps) {
-	// posthog-js is already initialized in instrumentation-client.ts
-	// We just need to wrap the app with the PostHogProvider for hook access
+	// posthog-js is initialized by importing instrumentation-client.ts above
+	// We wrap the app with the PostHogProvider for hook access
 	return (
 		<PHProvider client={posthog}>
 			<PostHogIdentify />

--- a/surfsense_web/instrumentation-client.ts
+++ b/surfsense_web/instrumentation-client.ts
@@ -12,5 +12,17 @@ if (process.env.NEXT_PUBLIC_POSTHOG_KEY) {
 		capture_pageview: "history_change",
 		// Enable session recording
 		capture_pageleave: true,
+		loaded: (posthog) => {
+			// Expose PostHog to window for console access and toolbar
+			if (typeof window !== "undefined") {
+				window.posthog = posthog;
+			}
+		},
 	});
+}
+
+// Always expose posthog to window for debugging/toolbar access
+// This allows testing feature flags even without POSTHOG_KEY configured
+if (typeof window !== "undefined") {
+	window.posthog = posthog;
 }

--- a/surfsense_web/types/window.d.ts
+++ b/surfsense_web/types/window.d.ts
@@ -1,0 +1,9 @@
+import type { PostHog } from "posthog-js";
+
+declare global {
+	interface Window {
+		posthog?: PostHog;
+	}
+}
+
+export {};


### PR DESCRIPTION
Implemented hero A/B test, added Contact Sales button and also fixed PostHog toolbar compatibility and browser console support
<!--- Summarize your pull request in a few sentences -->

## Description
<!--- Clearly describe what has changed in this pull request -->
Implemented the A/B test for the hero text, highlighting NotebookLM or not.
Added a button next to the "Continue with Google"/"Get Started" button for "Contact Sales" (directing to Eric's Calendly).
Fixed PostHog console support, as this was needed to be able to test the A/B test and enable the PostHog toolbar.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If this PR relates to an open issue, please link to the issue here: FIX #123 -->
The A/B test and PostHog changes allow us to measure what results in higher activation rates and therefore what kind of tool people are looking for.

The sales button allows us to better funnel enterprise users to a good experience and helps us understand their needs through scheduled meetings.

PostHog was not connected to the window, which was likely a bug.

## Screenshots
<!-- If applicable, add screenshots or images to demonstrate the changes visually -->

## API Changes
<!-- Document any API changes if applicable -->
- [ ] This PR includes API changes

## Change Type
<!--- Indicate what kind(s) of changes this PR includes: -->
- [x] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Dependency/Build system
- [ ] Breaking change
- [ ] Other (specify):

## Testing Performed
<!--- Briefly describe how you have tested these changes and what verification was performed -->
- [x] Tested locally
- [ ] Manual/QA verification

## Checklist
<!--- Please confirm the following by marking with an 'x' as appropriate -->
- [ ] Follows project coding standards and conventions
- [ ] Documentation updated as needed
- [ ] Dependencies updated as needed
- [x] No lint/build errors or new warnings
- [x] All relevant tests are passing

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR implements an A/B test for the hero section that toggles between two headline variants (*The AI Workspace Built for Teams* vs *NotebookLM for Teams*) using PostHog feature flags. It also adds a `Contact Sales` button linking to a Calendly scheduling page and fixes PostHog's browser console accessibility by exposing the PostHog client to the window object, which enables the PostHog toolbar and facilitates testing of feature flags.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/types/window.d.ts` |
| 2 | `surfsense_web/instrumentation-client.ts` |
| 3 | `surfsense_web/components/providers/PostHogProvider.tsx` |
| 4 | `surfsense_web/components/homepage/hero-section.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/f8e9861c3edd1cb83e67f5ba99335333f3e8063300f3f8a4a08c60df8b1d98f9/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=748)
<!-- RECURSEML_SUMMARY:END -->