### PR TITLE
fix: gate console.log calls behind development check

### DIFF
--- a/surfsense_web/components/assistant-ui/connector-popup/utils/mcp-config-validator.ts
+++ b/surfsense_web/components/assistant-ui/connector-popup/utils/mcp-config-validator.ts
@@ -33,6 +33,8 @@ import { z } from "zod";
 import type { MCPServerConfig, MCPToolDefinition } from "@/contracts/types/mcp.types";
 import { connectorsApiService } from "@/lib/apis/connectors-api.service";
 
+const IS_DEV = process.env.NODE_ENV === "development";
+
 /**
  * Zod schema for MCP server configuration
  * Supports both stdio (local process) and HTTP (remote server) transports
@@ -102,11 +104,11 @@ export const parseMCPConfig = (configJson: string): MCPConfigValidationResult =>
 	// Check cache first
 	const cached = configCache.get(configJson);
 	if (cached && Date.now() - cached.timestamp < CACHE_TTL) {
-		console.log("[MCP Validator] ✅ Using cached config");
+		if (IS_DEV) console.log("[MCP Validator] ✅ Using cached config");
 		return { config: cached.config, error: null };
 	}
 
-	console.log("[MCP Validator] 🔍 Parsing new config...");
+	if (IS_DEV) console.log("[MCP Validator] 🔍 Parsing new config...");
 
 	// Clean up expired cache entries periodically
 	if (configCache.size > 100) {
@@ -176,7 +178,7 @@ export const parseMCPConfig = (configJson: string): MCPConfigValidationResult =>
 			timestamp: Date.now(),
 		});
 
-		console.log("[MCP Validator] ✅ Config parsed successfully:", config);
+		if (IS_DEV) console.log("[MCP Validator] ✅ Config parsed successfully:", config);
 
 		return {
 			config,

--- a/surfsense_web/components/providers/ElectricProvider.tsx
+++ b/surfsense_web/components/providers/ElectricProvider.tsx
@@ -14,6 +14,8 @@ import {
 } from "@/lib/electric/client";
 import { ElectricContext } from "@/lib/electric/context";
 
+const IS_DEV = process.env.NODE_ENV === "development";
+
 interface ElectricProviderProps {
 	children: React.ReactNode;
 }
@@ -40,7 +42,7 @@ export function ElectricProvider({ children }: ElectricProviderProps) {
 		// No user logged in - cleanup if previous user existed
 		if (!isUserLoaded || !user?.id) {
 			if (previousUserIdRef.current && isElectricInitialized()) {
-				console.log("[ElectricProvider] User logged out, cleaning up...");
+				if (IS_DEV) console.log("[ElectricProvider] User logged out, cleaning up...");
 				cleanupElectric().then(() => {
 					previousUserIdRef.current = null;
 					setElectricClient(null);
@@ -61,14 +63,14 @@ export function ElectricProvider({ children }: ElectricProviderProps) {
 
 		async function init() {
 			try {
-				console.log(`[ElectricProvider] Initializing for user: ${userId}`);
+				if (IS_DEV) console.log(`[ElectricProvider] Initializing for user: ${userId}`);
 				const client = await initElectric(userId);
 
 				if (mounted) {
 					previousUserIdRef.current = userId;
 					setElectricClient(client);
 					setError(null);
-					console.log(`[ElectricProvider] ✅ Ready for user: ${userId}`);
+					if (IS_DEV) console.log(`[ElectricProvider] ✅ Ready for user: ${userId}`);
 				}
 			} catch (err) {
 				console.error("[ElectricProvider] Failed to initialize:", err);

--- a/surfsense_web/hooks/use-connectors-electric.ts
+++ b/surfsense_web/hooks/use-connectors-electric.ts
@@ -5,6 +5,8 @@ import type { SearchSourceConnector } from "@/contracts/types/connector.types";
 import type { SyncHandle } from "@/lib/electric/client";
 import { useElectricClient } from "@/lib/electric/context";
 
+const IS_DEV = process.env.NODE_ENV === "development";
+
 /**
  * Hook for managing connectors with Electric SQL real-time sync
  *
@@ -72,7 +74,7 @@ export function useConnectorsElectric(searchSpaceId: number | string | null) {
 
 		async function startSync() {
 			try {
-				console.log("[useConnectorsElectric] Starting sync for search space:", searchSpaceId);
+				if (IS_DEV) console.log("[useConnectorsElectric] Starting sync for search space:", searchSpaceId);
 
 				const handle = await electricClient.syncShape({
 					table: "search_source_connectors",
@@ -80,7 +82,7 @@ export function useConnectorsElectric(searchSpaceId: number | string | null) {
 					primaryKey: ["id"],
 				});
 
-				console.log("[useConnectorsElectric] Sync started:", {
+				if (IS_DEV) console.log("[useConnectorsElectric] Sync started:", {
 					isUpToDate: handle.isUpToDate,
 				});
 


### PR DESCRIPTION
Gates 8 unguarded console.log calls behind a development check.

## Why this matters

Debug logs leak into production console. The project already has an IS_DEV pattern in lib/electric/client.ts. These files missed it.

## Changes

- **use-connectors-electric.ts**: Gated 2 sync debug logs
- **mcp-config-validator.ts**: Gated 3 cache/parse debug logs
- **ElectricProvider.tsx**: Gated 3 init/cleanup debug logs

console.error calls are left untouched. Errors should always log.

## Testing

Grep confirms no unguarded console.log remains in the 3 files.

Fixes #904

This contribution was developed with AI assistance (Claude Code).

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR prevents debug logging from appearing in production by wrapping 8 `console.log` calls with a development environment check. The changes follow the existing `IS_DEV` pattern already used elsewhere in the project. Three files are modified to gate debug logs for sync operations, configuration parsing/caching, and provider initialization/cleanup. Error logging via `console.error` remains unchanged as those should always appear.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/components/assistant-ui/connector-popup/utils/mcp-config-validator.ts` |
| 2 | `surfsense_web/hooks/use-connectors-electric.ts` |
| 3 | `surfsense_web/components/providers/ElectricProvider.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/4e89a72f24e95a96ec36da26ce629974fce6f1837b930d15d0b10a0124c1fb51/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=922)
<!-- RECURSEML_SUMMARY:END -->