### PR TITLE
fix: use stable references for event listeners in Spotlight component

### DIFF
--- a/surfsense_web/components/ui/spotlight.tsx
+++ b/surfsense_web/components/ui/spotlight.tsx
@@ -48,14 +48,17 @@ export function Spotlight({
 	useEffect(() => {
 		if (!parentElement) return;
 
+		const handleEnter = () => setIsHovered(true);
+		const handleLeave = () => setIsHovered(false);
+
 		parentElement.addEventListener("mousemove", handleMouseMove);
-		parentElement.addEventListener("mouseenter", () => setIsHovered(true));
-		parentElement.addEventListener("mouseleave", () => setIsHovered(false));
+		parentElement.addEventListener("mouseenter", handleEnter);
+		parentElement.addEventListener("mouseleave", handleLeave);
 
 		return () => {
 			parentElement.removeEventListener("mousemove", handleMouseMove);
-			parentElement.removeEventListener("mouseenter", () => setIsHovered(true));
-			parentElement.removeEventListener("mouseleave", () => setIsHovered(false));
+			parentElement.removeEventListener("mouseenter", handleEnter);
+			parentElement.removeEventListener("mouseleave", handleLeave);
 		};
 	}, [parentElement, handleMouseMove]);
 


### PR DESCRIPTION
## Summary

- Extract mouseenter/mouseleave handlers into named variables so `removeEventListener` matches the same references that `addEventListener` used

## Changes

- **`surfsense_web/components/ui/spotlight.tsx`** (lines 48–60)

Closes #933

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a bug in the Spotlight component where event listeners were not being properly removed during cleanup. The issue was that inline arrow functions were being passed to both `addEventListener` and `removeEventListener`, creating different function references that prevented proper cleanup. The fix extracts the `mouseenter` and `mouseleave` handlers into stable named variables (`handleEnter` and `handleLeave`) so that the same function references are used for both adding and removing listeners.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/components/ui/spotlight.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/600983bd5e217f9d9d8866eb7d3b6c9b8cf6dad9c74919ad715094662f23d495/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=956)
<!-- RECURSEML_SUMMARY:END -->