### PR TITLE
fix: use asyncio.to_thread for embedding calls in search endpoints

### DIFF
--- a/surfsense_backend/app/retriever/chunks_hybrid_search.py
+++ b/surfsense_backend/app/retriever/chunks_hybrid_search.py
@@ -1,3 +1,4 @@
+import asyncio
 import time
 from datetime import datetime
 
@@ -49,7 +50,7 @@ class ChucksHybridSearchRetriever:
         # Get embedding for the query
         embedding_model = config.embedding_model_instance
         t_embed = time.perf_counter()
-        query_embedding = embedding_model.embed(query_text)
+        query_embedding = await asyncio.to_thread(embedding_model.embed, query_text)
         perf.debug(
             "[chunk_search] vector_search embedding in %.3fs",
             time.perf_counter() - t_embed,
@@ -195,7 +196,7 @@ class ChucksHybridSearchRetriever:
         if query_embedding is None:
             embedding_model = config.embedding_model_instance
             t_embed = time.perf_counter()
-            query_embedding = embedding_model.embed(query_text)
+            query_embedding = await asyncio.to_thread(embedding_model.embed, query_text)
             perf.debug(
                 "[chunk_search] hybrid_search embedding in %.3fs",
                 time.perf_counter() - t_embed,


### PR DESCRIPTION
Fixes #794

## Summary

Wraps synchronous `embedding_model.embed()` calls with `asyncio.to_thread()` in both `vector_search` and `hybrid_search` methods of `ChucksHybridSearchRetriever`.

## Problem

The `embed()` call is a blocking I/O operation (network call to the embedding provider). When called directly inside an `async` method, it blocks the entire asyncio event loop, degrading server responsiveness under concurrent requests.

## Changes

- Added `import asyncio` at the top of `chunks_hybrid_search.py`
- `vector_search`: changed `embedding_model.embed(query_text)` → `await asyncio.to_thread(embedding_model.embed, query_text)`
- `hybrid_search`: same change for the fallback embedding path

## Why `asyncio.to_thread`

- Zero dependency — stdlib only
- Offloads the blocking call to a thread-pool worker, freeing the event loop
- Drop-in replacement; no API changes needed

> Re-opened from #885, now targeting the `dev` branch as requested by @MODSetter.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a concurrency issue where synchronous embedding API calls were blocking the asyncio event loop. The fix wraps `embedding_model.embed()` calls with `asyncio.to_thread()` in both the `vector_search` and `hybrid_search` methods, offloading the blocking I/O operations to a thread pool worker. This change improves server responsiveness under concurrent requests without requiring any API changes or external dependencies.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_backend/app/retriever/chunks_hybrid_search.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyzing latest changes...](https://img.shields.io/badge/Analyzing%20latest%20changes...-lightgray?style=plastic)](https://github.com/MODSetter/SurfSense/pull/886)
<!-- RECURSEML_SUMMARY:END -->