### PR TITLE
fix: add AbortController to fetch call in audio download

### DIFF
--- a/surfsense_web/components/tool-ui/audio.tsx
+++ b/surfsense_web/components/tool-ui/audio.tsx
@@ -27,6 +27,7 @@ function formatTime(seconds: number): string {
 
 export function Audio({ id, src, title, description, artwork, durationMs, className }: AudioProps) {
 	const audioRef = useRef<HTMLAudioElement>(null);
+	const downloadControllerRef = useRef<AbortController | null>(null);
 	const [isPlaying, setIsPlaying] = useState(false);
 	const [currentTime, setCurrentTime] = useState(0);
 	const [duration, setDuration] = useState(durationMs ? durationMs / 1000 : 0);
@@ -84,8 +85,12 @@ export function Audio({ id, src, title, description, artwork, durationMs, classN
 
 	// Handle download
 	const handleDownload = useCallback(async () => {
+		downloadControllerRef.current?.abort();
+		const controller = new AbortController();
+		downloadControllerRef.current = controller;
+
 		try {
-			const response = await fetch(src);
+			const response = await fetch(src, { signal: controller.signal });
 			const blob = await response.blob();
 			const url = window.URL.createObjectURL(blob);
 			const a = document.createElement("a");
@@ -96,9 +101,15 @@ export function Audio({ id, src, title, description, artwork, durationMs, classN
 			document.body.removeChild(a);
 			window.URL.revokeObjectURL(url);
 		} catch (err) {
+			if (err instanceof DOMException && err.name === "AbortError") return;
 			console.error("Error downloading audio:", err);
 		}
 	}, [src, title]);
+
+	// Abort in-flight download on unmount
+	useEffect(() => {
+		return () => downloadControllerRef.current?.abort();
+	}, []);
 
 	// Set up audio event listeners
 	useEffect(() => {


### PR DESCRIPTION
## Summary

- Wrap the download fetch with an `AbortController` so in-flight requests are cancelled on unmount
- Also abort any previous download when a new one starts

## Changes

- **`surfsense_web/components/tool-ui/audio.tsx`** — add `downloadControllerRef`, pass `signal` to fetch, cleanup on unmount

Follows the same pattern as `surfsense_web/components/homepage/github-stars-badge.tsx` (lines 249–266).

Closes #919

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds `AbortController` support to the audio download functionality to properly cancel in-flight fetch requests when the component unmounts or when a new download is initiated while another is in progress. The implementation follows an existing pattern used in the github-stars-badge component and includes proper error handling for abort exceptions.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/components/tool-ui/audio.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/753b4f6ffe4cd20f30fa901ff1ab172d89593c89151a3108e8300a83aae5bae6/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=927)
<!-- RECURSEML_SUMMARY:END -->