### PR TITLE
Simplified Announcements and made minor updates to homepage

### DIFF
--- a/surfsense_web/components/homepage/hero-section.tsx
+++ b/surfsense_web/components/homepage/hero-section.tsx
@@ -98,7 +98,7 @@ export function HeroSection() {
 			</h2>
 			{/* // TODO:aCTUAL DESCRITION */}
 			<p className="relative z-50 mx-auto mt-4 max-w-lg px-4 text-center text-base/6 text-gray-600 dark:text-gray-200">
-				Connect any AI to your documents and knowledge sources,
+				Connect any AI to your documents, Drive, Notion and more,
 			</p>
 			<p className="relative z-50 mx-auto mt-0 max-w-lg px-4 text-center text-base/6 text-gray-600 dark:text-gray-200">
 				then chat with it, invite your team, or generate podcasts and reports.

--- a/surfsense_web/components/homepage/hero-section.tsx
+++ b/surfsense_web/components/homepage/hero-section.tsx
@@ -41,7 +41,7 @@ export function HeroSection() {
 	return (
 		<div
 			ref={parentRef}
-			className="relative flex min-h-screen flex-col items-center justify-center overflow-hidden px-4 py-12 md:px-8 md:py-24"
+			className="relative flex min-h-screen flex-col items-center justify-center overflow-hidden px-4 py-24 md:px-8 md:py-48"
 		>
 			<BackgroundGrids />
 			<CollisionMechanism
@@ -81,7 +81,7 @@ export function HeroSection() {
 				}}
 			/>
 
-			<h2 className="relative z-50 mx-auto mb-4 mt-4 max-w-4xl text-balance text-center text-3xl font-semibold tracking-tight text-gray-700 md:text-7xl dark:text-neutral-300">
+			<h2 className="relative z-50 mx-auto mb-4 mt-8 max-w-4xl text-balance text-center text-3xl font-semibold tracking-tight text-gray-700 md:text-7xl dark:text-neutral-300">
 				{isNotebookLMVariant ? (
 					<div className="relative mx-auto inline-block w-max filter-[drop-shadow(0px_1px_3px_rgba(27,37,80,0.14))]">
 						<div className="text-black [text-shadow:0_0_rgba(0,0,0,0.1)] dark:text-white">
@@ -98,14 +98,14 @@ export function HeroSection() {
 			</h2>
 			{/* // TODO:aCTUAL DESCRITION */}
 			<p className="relative z-50 mx-auto mt-4 max-w-lg px-4 text-center text-base/6 text-gray-600 dark:text-gray-200">
-				Connect any AI to your documents and knowledge sources.
+				Connect any AI to your documents and knowledge sources,
 			</p>
 			<p className="relative z-50 mx-auto mt-0 max-w-lg px-4 text-center text-base/6 text-gray-600 dark:text-gray-200">
-				Then chat with it in real-time, even alongside your team.
+				then chat with it, invite your team, or generate podcasts and reports.
 			</p>
 			<div className="mb-6 mt-6 flex w-full flex-col items-center justify-center gap-4 px-8 sm:flex-row md:mb-10">
 				<GetStartedButton />
-				<ContactSalesButton />
+				{/* <ContactSalesButton /> */}
 			</div>
 			<div ref={containerRef} className="relative w-full">
 				<WalkthroughScroll />

--- a/surfsense_web/components/homepage/navbar.tsx
+++ b/surfsense_web/components/homepage/navbar.tsx
@@ -22,9 +22,9 @@ export const Navbar = () => {
 
 	const navItems = [
 		{ name: "Pricing", link: "/pricing" },
-		{ name: "Contact\u00A0Us", link: "/contact" },
 		{ name: "Changelog", link: "/changelog" },
 		{ name: "Docs", link: "/docs" },
+		{ name: "Contact\u00A0Us", link: "/contact" },
 	];
 
 	useEffect(() => {

--- a/surfsense_web/contracts/types/announcement.types.ts
+++ b/surfsense_web/contracts/types/announcement.types.ts
@@ -4,11 +4,16 @@
  * Frontend-only announcement system that supports:
  * - Multiple announcement categories (update, feature, maintenance, info)
  * - Important flag for toast notifications
- * - Read/dismissed state tracking via localStorage
+ * - Time-bound visibility (start/end times)
+ * - Audience targeting (all, users, web_visitors)
+ * - Read state tracking via localStorage
  */
 
 /** Announcement category */
 export type AnnouncementCategory = "update" | "feature" | "maintenance" | "info";
+
+/** Who should see the announcement */
+export type AnnouncementAudience = "all" | "users" | "web_visitors";
 
 /** Single announcement entry */
 export interface Announcement {
@@ -22,6 +27,12 @@ export interface Announcement {
 	category: AnnouncementCategory;
 	/** ISO date string of when the announcement was published */
 	date: string;
+	/** ISO datetime — announcement becomes visible at this time */
+	startTime: string;
+	/** ISO datetime — announcement expires and is hidden after this time */
+	endTime: string;
+	/** Who should see this announcement */
+	audience: AnnouncementAudience;
 	/** If true, the user will see a toast notification for this announcement */
 	isImportant: boolean;
 	/** Optional CTA link */
@@ -37,6 +48,4 @@ export interface AnnouncementUserState {
 	readIds: string[];
 	/** IDs of important announcements already shown as toasts */
 	toastedIds: string[];
-	/** IDs of announcements the user has explicitly dismissed */
-	dismissedIds: string[];
 }

--- a/surfsense_web/lib/announcements/announcements-data.ts
+++ b/surfsense_web/lib/announcements/announcements-data.ts
@@ -4,6 +4,10 @@ import type { Announcement } from "@/contracts/types/announcement.types";
  * Static announcements data.
  *
  * To add a new announcement, append an entry to this array.
+ * Each announcement requires `startTime` and `endTime` (ISO datetime strings)
+ * to define its visibility window, and `audience` to control who sees it.
+ * Current possible audiences are "all", "users", and "web_visitors".
+ * Current possible categories are "feature", "update", "maintenance", and "info".
  * Set `isImportant: true` to trigger a toast notification for the user.
  *
  * This file can be replaced with an API call in the future.
@@ -15,11 +19,21 @@ export const announcements: Announcement[] = [
 		description: "All major announcements will be posted here.",
 		category: "feature",
 		date: "2026-02-17T00:00:00Z",
+		startTime: "2026-02-17T00:00:00Z",
+		endTime: "2026-02-20T00:00:00Z",
+		audience: "all",
+		isImportant: false,
+	},
+	{
+		id: "announcement-6",
+		title: "Past Test Announcement",
+		description: "This should be seen by nobody, because it's in the past.",
+		category: "maintenance",
+		date: "2026-02-17T00:00:00Z",
+		startTime: "2026-02-15T23:23:00Z",
+		endTime: "2026-02-16T00:00:00Z",
+		audience: "users",
 		isImportant: true,
-		link: {
-			label: "Check Here",
-			url: "/announcements",
-		},
 	},
 	// {
 	// 	id: "2026-02-10-podcast-improvements",
@@ -28,6 +42,9 @@ export const announcements: Announcement[] = [
 	// 		"We've improved podcast generation with faster processing, better audio quality, and support for longer documents. Try it out in any search space.",
 	// 	category: "update",
 	// 	date: "2026-02-10T00:00:00Z",
+	// 	startTime: "2026-02-10T00:00:00Z",
+	// 	endTime: "2026-03-10T00:00:00Z",
+	// 	audience: "all",
 	// 	isImportant: false,
 	// },
 	// {
@@ -37,6 +54,9 @@ export const announcements: Announcement[] = [
 	// 		"SurfSense will undergo scheduled maintenance on February 15, 2026 from 2:00 AM to 4:00 AM UTC. During this window, the service may be temporarily unavailable. We apologize for any inconvenience.",
 	// 	category: "maintenance",
 	// 	date: "2026-02-08T00:00:00Z",
+	// 	startTime: "2026-02-08T00:00:00Z",
+	// 	endTime: "2026-02-16T00:00:00Z",
+	// 	audience: "all",
 	// 	isImportant: true,
 	// },
 	// {
@@ -46,6 +66,9 @@ export const announcements: Announcement[] = [
 	// 		"We've added support for new connectors including Linear, Jira, and Confluence. Connect your project management tools and start chatting with your data.",
 	// 	category: "feature",
 	// 	date: "2026-02-05T00:00:00Z",
+	// 	startTime: "2026-02-05T00:00:00Z",
+	// 	endTime: "2026-03-05T00:00:00Z",
+	// 	audience: "users",
 	// 	isImportant: false,
 	// 	link: {
 	// 		label: "View connectors",
@@ -59,6 +82,9 @@ export const announcements: Announcement[] = [
 	// 		"Shared search spaces now support real-time mentions, comment threads, and role-based access control. Invite your team and collaborate more effectively.",
 	// 	category: "feature",
 	// 	date: "2026-01-28T00:00:00Z",
+	// 	startTime: "2026-01-28T00:00:00Z",
+	// 	endTime: "2026-02-28T00:00:00Z",
+	// 	audience: "users",
 	// 	isImportant: false,
 	// },
 ];

--- a/surfsense_web/lib/announcements/announcements-storage.ts
+++ b/surfsense_web/lib/announcements/announcements-storage.ts
@@ -5,11 +5,11 @@ const STORAGE_KEY = "surfsense_announcements_state";
 const defaultState: AnnouncementUserState = {
 	readIds: [],
 	toastedIds: [],
-	dismissedIds: [],
 };
 
 /**
- * Get the current announcement user state from localStorage
+ * Get the current announcement user state from localStorage.
+ * Gracefully ignores legacy `dismissedIds` from older versions.
  */
 export function getAnnouncementState(): AnnouncementUserState {
 	if (typeof window === "undefined") return defaultState;
@@ -21,7 +21,6 @@ export function getAnnouncementState(): AnnouncementUserState {
 		return {
 			readIds: Array.isArray(parsed.readIds) ? parsed.readIds : [],
 			toastedIds: Array.isArray(parsed.toastedIds) ? parsed.toastedIds : [],
-			dismissedIds: Array.isArray(parsed.dismissedIds) ? parsed.dismissedIds : [],
 		};
 	} catch {
 		return defaultState;
@@ -64,17 +63,6 @@ export function markAllAnnouncementsRead(ids: string[]): void {
 }
 
 /**
- * Dismiss an announcement (hide it from the list)
- */
-export function dismissAnnouncement(id: string): void {
-	const state = getAnnouncementState();
-	if (!state.dismissedIds.includes(id)) {
-		state.dismissedIds.push(id);
-		saveAnnouncementState(state);
-	}
-}
-
-/**
  * Mark an important announcement as already toasted (shown as toast)
  */
 export function markAnnouncementToasted(id: string): void {
@@ -97,11 +85,4 @@ export function isAnnouncementRead(id: string): boolean {
  */
 export function isAnnouncementToasted(id: string): boolean {
 	return getAnnouncementState().toastedIds.includes(id);
-}
-
-/**
- * Check if an announcement has been dismissed
- */
-export function isAnnouncementDismissed(id: string): boolean {
-	return getAnnouncementState().dismissedIds.includes(id);
 }

--- a/surfsense_web/lib/announcements/announcements-utils.ts
+++ b/surfsense_web/lib/announcements/announcements-utils.ts
@@ -1,0 +1,80 @@
+import type { Announcement } from "@/contracts/types/announcement.types";
+
+/**
+ * Returns true when the current time falls within the announcement's
+ * [startTime, endTime] window. Returns false for invalid windows
+ * (endTime before startTime) or when now is outside the range.
+ */
+export function isAnnouncementActive(announcement: Announcement, now = new Date()): boolean {
+	const start = new Date(announcement.startTime).getTime();
+	const end = new Date(announcement.endTime).getTime();
+
+	if (Number.isNaN(start) || Number.isNaN(end) || end < start) return false;
+
+	const nowMs = now.getTime();
+	return nowMs >= start && nowMs <= end;
+}
+
+/**
+ * Returns true when the announcement's audience matches the viewer context.
+ * - `"all"` — visible to everyone
+ * - `"users"` — visible only to authenticated users
+ * - `"web_visitors"` — visible only to unauthenticated visitors
+ */
+export function announcementMatchesAudience(
+	announcement: Announcement,
+	isAuthenticated: boolean,
+): boolean {
+	switch (announcement.audience) {
+		case "all":
+			return true;
+		case "users":
+			return isAuthenticated;
+		case "web_visitors":
+			return !isAuthenticated;
+		default:
+			return false;
+	}
+}
+
+/**
+ * Filter announcements to only those that are currently active and
+ * targeted at the given audience.
+ */
+export function getActiveAnnouncements(
+	announcements: Announcement[],
+	isAuthenticated: boolean,
+	now = new Date(),
+): Announcement[] {
+	return announcements.filter(
+		(a) => isAnnouncementActive(a, now) && announcementMatchesAudience(a, isAuthenticated),
+	);
+}
+
+/**
+ * Returns the number of milliseconds until the next announcement either
+ * starts or expires. Returns `null` when there are no upcoming transitions.
+ * Useful for scheduling re-renders so the UI updates automatically.
+ */
+export function msUntilNextTransition(
+	announcements: Announcement[],
+	now = new Date(),
+): number | null {
+	const nowMs = now.getTime();
+	let nearest: number | null = null;
+
+	for (const a of announcements) {
+		const start = new Date(a.startTime).getTime();
+		const end = new Date(a.endTime).getTime();
+		if (Number.isNaN(start) || Number.isNaN(end) || end < start) continue;
+
+		for (const edge of [start, end]) {
+			if (edge > nowMs) {
+				const diff = edge - nowMs;
+				if (nearest === null || diff < nearest) nearest = diff;
+			}
+		}
+	}
+
+	return nearest;
+}


### PR DESCRIPTION
## Description
- Announcements now have start and end dates and only display between those dates
- Announcements now also have an audience and only display for that audience
- Announcements are automatically marked as read when displayed
- Announcement badges only display for unread messages
- Removed filter for announcements (since there should generally be none or very few)
- Read announcements remain in the list until they expire (but do not increase the badge unread count)
- Changed spacing and wording in hero section of website
- Changed order of links in navbar to be more logical

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If this PR relates to an open issue, please link to the issue here: FIX #123 -->
Unread badges are attention grabbing and should be used sparingly, especially on the homepage. Therefore, I introduced start and end dates so that they automatically expire and disappear, and also introduced audiences so that announcements only display for relevant users. This should reduce the frequency and likelihood of unread badges appearing.

## Screenshots
<!-- If applicable, add screenshots or images to demonstrate the changes visually -->

## API Changes
<!-- Document any API changes if applicable -->
- [ ] This PR includes API changes

## Change Type
<!--- Indicate what kind(s) of changes this PR includes: -->
- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [x] Refactoring
- [ ] Documentation
- [ ] Dependency/Build system
- [ ] Breaking change
- [x] Other (specify):

## Testing Performed
<!--- Briefly describe how you have tested these changes and what verification was performed -->
- [x] Tested locally
- [ ] Manual/QA verification

## Checklist
<!--- Please confirm the following by marking with an 'x' as appropriate -->
- [ ] Follows project coding standards and conventions
- [ ] Documentation updated as needed
- [ ] Dependencies updated as needed
- [x] No lint/build errors or new warnings
- [x] All relevant tests are passing

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR enhances the announcements system by introducing time-bound visibility with `startTime` and `endTime` properties, audience targeting (all, authenticated users, or web visitors), and automatic read marking when announcements are displayed. The changes simplify the UI by removing the filtering dropdown and dismissal functionality, ensuring unread badges only show for truly unread items within their active window. Additionally, the homepage hero section receives minor spacing and wording updates, and the navbar links are reordered to a more logical sequence.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/contracts/types/announcement.types.ts` |
| 2 | `surfsense_web/lib/announcements/announcements-utils.ts` |
| 3 | `surfsense_web/lib/announcements/announcements-data.ts` |
| 4 | `surfsense_web/lib/announcements/announcements-storage.ts` |
| 5 | `surfsense_web/hooks/use-announcements.ts` |
| 6 | `surfsense_web/components/announcements/AnnouncementToastProvider.tsx` |
| 7 | `surfsense_web/app/(home)/announcements/page.tsx` |
| 8 | `surfsense_web/components/homepage/hero-section.tsx` |
| 9 | `surfsense_web/components/homepage/navbar.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/10bf3ed6b7aa77aebbbd83547628e2192cdbf7818309006cccebd1a3d9a3bf09/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=827)
<!-- RECURSEML_SUMMARY:END -->