### PR TITLE
fix: Add BookStack and Obsidian to periodic scheduler task_map

### DIFF
--- a/surfsense_backend/app/tasks/celery_tasks/schedule_checker_task.py
+++ b/surfsense_backend/app/tasks/celery_tasks/schedule_checker_task.py
@@ -54,6 +54,7 @@ async def _check_and_trigger_schedules():
             # Import all indexing tasks
             from app.tasks.celery_tasks.connector_tasks import (
                 index_airtable_records_task,
+                index_bookstack_pages_task,
                 index_clickup_tasks_task,
                 index_composio_connector_task,
                 index_confluence_pages_task,
@@ -68,6 +69,7 @@ async def _check_and_trigger_schedules():
                 index_linear_issues_task,
                 index_luma_events_task,
                 index_notion_pages_task,
+                index_obsidian_vault_task,
                 index_slack_messages_task,
             )
 
@@ -87,6 +89,8 @@ async def _check_and_trigger_schedules():
                 SearchSourceConnectorType.LUMA_CONNECTOR: index_luma_events_task,
                 SearchSourceConnectorType.ELASTICSEARCH_CONNECTOR: index_elasticsearch_documents_task,
                 SearchSourceConnectorType.WEBCRAWLER_CONNECTOR: index_crawled_urls_task,
+                SearchSourceConnectorType.BOOKSTACK_CONNECTOR: index_bookstack_pages_task,
+                SearchSourceConnectorType.OBSIDIAN_CONNECTOR: index_obsidian_vault_task,
                 SearchSourceConnectorType.GOOGLE_DRIVE_CONNECTOR: index_google_drive_files_task,
                 # Composio connector types
                 SearchSourceConnectorType.COMPOSIO_GOOGLE_DRIVE_CONNECTOR: index_composio_connector_task,


### PR DESCRIPTION
## Summary
- Add `BOOKSTACK_CONNECTOR` → `index_bookstack_pages_task` to `task_map` in `schedule_checker_task.py`
- Add `OBSIDIAN_CONNECTOR` → `index_obsidian_vault_task` to `task_map` in `schedule_checker_task.py`
- Add corresponding imports for both tasks

## Motivation
Both BookStack and Obsidian connectors support periodic indexing in the UI (the frontend correctly saves `periodic_indexing_enabled`, `indexing_frequency_minutes`, and `next_scheduled_at`), but the `check_periodic_schedules` task couldn't dispatch their indexing tasks because they were missing from the `task_map`.

The tasks exist in `connector_tasks.py` and are routed to `surfsense.connectors` queue in `celery_app.py` — they were just never added to the scheduler's dispatch map.

FIX #891

## Test plan
- [x] Verified BookStack periodic indexing triggers automatically after this fix
- [x] Confirmed existing connector types still work (no regressions)
- [x] Both tasks are already registered in `connector_tasks.py` and `celery_app.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a bug where BookStack and Obsidian connectors couldn't execute periodic indexing despite the UI allowing users to configure it. The fix adds the missing mappings for `BOOKSTACK_CONNECTOR` and `OBSIDIAN_CONNECTOR` to the `task_map` dictionary in the periodic scheduler, along with the necessary imports for their indexing tasks. This allows the `check_periodic_schedules` task to properly dispatch indexing jobs for these two connector types.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_backend/app/tasks/celery_tasks/schedule_checker_task.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/26998171e6a21961e6d500e86bcb5d4b5a8f749ba169775fd7d9cb1701c391f6/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=893)
<!-- RECURSEML_SUMMARY:END -->