### PR TITLE
fix(database): handle duplicate podcast_status type creation gracefully

### DIFF
--- a/surfsense_backend/alembic/versions/82_add_podcast_status_and_thread.py
+++ b/surfsense_backend/alembic/versions/82_add_podcast_status_and_thread.py
@@ -20,7 +20,11 @@ depends_on: str | Sequence[str] | None = None
 def upgrade() -> None:
     op.execute(
         """
-        CREATE TYPE podcast_status AS ENUM ('pending', 'generating', 'ready', 'failed');
+        DO $$ BEGIN
+            CREATE TYPE podcast_status AS ENUM ('pending', 'generating', 'ready', 'failed');
+        EXCEPTION
+            WHEN duplicate_object THEN null;
+        END $$;
         """
     )
 


### PR DESCRIPTION
Modify the upgrade function to prevent errors when creating the podcast_status ENUM type by wrapping the creation in a DO block that catches duplicate_object exceptions.

<!--- Summarize your pull request in a few sentences -->

## Description
The existence of the podcast_status in a database was causing a mandatory Alembic upgrade step (82) to fail during migration.
<!--- Clearly describe what has changed in this pull request -->

## Motivation and Context
This specific upgrade (82) was not idempotent, essentially causing breaking migration issues for anyone using it. Now it is.
<!--- Why is this change required? What problem does it solve? -->
<!--- If this PR relates to an open issue, please link to the issue here: FIX #123 -->


## Screenshots
<!-- If applicable, add screenshots or images to demonstrate the changes visually -->

## API Changes
<!-- Document any API changes if applicable -->
- [ ] This PR includes API changes

## Change Type
<!--- Indicate what kind(s) of changes this PR includes: -->
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Dependency/Build system
- [ ] Breaking change
- [ ] Other (specify):

## Testing Performed
<!--- Briefly describe how you have tested these changes and what verification was performed -->
- [x] Tested locally
- [x] Manual/QA verification

## Checklist
<!--- Please confirm the following by marking with an 'x' as appropriate -->
- [x] Follows project coding standards and conventions
- [ ] Documentation updated as needed <-- in general, Alembic migration needs to be documented for installing updates
- [ ] Dependencies updated as needed
- [x] No lint/build errors or new warnings
- [x] All relevant tests are passing

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a database migration issue by making the Alembic upgrade step 82 idempotent. The change wraps the `podcast_status` ENUM type creation in a PostgreSQL `DO` block that catches `duplicate_object` exceptions, preventing migration failures when the type already exists in the database.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_backend/alembic/versions/82_add_podcast_status_and_thread.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/90cae7ddb358dd7ad3d9eb63be6d24fe95d00637fa4d60b60fb38398fa3a414e/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=753)
<!-- RECURSEML_SUMMARY:END -->