### PR TITLE
feat: Add shelf exclusion filter to BookStack connector

### DIFF
--- a/surfsense_backend/app/connectors/bookstack_connector.py
+++ b/surfsense_backend/app/connectors/bookstack_connector.py
@@ -155,12 +155,77 @@ class BookStackConnector:
         except requests.exceptions.RequestException as e:
             raise Exception(f"BookStack API request failed: {e!s}") from e
 
-    def get_all_pages(self, count: int = 500) -> list[dict[str, Any]]:
+    def get_all_shelves(self, count: int = 500) -> list[dict[str, Any]]:
+        """
+        Fetch all shelves from BookStack with pagination.
+
+        Args:
+            count: Number of records per request (max 500)
+
+        Returns:
+            List of shelf objects
+        """
+        all_shelves = []
+        offset = 0
+
+        while True:
+            params = {
+                "count": min(count, 500),
+                "offset": offset,
+            }
+
+            result = self.make_api_request("shelves", params)
+
+            if not isinstance(result, dict) or "data" not in result:
+                raise Exception("Invalid response from BookStack API")
+
+            shelves = result["data"]
+            all_shelves.extend(shelves)
+
+            logger.info(f"Fetched {len(shelves)} shelves (offset: {offset})")
+
+            total = result.get("total", 0)
+            if offset + len(shelves) >= total:
+                break
+
+            offset += len(shelves)
+
+        logger.info(f"Total shelves fetched: {len(all_shelves)}")
+        return all_shelves
+
+    def build_book_to_shelf_map(self) -> dict[int, int]:
+        """
+        Build a mapping from book_id to shelf_id.
+
+        Fetches all shelves and their book listings to create
+        a lookup table used for filtering pages by shelf.
+
+        Returns:
+            Dict mapping book_id -> shelf_id
+        """
+        book_to_shelf = {}
+        shelves = self.get_all_shelves()
+
+        for shelf in shelves:
+            shelf_id = shelf["id"]
+            shelf_detail = self.make_api_request(f"shelves/{shelf_id}")
+            if isinstance(shelf_detail, dict):
+                for book in shelf_detail.get("books", []):
+                    book_to_shelf[book["id"]] = shelf_id
+
+        return book_to_shelf
+
+    def get_all_pages(
+        self,
+        count: int = 500,
+        excluded_shelf_ids: list[int] | None = None,
+    ) -> list[dict[str, Any]]:
         """
         Fetch all pages from BookStack with pagination.
 
         Args:
             count: Number of records per request (max 500)
+            excluded_shelf_ids: Optional list of shelf IDs whose pages should be excluded
 
         Returns:
             List of page objects
@@ -194,6 +259,15 @@ class BookStackConnector:
                 break
 
             offset += len(pages)
+
+        # Filter by excluded shelves if specified
+        if excluded_shelf_ids:
+            book_to_shelf = self.build_book_to_shelf_map()
+            excluded = set(excluded_shelf_ids)
+            all_pages = [
+                p for p in all_pages
+                if book_to_shelf.get(p.get("book_id")) not in excluded
+            ]
 
         logger.info(f"Total pages fetched: {len(all_pages)}")
         return all_pages
@@ -268,6 +342,7 @@ class BookStackConnector:
         start_date: str,
         end_date: str,
         count: int = 500,
+        excluded_shelf_ids: list[int] | None = None,
     ) -> tuple[list[dict[str, Any]], str | None]:
         """
         Fetch pages updated within a specific date range.
@@ -278,6 +353,7 @@ class BookStackConnector:
             start_date: Start date in YYYY-MM-DD format
             end_date: End date in YYYY-MM-DD format (currently unused, for future use)
             count: Number of records per request (max 500)
+            excluded_shelf_ids: Optional list of shelf IDs whose pages should be excluded
 
         Returns:
             Tuple of (list of page objects, error message or None)
@@ -315,6 +391,15 @@ class BookStackConnector:
                     break
 
                 offset += len(pages)
