### PR TITLE
Fix/upstream extension runtime dev

### DIFF
--- a/surfsense_browser_extension/background/messages/savedata.ts
+++ b/surfsense_browser_extension/background/messages/savedata.ts
@@ -2,6 +2,7 @@ import type { PlasmoMessaging } from "@plasmohq/messaging";
 import { Storage } from "@plasmohq/storage";
 
 import { emptyArr, webhistoryToLangChainDocument } from "~utils/commons";
+import { buildBackendUrl } from "~utils/backend-url";
 
 const clearMemory = async () => {
 	try {
@@ -130,10 +131,7 @@ const handler: PlasmoMessaging.MessageHandler = async (req, res) => {
 				body: JSON.stringify(toSend),
 			};
 
-			const response = await fetch(
-				`${process.env.PLASMO_PUBLIC_BACKEND_URL}/api/v1/documents`,
-				requestOptions
-			);
+			const response = await fetch(await buildBackendUrl("/api/v1/documents"), requestOptions);
 			const resp = await response.json();
 			if (resp) {
 				await clearMemory();

--- a/surfsense_browser_extension/background/messages/savesnapshot.ts
+++ b/surfsense_browser_extension/background/messages/savesnapshot.ts
@@ -3,6 +3,7 @@ import type { PlasmoMessaging } from "@plasmohq/messaging";
 import { Storage } from "@plasmohq/storage";
 import { convertHtmlToMarkdown } from "dom-to-semantic-markdown";
 import { DOMParser } from "linkedom";
+import { buildBackendUrl } from "~utils/backend-url";
 import { getRenderedHtml, webhistoryToLangChainDocument } from "~utils/commons";
 import type { WebHistory } from "~utils/interfaces";
 
@@ -122,10 +123,7 @@ const handler: PlasmoMessaging.MessageHandler = async (req, res) => {
 					body: JSON.stringify(toSend),
 				};
 
-				const response = await fetch(
-					`${process.env.PLASMO_PUBLIC_BACKEND_URL}/api/v1/documents`,
-					requestOptions
-				);
+				const response = await fetch(await buildBackendUrl("/api/v1/documents"), requestOptions);
 				const resp = await response.json();
 				if (resp) {
 					res.send({

--- a/surfsense_browser_extension/background/messages/savesnapshot.ts
+++ b/surfsense_browser_extension/background/messages/savesnapshot.ts
@@ -8,7 +8,7 @@ import { getRenderedHtml, webhistoryToLangChainDocument } from "~utils/commons";
 import type { WebHistory } from "~utils/interfaces";
 
 // @ts-ignore
-global.Node = {
+globalThis.Node = {
 	ELEMENT_NODE: 1,
 	ATTRIBUTE_NODE: 2,
 	TEXT_NODE: 3,


### PR DESCRIPTION
<!--- Summarize your pull request in a few sentences -->
This PR fixes two browser extension runtime issues affecting self-hosted and custom-backend deployments. It makes background  document uploads use the configured backend URL and replaces an MV3-unsafe global reference in the snapshot worker path.

## Description
<!--- Clearly describe what has changed in this pull request -->
- Updated browser extension background upload flows to use the configured backend URL instead of always using `PLASMO_PUBLIC_BACKEND_URL` - Replaced `global.Node` with `globalThis.Node` in the snapshot save path so the MV3 background worker uses a valid global object

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If this PR relates to an open issue, please link to the issue here: FIX #123 -->

These fixes address real extension failures observed while testing against a self-hosted SurfSense deployment:
- Login and search space loading could succeed with a custom backend URL, but background uploads still posted to the  default backend - The snapshot background path used `global.Node`, which is not safe in the MV3 service worker context and can break background execution

## Screenshots
<!-- If applicable, add screenshots or images to demonstrate the changes visually -->
No screenshots included. The visible UI is unchanged; the fixes are in extension runtime behavior.

## API Changes
<!-- Document any API changes if applicable -->
- [ ] This PR includes API changes

## Change Type
<!--- Indicate what kind(s) of changes this PR includes: -->
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Dependency/Build system
- [ ] Breaking change
- [ ] Other (specify):

## Testing Performed
<!--- Briefly describe how you have tested these changes and what verification was performed -->
- [x] Tested locally
- [x] Manual/QA verification

Manual extension smoke testing was performed against a self-hosted SurfSense deployment exposed through a public Cloudflare URL.

Verified flow:
- Set a custom backend URL in the extension
- Connected with a valid API token  - Loaded search spaces successfully - Saved the current page
- Uploaded the captured document successfully

Note: the tested release artifact was built from the same source changes with local build-only Plasmo packaging workarounds, because clean upstream packaging currently has a separate Plasmo build issue outside the scope of this PR.

## Checklist
<!--- Please confirm the following by marking with an 'x' as appropriate -->
- [x] Follows project coding standards and conventions
- [ ] Documentation updated as needed
- [ ] Dependencies updated as needed
- [ ] No lint/build errors or new warnings
- [ ] All relevant tests are passing

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes two critical browser extension runtime issues for self-hosted deployments. First, it updates background document upload flows to use the configured backend URL via `buildBackendUrl()` instead of hardcoding `PLASMO_PUBLIC_BACKEND_URL`, ensuring custom backend configurations are respected. Second, it replaces `global.Node` with `globalThis.Node` in the snapshot worker to fix MV3 service worker compatibility issues where `global` is not available.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_browser_extension/background/messages/savedata.ts` |
| 2 | `surfsense_browser_extension/background/messages/savesnapshot.ts` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/1f604230b2761e0f7108d0b969d1da0e6708a3d9624af8d20bd3dcbabf1b326e/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=876)
<!-- RECURSEML_SUMMARY:END -->