### PR TITLE
fix: replace `any` types with proper types in contact form component

### DIFF
--- a/surfsense_web/components/contact/contact-form.tsx
+++ b/surfsense_web/components/contact/contact-form.tsx
@@ -161,7 +161,7 @@ export const FeatureIconContainer = ({
 	);
 };
 
-export const Grid = ({ pattern, size }: { pattern?: number[][]; size?: number }) => {
+export const Grid = ({ pattern, size }: { pattern?: [number, number][]; size?: number }) => {
 	const p = pattern ?? [
 		[9, 3],
 		[8, 5],
@@ -185,7 +185,7 @@ export const Grid = ({ pattern, size }: { pattern?: number[][]; size?: number })
 	);
 };
 
-export function GridPattern({ width, height, x, y, squares, ...props }: any) {
+export function GridPattern({ width, height, x, y, squares, ...props }: React.ComponentProps<"svg"> & { width: number; height: number; x: string | number; y: string | number; squares?: [number, number][] }) {
 	const patternId = useId();
 
 	return (
@@ -205,7 +205,7 @@ export function GridPattern({ width, height, x, y, squares, ...props }: any) {
 			<rect width="100%" height="100%" strokeWidth={0} fill={`url(#${patternId})`} />
 			{squares && (
 				<svg aria-hidden="true" x={x} y={y} className="overflow-visible">
-					{squares.map(([x, y]: any, idx: number) => (
+					{squares.map(([x, y]: [number, number], idx: number) => (
 						<rect
 							strokeWidth="0"
 							key={`${x}-${y}-${idx}`}


### PR DESCRIPTION
## Summary

- Replace `any` props type in `GridPattern` with `React.ComponentProps<"svg">` plus explicit named props
- Replace `any` tuple type with `[number, number]` in the squares mapper

## Changes

- **`surfsense_web/components/contact/contact-form.tsx`** (lines 188, 208)

Closes #912

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR improves type safety in the contact form component by replacing `any` types with proper TypeScript types. The `GridPattern` component props are now explicitly typed using `React.ComponentProps<"svg">` extended with named props for `width`, `height`, `x`, `y`, and `squares`, while the tuple destructuring in the squares mapper now uses the explicit `[number, number]` type instead of `any`.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/components/contact/contact-form.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/7cef3407ef58a9fe6ca529d7e03e96b50093736d0cb3de212872062d3b5cf5d8/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=926)
<!-- RECURSEML_SUMMARY:END -->