### PR TITLE
fix(web): allow public invite info fetches

### DIFF
--- a/surfsense_web/lib/apis/base-api.service.ts
+++ b/surfsense_web/lib/apis/base-api.service.ts
@@ -91,7 +91,8 @@ class BaseApiService {
 			// Validate the bearer token
 			const isNoAuthEndpoint =
 				this.noAuthEndpoints.includes(url) ||
-				this.noAuthPrefixes.some((prefix) => url.startsWith(prefix));
+				this.noAuthPrefixes.some((prefix) => url.startsWith(prefix)) ||
+				/^\/api\/v1\/invites\/[^/]+\/info$/.test(url);
 			if (!this.bearerToken && !isNoAuthEndpoint) {
 				throw new AuthenticationError("You are not authenticated. Please login again.");
 			}


### PR DESCRIPTION
<!--- Summarize your pull request in a few sentences -->

This PR fixes public invite links for signed-out users in the web app. It makes only the public invite info endpoint loadable before login, while leaving the rest of the invite routes behind the normal client-side auth gate.

## Description
<!--- Clearly describe what has changed in this pull request -->

- Added a narrow no-auth check for `/api/v1/invites/<invite_code>/info` in the frontend API client
- This allows the public invite info request to load without a bearer token
- Other invite routes such as `/api/v1/invites/accept` still go through the normal authenticated client flow

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If this PR relates to an open issue, please link to the issue here: FIX #123 -->

The invite acceptance page is intended to be public before login, but the shared frontend API client was treating invite info fetches as authenticated requests. That caused valid invite links to fail for signed-out users before the page could display invite details.

With this change:
- public invite details can load before authentication
- valid invite links render the expected invite screen instead of failing client-side
- invite acceptance remains on the authenticated code path

FIX #N/A

## Screenshots
<!-- If applicable, add screenshots or images to demonstrate the changes visually -->

No screenshots included. The visible change is that signed-out users can now load a valid invite page correctly.

## API Changes
<!-- Document any API changes if applicable -->
- [ ] This PR includes API changes

## Change Type
<!--- Indicate what kind(s) of changes this PR includes: -->
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Dependency/Build system
- [ ] Breaking change
- [ ] Other (specify):

## Testing Performed
<!--- Briefly describe how you have tested these changes and what verification was performed -->

Tested against a self-hosted SurfSense deployment exposed through a public Cloudflare URL.

Verified flow:
- opened a valid invite link while signed out
- confirmed the page rendered the invite state (`You're Invited!`)
- confirmed it did not show `Invalid Invite`
- confirmed there were no page or console errors during the signed-out load
- rebuilt and redeployed the frontend with this exact route-specific client change and repeated the same signed-out verification successfully

- [x] Tested locally
- [x] Manual/QA verification

## Checklist
<!--- Please confirm the following by marking with an 'x' as appropriate -->
- [x] Follows project coding standards and conventions
- [ ] Documentation updated as needed
- [ ] Dependencies updated as needed
- [ ] No lint/build errors or new warnings
- [ ] All relevant tests are passing

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a bug where public invite links failed for signed-out users. It makes only the public invite info endpoint (`/api/v1/invites/{invite_code}/info`) bypass the client-side auth gate, so valid invite pages can render before login without broadening the rest of the invite route handling.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/lib/apis/base-api.service.ts` |
</details>

[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/5996bedf503b22523db175b811363df1fe77c11e8e2c09fdfebec7fefcb3c53f/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=878)
<!-- RECURSEML_SUMMARY:END -->
