### PR TITLE
fix: use asyncio.to_thread for embedding calls in search endpoints

### DIFF
--- a/surfsense_backend/app/retriever/chunks_hybrid_search.py
+++ b/surfsense_backend/app/retriever/chunks_hybrid_search.py
@@ -1,3 +1,4 @@
+import asyncio
 import time
 from datetime import datetime
 
@@ -46,10 +47,10 @@ class ChucksHybridSearchRetriever:
         perf = get_perf_logger()
         t0 = time.perf_counter()
 
-        # Get embedding for the query
+        # Get embedding for the query (run in thread to avoid blocking the event loop)
         embedding_model = config.embedding_model_instance
         t_embed = time.perf_counter()
-        query_embedding = embedding_model.embed(query_text)
+        query_embedding = await asyncio.to_thread(embedding_model.embed, query_text)
         perf.debug(
             "[chunk_search] vector_search embedding in %.3fs",
             time.perf_counter() - t_embed,
@@ -195,7 +196,7 @@ class ChucksHybridSearchRetriever:
         if query_embedding is None:
             embedding_model = config.embedding_model_instance
             t_embed = time.perf_counter()
-            query_embedding = embedding_model.embed(query_text)
+            query_embedding = await asyncio.to_thread(embedding_model.embed, query_text)
             perf.debug(
                 "[chunk_search] hybrid_search embedding in %.3fs",
                 time.perf_counter() - t_embed,


### PR DESCRIPTION
## Summary

- Wraps synchronous `embedding_model.embed()` calls in `vector_search` and `hybrid_search` with `asyncio.to_thread()` so they no longer block the asyncio event loop
- Adds `import asyncio` to support the change
- The underlying `litellm.embedding` call performs network I/O synchronously; offloading it to a thread allows the server to continue handling concurrent requests during embedding generation

Fixes #794

## Details

The `ChucksHybridSearchRetriever.vector_search` and `hybrid_search` methods are `async` but call `embedding_model.embed(query_text)` synchronously. Since `LiteLLMEmbeddings.embed` issues a blocking HTTP request via `litellm.embedding(...)`, this stalls the entire event loop under load.

`asyncio.to_thread()` (Python 3.9+) delegates the blocking call to a thread pool worker, keeping the event loop responsive.

## Test plan

- [ ] Verify search endpoints still return correct results after the change
- [ ] Under concurrent load, confirm the server remains responsive during embedding generation
- [ ] Validate with both local and API-based embedding models

Signed-off-by: Tim Ren <137012659+xr843@users.noreply.github.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a critical performance issue where synchronous embedding API calls were blocking the asyncio event loop in search endpoints. By wrapping `embedding_model.embed()` calls with `asyncio.to_thread()` in both `vector_search` and `hybrid_search` methods, the server can now handle concurrent requests without stalling during embedding generation. The change adds an `asyncio` import and modifies two embedding calls to run in a thread pool, preventing the blocking HTTP requests from freezing the event loop under load.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_backend/app/retriever/chunks_hybrid_search.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/0dc3b6af0838f5097afae6e9c26ef981ceec07576e1c2c6e244fa5f1ab2a19d5/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=885)
<!-- RECURSEML_SUMMARY:END -->