+
+            # Filter by excluded shelves if specified
+            if excluded_shelf_ids and all_pages:
+                book_to_shelf = self.build_book_to_shelf_map()
+                excluded = set(excluded_shelf_ids)
+                all_pages = [
+                    p for p in all_pages
+                    if book_to_shelf.get(p.get("book_id")) not in excluded
+                ]
 
             if not all_pages:
                 return [], f"No pages found updated after {start_date}"

--- a/surfsense_backend/app/routes/search_source_connectors_routes.py
+++ b/surfsense_backend/app/routes/search_source_connectors_routes.py
@@ -143,6 +143,53 @@ async def list_github_repositories(
         ) from e
 
 
+class BookStackCredentialsRequest(BaseModel):
+    """Request model for BookStack API credentials."""
+    base_url: str = Field(..., description="BookStack instance base URL")
+    token_id: str = Field(..., description="BookStack API Token ID")
+    token_secret: str = Field(..., description="BookStack API Token Secret")
+
+
+@router.post("/bookstack/shelves", response_model=list[dict[str, Any]])
+async def list_bookstack_shelves(
+    creds: BookStackCredentialsRequest,
+    user: User = Depends(current_active_user),
+):
+    """
+    Fetches all shelves from a BookStack instance.
+    Used by the frontend to let users select which shelves to exclude from indexing.
+    """
+    try:
+        from app.connectors.bookstack_connector import BookStackConnector
+
+        client = BookStackConnector(
+            base_url=creds.base_url,
+            token_id=creds.token_id,
+            token_secret=creds.token_secret,
+        )
+        shelves = client.get_all_shelves()
+
+        result = []
+        for shelf in shelves:
+            detail = client.make_api_request(f"shelves/{shelf['id']}")
+            books = detail.get("books", []) if isinstance(detail, dict) else []
+            result.append({
+                "id": shelf["id"],
+                "name": shelf["name"],
+                "book_count": len(books),
+                "books": [{"id": b["id"], "name": b["name"]} for b in books],
+            })
+        return result
+    except ValueError as e:
+        logger.error(f"BookStack credential validation failed for user {user.id}: {e!s}")
+        raise HTTPException(status_code=400, detail=f"Invalid BookStack credentials: {e!s}") from e
+    except Exception as e:
+        logger.error(f"Failed to fetch BookStack shelves for user {user.id}: {e!s}")
+        raise HTTPException(
+            status_code=500, detail=f"Failed to fetch BookStack shelves: {e!s}"
+        ) from e
+
+
 @router.post("/search-source-connectors", response_model=SearchSourceConnectorRead)
 async def create_search_source_connector(
     connector: SearchSourceConnectorCreate,

--- a/surfsense_backend/app/tasks/connector_indexers/bookstack_indexer.py
+++ b/surfsense_backend/app/tasks/connector_indexers/bookstack_indexer.py
@@ -104,6 +104,9 @@ async def index_bookstack_pages(
         bookstack_token_id = connector.config.get("BOOKSTACK_TOKEN_ID")
         bookstack_token_secret = connector.config.get("BOOKSTACK_TOKEN_SECRET")
 
+        # Optional: shelf IDs to exclude from indexing
+        excluded_shelf_ids = connector.config.get("BOOKSTACK_EXCLUDED_SHELF_IDS", [])
+
         if (
             not bookstack_base_url
             or not bookstack_token_id
@@ -148,7 +151,9 @@ async def index_bookstack_pages(
         # Get pages within date range
         try:
             pages, error = bookstack_client.get_pages_by_date_range(
-                start_date=start_date_str, end_date=end_date_str
+                start_date=start_date_str,
+                end_date=end_date_str,
+                excluded_shelf_ids=excluded_shelf_ids,
             )
 
             if error:

--- a/surfsense_web/components/assistant-ui/connector-popup/connect-forms/components/bookstack-connect-form.tsx
+++ b/surfsense_web/components/assistant-ui/connector-popup/connect-forms/components/bookstack-connect-form.tsx
@@ -1,12 +1,15 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Info } from "lucide-react";
+import { Info, Loader2, RefreshCw, X } from "lucide-react";
 import type { FC } from "react";
-import { useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import * as z from "zod";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
 	Form,
 	FormControl,
@@ -27,6 +30,7 @@ import {
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import { EnumConnectorName } from "@/contracts/enums/connector";
+import { connectorsApiService } from "@/lib/apis/connectors-api.service";
 import { DateRangeSelector } from "../../components/date-range-selector";
 import { getConnectorBenefits } from "../connector-benefits";
 import type { ConnectFormProps } from "../index";
@@ -46,12 +50,25 @@ const bookstackConnectorFormSchema = z.object({
 
 type BookStackConnectorFormValues = z.infer<typeof bookstackConnectorFormSchema>;
 
+interface BookStackShelf {
+	id: number;
+	name: string;
+	book_count: number;
+	books: { id: number; name: string }[];
+}
+
 export const BookStackConnectForm: FC<ConnectFormProps> = ({ onSubmit, isSubmitting }) => {
 	const isSubmittingRef = useRef(false);
 	const [startDate, setStartDate] = useState<Date | undefined>(undefined);
 	const [endDate, setEndDate] = useState<Date | undefined>(undefined);
 	const [periodicEnabled, setPeriodicEnabled] = useState(false);
 	const [frequencyMinutes, setFrequencyMinutes] = useState("1440");
+	const [shelves, setShelves] = useState<BookStackShelf[]>([]);
+	const [excludedShelfIds, setExcludedShelfIds] = useState<number[]>([]);
+	const [loadingShelves, setLoadingShelves] = useState(false);
+	const [shelvesError, setShelvesError] = useState<string | null>(null);
+	const [shelvesLoaded, setShelvesLoaded] = useState(false);
+
 	const form = useForm<BookStackConnectorFormValues>({
 		resolver: zodResolver(bookstackConnectorFormSchema),
 		defaultValues: {
@@ -62,8 +79,42 @@ export const BookStackConnectForm: FC<ConnectFormProps> = ({ onSubmit, isSubmitt
 		},
 	});
 
+	const fetchShelves = useCallback(async () => {
+		const values = form.getValues();
+		if (!values.base_url || !values.token_id || !values.token_secret) {
+			setShelvesError("Please fill in Base URL, Token ID, and Token Secret first.");
+			return;
+		}
+
+		setLoadingShelves(true);
+		setShelvesError(null);
+
+		try {
+			const data = await connectorsApiService.listBookStackShelves(
+				values.base_url,
+				values.token_id,
+				values.token_secret,
+			) as BookStackShelf[];
+			setShelves(data);
+			setShelvesLoaded(true);
+		} catch (err) {
+			setShelvesError(err instanceof Error ? err.message : "Failed to fetch shelves");
+			setShelves([]);
+			setShelvesLoaded(false);
+		} finally {
+			setLoadingShelves(false);
+		}
+	}, [form]);
+
+	const toggleShelfExclusion = (shelfId: number) => {
+		setExcludedShelfIds((prev) =>
+			prev.includes(shelfId)
+				? prev.filter((id) => id !== shelfId)
+				: [...prev, shelfId]
+		);
+	};
+
 	const handleSubmit = async (values: BookStackConnectorFormValues) => {
-		// Prevent multiple submissions
 		if (isSubmittingRef.current || isSubmitting) {
 			return;
 		}
@@ -77,6 +128,7 @@ export const BookStackConnectForm: FC<ConnectFormProps> = ({ onSubmit, isSubmitt
 					BOOKSTACK_BASE_URL: values.base_url,
 					BOOKSTACK_TOKEN_ID: values.token_id,
 					BOOKSTACK_TOKEN_SECRET: values.token_secret,
+					BOOKSTACK_EXCLUDED_SHELF_IDS: excludedShelfIds,
 				},
 				is_indexable: true,
 				is_active: true,
@@ -202,6 +254,95 @@ export const BookStackConnectForm: FC<ConnectFormProps> = ({ onSubmit, isSubmitt
 								</FormItem>
 							)}
 						/>
+
+						{/* Shelf Exclusion Picker */}
+						<div className="space-y-3 pt-4 border-t border-slate-400/20">
+							<div className="flex items-center justify-between">
+								<div>
+									<h3 className="text-sm sm:text-base font-medium">Shelf Filter</h3>
+									<p className="text-[10px] sm:text-xs text-muted-foreground mt-1">
+										Optionally exclude shelves from indexing. Click &quot;Load Shelves&quot; after entering your credentials.
+									</p>
+								</div>
+								<Button
+									type="button"
+									variant="outline"
+									size="sm"
+									onClick={fetchShelves}
+									disabled={loadingShelves || isSubmitting}
+									className="text-xs"
+								>
+									{loadingShelves ? (
+										<Loader2 className="h-3 w-3 animate-spin mr-1" />
+									) : (
+										<RefreshCw className="h-3 w-3 mr-1" />
+									)}
+									{shelvesLoaded ? "Refresh" : "Load Shelves"}
+								</Button>
+							</div>
+
+							{shelvesError && (
+								<p className="text-xs text-destructive">{shelvesError}</p>
+							)}
+
+							{shelvesLoaded && shelves.length > 0 && (
+								<div className="rounded-lg border border-slate-400/20 divide-y divide-slate-400/10">
+									{shelves.map((shelf) => {
+										const isExcluded = excludedShelfIds.includes(shelf.id);
+										return (
+											<label
+												key={shelf.id}
+												className={`flex items-center gap-3 p-2.5 sm:p-3 cursor-pointer hover:bg-slate-400/5 transition-colors ${
+													isExcluded ? "opacity-50" : ""
+												}`}
+											>
+												<Checkbox
+													checked={!isExcluded}
+													onCheckedChange={() => toggleShelfExclusion(shelf.id)}
+												/>
+												<div className="flex-1 min-w-0">
+													<div className="text-xs sm:text-sm font-medium truncate">
+														{shelf.name}
+													</div>
+													<div className="text-[10px] sm:text-xs text-muted-foreground">
+														{shelf.book_count} {shelf.book_count === 1 ? "book" : "books"}
+													</div>
+												</div>
+												{isExcluded && (
+													<Badge variant="secondary" className="text-[10px] shrink-0">
+														Excluded
+													</Badge>
+												)}
+											</label>
+										);
+									})}
+								</div>
+							)}
+
+							{shelvesLoaded && shelves.length === 0 && (
+								<p className="text-xs text-muted-foreground italic">No shelves found in this BookStack instance.</p>
+							)}
+
+							{excludedShelfIds.length > 0 && shelvesLoaded && (
+								<div className="flex flex-wrap gap-1.5 mt-2">
+									<span className="text-[10px] sm:text-xs text-muted-foreground">Excluding:</span>
+									{excludedShelfIds.map((id) => {
+										const shelf = shelves.find((s) => s.id === id);
+										return (
+											<Badge
+												key={id}
+												variant="destructive"
+												className="text-[10px] cursor-pointer hover:bg-destructive/80"
+												onClick={() => toggleShelfExclusion(id)}
+											>
+												{shelf?.name || `ID ${id}`}
+												<X className="h-2.5 w-2.5 ml-1" />
+											</Badge>
+										);
+									})}
+								</div>
+							)}
+						</div>
 
 						{/* Indexing Configuration */}
 						<div className="space-y-4 pt-4 border-t border-slate-400/20">

--- a/surfsense_web/components/assistant-ui/connector-popup/connector-configs/components/bookstack-config.tsx
+++ b/surfsense_web/components/assistant-ui/connector-popup/connector-configs/components/bookstack-config.tsx
@@ -1,14 +1,25 @@
 "use client";
 
-import { KeyRound } from "lucide-react";
+import { KeyRound, Loader2, RefreshCw, X } from "lucide-react";
 import type { FC } from "react";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { connectorsApiService } from "@/lib/apis/connectors-api.service";
 import type { ConnectorConfigProps } from "../index";
 
 export interface BookStackConfigProps extends ConnectorConfigProps {
 	onNameChange?: (name: string) => void;
+}
+
+interface BookStackShelf {
+	id: number;
+	name: string;
+	book_count: number;
+	books: { id: number; name: string }[];
 }
 
 export const BookStackConfig: FC<BookStackConfigProps> = ({
@@ -26,17 +37,65 @@ export const BookStackConfig: FC<BookStackConfigProps> = ({
 		(connector.config?.BOOKSTACK_TOKEN_SECRET as string) || ""
 	);
 	const [name, setName] = useState<string>(connector.name || "");
+	const [shelves, setShelves] = useState<BookStackShelf[]>([]);
+	const [excludedShelfIds, setExcludedShelfIds] = useState<number[]>(
+		(connector.config?.BOOKSTACK_EXCLUDED_SHELF_IDS as number[]) || []
+	);
+	const [loadingShelves, setLoadingShelves] = useState(false);
+	const [shelvesError, setShelvesError] = useState<string | null>(null);
+	const [shelvesLoaded, setShelvesLoaded] = useState(false);
 
 	// Update values when connector changes
 	useEffect(() => {
 		const url = (connector.config?.BOOKSTACK_BASE_URL as string) || "";
 		const id = (connector.config?.BOOKSTACK_TOKEN_ID as string) || "";
 		const secret = (connector.config?.BOOKSTACK_TOKEN_SECRET as string) || "";
+		const excluded = (connector.config?.BOOKSTACK_EXCLUDED_SHELF_IDS as number[]) || [];
 		setBaseUrl(url);
 		setTokenId(id);
 		setTokenSecret(secret);
+		setExcludedShelfIds(excluded);
 		setName(connector.name || "");
 	}, [connector.config, connector.name]);
+
+	const fetchShelves = useCallback(async () => {
+		if (!baseUrl || !tokenId || !tokenSecret) {
+			setShelvesError("Please fill in Base URL, Token ID, and Token Secret first.");
+			return;
+		}
+
+		setLoadingShelves(true);
+		setShelvesError(null);
+
+		try {
+			const data = await connectorsApiService.listBookStackShelves(
+				baseUrl,
+				tokenId,
+				tokenSecret,
+			) as BookStackShelf[];
+			setShelves(data);
+			setShelvesLoaded(true);
+		} catch (err) {
+			setShelvesError(err instanceof Error ? err.message : "Failed to fetch shelves");
+			setShelves([]);
+			setShelvesLoaded(false);
+		} finally {
+			setLoadingShelves(false);
+		}
+	}, [baseUrl, tokenId, tokenSecret]);
+
+	const toggleShelfExclusion = (shelfId: number) => {
+		const newExcluded = excludedShelfIds.includes(shelfId)
+			? excludedShelfIds.filter((id) => id !== shelfId)
+			: [...excludedShelfIds, shelfId];
+		setExcludedShelfIds(newExcluded);
+		if (onConfigChange) {
+			onConfigChange({
+				...connector.config,
+				BOOKSTACK_EXCLUDED_SHELF_IDS: newExcluded,
+			});
+		}
+	};
 
 	const handleBaseUrlChange = (value: string) => {
 		setBaseUrl(value);
@@ -144,6 +203,105 @@ export const BookStackConfig: FC<BookStackConfigProps> = ({
 						</p>
 					</div>
 				</div>
+			</div>
+
+			{/* Shelf Exclusion Picker */}
+			<div className="rounded-xl border border-border bg-slate-400/5 dark:bg-white/5 p-3 sm:p-6 space-y-3 sm:space-y-4">
+				<div className="flex items-center justify-between">
+					<div className="space-y-1 sm:space-y-2">
+						<h3 className="font-medium text-sm sm:text-base">Shelf Filter</h3>
+						<p className="text-[10px] sm:text-xs text-muted-foreground">
+							Select which shelves to include in indexing. Unchecked shelves will be excluded.
+						</p>
+					</div>
+					<Button
+						type="button"
+						variant="outline"
+						size="sm"
+						onClick={fetchShelves}
+						disabled={loadingShelves}
+						className="text-xs"
+					>
+						{loadingShelves ? (
+							<Loader2 className="h-3 w-3 animate-spin mr-1" />
+						) : (
+							<RefreshCw className="h-3 w-3 mr-1" />
+						)}
+						{shelvesLoaded ? "Refresh" : "Load Shelves"}
+					</Button>
+				</div>
+
+				{shelvesError && (
+					<p className="text-xs text-destructive">{shelvesError}</p>
+				)}
+
+				{shelvesLoaded && shelves.length > 0 && (
+					<div className="rounded-lg border border-slate-400/20 divide-y divide-slate-400/10">
+						{shelves.map((shelf) => {
+							const isExcluded = excludedShelfIds.includes(shelf.id);
+							return (
+								<label
+									key={shelf.id}
+									className={`flex items-center gap-3 p-2.5 sm:p-3 cursor-pointer hover:bg-slate-400/5 transition-colors ${
+										isExcluded ? "opacity-50" : ""
+									}`}
+								>
+									<Checkbox
+										checked={!isExcluded}
+										onCheckedChange={() => toggleShelfExclusion(shelf.id)}
+									/>
+									<div className="flex-1 min-w-0">
+										<div className="text-xs sm:text-sm font-medium truncate">
+											{shelf.name}
+										</div>
+										<div className="text-[10px] sm:text-xs text-muted-foreground">
+											{shelf.book_count} {shelf.book_count === 1 ? "book" : "books"}
+										</div>
+									</div>
+									{isExcluded && (
+										<Badge variant="secondary" className="text-[10px] shrink-0">
+											Excluded
+										</Badge>
+									)}
+								</label>
+							);
+						})}
+					</div>
+				)}
+
+				{!shelvesLoaded && excludedShelfIds.length > 0 && (
+					<div className="flex flex-wrap gap-1.5">
+						<span className="text-[10px] sm:text-xs text-muted-foreground">Currently excluding shelf IDs:</span>
+						{excludedShelfIds.map((id) => (
+							<Badge key={id} variant="secondary" className="text-[10px]">
+								{id}
+							</Badge>
+						))}
+						<p className="text-[10px] sm:text-xs text-muted-foreground w-full mt-1">
+							Click &quot;Load Shelves&quot; to see shelf names and modify exclusions.
+						</p>
+					</div>
+				)}
+
+				{excludedShelfIds.length > 0 && shelvesLoaded && (
+					<div className="flex flex-wrap gap-1.5 mt-2">
+						<span className="text-[10px] sm:text-xs text-muted-foreground">Excluding:</span>
+						{excludedShelfIds.map((id) => {
+							const shelf = shelves.find((s) => s.id === id);
+							return (
+								<Badge
+									key={id}
+									variant="destructive"
+									className="text-[10px] cursor-pointer hover:bg-destructive/80"
+									onClick={() => toggleShelfExclusion(id)}
+								>
+									{shelf?.name || `ID ${id}`}
+									<X className="h-2.5 w-2.5 ml-1" />
+								</Badge>
+							);
+						})}
+					</div>
+				)}
 			</div>
 		</div>
 	);

--- a/surfsense_web/lib/apis/connectors-api.service.ts
+++ b/surfsense_web/lib/apis/connectors-api.service.ts
@@ -378,6 +378,23 @@ class ConnectorsApiService {
 			listDiscordChannelsResponse
 		);
 	};
+
+	// =============================================================================
+	// BookStack Connector Methods
+	// =============================================================================
+
+	/**
+	 * List BookStack shelves for shelf exclusion picker
+	 */
+	listBookStackShelves = async (baseUrl: string, tokenId: string, tokenSecret: string) => {
+		return baseApiService.post<any>(`/api/v1/bookstack/shelves`, undefined, {
+			body: {
+				base_url: baseUrl,
+				token_id: tokenId,
+				token_secret: tokenSecret,
+			},
+		});
+	};
 }
 
 export type { SlackChannel, DiscordChannel };


### PR DESCRIPTION
## Summary
- Add shelf exclusion filter to BookStack connector — lets users choose which shelves to include/exclude from indexing
- New `POST /api/v1/bookstack/shelves` endpoint to fetch shelves for the picker UI
- Shelf picker added to both the connect form and config/edit view
- Fully backward compatible — no migration needed, stored in existing connector config JSON

## Motivation
BookStack organizes content in a Shelves > Books > Chapters > Pages hierarchy. Teams often have shelves that shouldn't be indexed into certain search spaces (e.g., internal/private shelves, archives). This feature gives users control over what gets synced.

FIX #892

## Screenshots

The shelf picker appears in the connector setup after clicking "Load Shelves":
- Checkbox list shows all shelves with book counts
- Unchecked shelves are excluded (shown with "Excluded" badge)
- Excluded shelves shown as removable red badges below the list

## Changes

### Backend (3 files)
- `bookstack_connector.py`: Added `get_all_shelves()`, `build_book_to_shelf_map()`, and `excluded_shelf_ids` parameter to page fetching methods
- `bookstack_indexer.py`: Reads `BOOKSTACK_EXCLUDED_SHELF_IDS` from connector config
- `search_source_connectors_routes.py`: New `POST /bookstack/shelves` endpoint

### Frontend (3 files)
- `bookstack-connect-form.tsx`: Shelf picker with "Load Shelves" button
- `bookstack-config.tsx`: Same shelf picker on the edit view
- `connectors-api.service.ts`: `listBookStackShelves()` method

## API Changes
- [x] New endpoint: `POST /api/v1/bookstack/shelves` (accepts credentials, returns shelves with books)

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)
- [ ] Documentation update
- [ ] Dependencies update
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing
- [x] I have tested this locally
- [x] Manual/QA testing done
  - Verified shelf picker loads correctly with valid credentials
  - Verified excluded shelves are filtered during indexing
  - Verified existing connectors without exclusions still work (backward compat)
  - Verified periodic sync respects exclusion list

## Quality Checklist
- [x] My code follows the coding standards of this project
- [x] I have updated the documentation if necessary
- [x] I have not added any unnecessary dependencies
- [x] There are no lint errors in my changes
- [x] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds shelf exclusion filtering to the BookStack connector, allowing users to selectively choose which shelves to include or exclude during indexing. The implementation includes a new backend endpoint (`POST /api/v1/bookstack/shelves`) to fetch available shelves, enhanced filtering logic in the connector and indexer to respect excluded shelf IDs stored in the connector configuration, and a shelf picker UI in both the connector setup and edit views. The feature is fully backward compatible with no database migrations required, as the exclusion list is stored in the existing connector config JSON field.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_backend/app/routes/search_source_connectors_routes.py` |
| 2 | `surfsense_web/lib/apis/connectors-api.service.ts` |
| 3 | `surfsense_backend/app/connectors/bookstack_connector.py` |
| 4 | `surfsense_backend/app/tasks/connector_indexers/bookstack_indexer.py` |
| 5 | `surfsense_web/components/assistant-ui/connector-popup/connect-forms/components/bookstack-connect-form.tsx` |
| 6 | `surfsense_web/components/assistant-ui/connector-popup/connector-configs/components/bookstack-config.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyzing latest changes...](https://img.shields.io/badge/Analyzing%20latest%20changes...-lightgray?style=plastic)](https://github.com/MODSetter/SurfSense/pull/894)
<!-- RECURSEML_SUMMARY:END -->