### PR TITLE
fix: add error logging to empty catch blocks in useMessagesElectric

### DIFF
--- a/surfsense_web/hooks/use-messages-electric.ts
+++ b/surfsense_web/hooks/use-messages-electric.ts
@@ -57,8 +57,8 @@ export function useMessagesElectric(
 							handle.initialSyncPromise,
 							new Promise((resolve) => setTimeout(resolve, 3000)),
 						]);
-					} catch {
-						// Timeout
+					} catch (err) {
+						console.warn("[useMessagesElectric] Sync timeout:", err);
 					}
 				}
 
@@ -70,8 +70,8 @@ export function useMessagesElectric(
 				syncHandleRef.current = handle;
 				await fetchMessages();
 				await setupLiveQuery();
-			} catch {
-				// Sync failed
+			} catch (err) {
+				console.warn("[useMessagesElectric] Sync failed:", err);
 			}
 		}
 
@@ -88,8 +88,8 @@ export function useMessagesElectric(
 				if (mounted && result.rows) {
 					handleMessagesUpdate(result.rows);
 				}
-			} catch {
-				// Query failed
+			} catch (err) {
+				console.warn("[useMessagesElectric] Query failed:", err);
 			}
 		}
 
@@ -130,8 +130,8 @@ export function useMessagesElectric(
 						liveQueryRef.current = liveQuery;
 					}
 				}
-			} catch {
-				// Live query failed
+			} catch (err) {
+				console.warn("[useMessagesElectric] Live query failed:", err);
 			}
 		}
 


### PR DESCRIPTION
Adds console.warn to 4 silent catch blocks in the Electric sync hook.

## Why this matters

Empty catch blocks swallow errors silently. When sync fails, there's no trace in the console. These warnings make failures observable without changing behavior.

## Changes

- **use-messages-electric.ts**: Added `console.warn` to catch blocks at lines 60, 73, 91, 133
- Cleanup catches at lines 147/155 stay silent (PGlite may already be closed)

## Testing

The hook still swallows errors (no re-throw). Warnings appear only when something fails.

Fixes #905

This contribution was developed with AI assistance (Claude Code).

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR improves observability in the `useMessagesElectric` hook by replacing four empty catch blocks with `console.warn` statements. Previously, sync failures, query errors, and timeouts were silently swallowed, making debugging difficult. The changes add error logging without altering the error handling behavior, making failures visible in the console while preserving the existing error-swallowing strategy.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/hooks/use-messages-electric.ts` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/4cccac9af93b4e47d9c4431b17a804c3120b5442e46747e12bd2dd8357101d64/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=923)
<!-- RECURSEML_SUMMARY:END -->