### PR TITLE
fix: add missing `clearTimeout` cleanup in CopyButton useEffect

### DIFF
--- a/surfsense_web/components/ui/code-block-node.tsx
+++ b/surfsense_web/components/ui/code-block-node.tsx
@@ -143,9 +143,11 @@ function CopyButton({
 	const [hasCopied, setHasCopied] = React.useState(false);
 
 	React.useEffect(() => {
-		setTimeout(() => {
+		if (!hasCopied) return;
+		const timer = setTimeout(() => {
 			setHasCopied(false);
 		}, 2000);
+		return () => clearTimeout(timer);
 	}, [hasCopied]);
 
 	return (


### PR DESCRIPTION
## Summary

- Store timeout ID and clear it on unmount/re-trigger
- Add early return when `!hasCopied` to skip pointless timeout

## Changes

- **`surfsense_web/components/ui/code-block-node.tsx`** (lines 145–149)

Closes #934

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a memory leak in the `CopyButton` component by properly cleaning up the timeout when the component unmounts or when the effect re-runs. It stores the timeout ID and clears it in the cleanup function, and adds an early return optimization to skip creating unnecessary timeouts when `hasCopied` is false.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/components/ui/code-block-node.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/ea0e79df0de08065763d9ae38d50aa84604483186b982f7d02e2bb576adb75b0/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=955)
<!-- RECURSEML_SUMMARY:END -->