### PR TITLE
fix: prevent file attachment dialog from opening twice

### DIFF
--- a/surfsense_web/components/assistant-ui/thread.tsx
+++ b/surfsense_web/components/assistant-ui/thread.tsx
@@ -253,6 +253,7 @@ const Composer: FC = () => {
 	const editorRef = useRef<InlineMentionEditorRef>(null);
 	const editorContainerRef = useRef<HTMLDivElement>(null);
 	const uploadInputRef = useRef<HTMLInputElement>(null);
+	const isFileDialogOpenRef = useRef(false);
 	const documentPickerRef = useRef<DocumentMentionPickerRef>(null);
 	const { search_space_id, chat_id } = useParams();
 	const setMentionedDocumentIds = useSetAtom(mentionedDocumentIdsAtom);
@@ -516,11 +517,18 @@ const Composer: FC = () => {
 	);
 
 	const handleUploadClick = useCallback(() => {
+		if (isFileDialogOpenRef.current) return;
+		isFileDialogOpenRef.current = true;
 		uploadInputRef.current?.click();
+		// Reset after a delay to handle cancellation (which doesn't fire the change event).
+		setTimeout(() => {
+			isFileDialogOpenRef.current = false;
+		}, 1000);
 	}, []);
 
 	const handleUploadInputChange = useCallback(
 		async (event: React.ChangeEvent<HTMLInputElement>) => {
+			isFileDialogOpenRef.current = false;
 			const files = Array.from(event.target.files ?? []);
 			event.target.value = "";
 			if (files.length === 0 || !search_space_id) return;


### PR DESCRIPTION
## Summary

Closes #781

When clicking the Paperclip (upload) button in the chat composer, the native file picker dialog opens twice. After selecting a file or canceling, the dialog immediately reopens.

**Root cause:** The upload button is wrapped in a Radix UI `TooltipTrigger`. When the native file dialog closes and the browser window regains focus, Chrome re-dispatches a synthetic click event on the button, triggering `handleUploadClick` a second time.

**Fix:** Add a ref-based guard (`isFileDialogOpenRef`) to `handleUploadClick` that prevents re-triggering while the file dialog is open. The guard resets when:
- A file is selected (via the `change` event in `handleUploadInputChange`)
- After a 1-second timeout (to handle cancellation, which doesn't fire `change`)

This matches the existing pattern in `document-upload-popup.tsx` (lines 44–61) which uses `isClosingRef` to prevent the same double-open issue for the Upload Documents dialog.

## Test plan

- [ ] Open any chat or "New Chat"
- [ ] Click the Paperclip (upload) button
- [ ] Select a file or click Cancel
- [ ] Verify the file dialog does **not** open a second time
- [ ] Click the Paperclip button again — verify it still works normally
- [ ] Verify the "Upload Documents" dialog (separate flow) still works correctly

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a bug where the file attachment dialog opens twice when clicking the upload button in the chat composer. The issue occurs because Chrome re-dispatches a synthetic click event when the browser window regains focus after the native file dialog closes. The fix introduces a ref-based guard (`isFileDialogOpenRef`) that prevents the upload handler from retriggering while the file dialog is open, resetting either when a file is selected or after a 1-second timeout to handle cancellation.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/components/assistant-ui/thread.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/45fc0ca80b3778f3ff4d03bd1fbd9d20ff9773ef1191df3ddf29cd4618e37462/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=824)
<!-- RECURSEML_SUMMARY:END -->