### PR TITLE
fix: remove unused `useRouter` and `useParams` in SidebarHeader

### DIFF
--- a/surfsense_web/components/layout/ui/sidebar/SidebarHeader.tsx
+++ b/surfsense_web/components/layout/ui/sidebar/SidebarHeader.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { ChevronsUpDown, Settings, UserPen } from "lucide-react";
-import { useParams, useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import {
@@ -29,9 +28,6 @@ export function SidebarHeader({
 	className,
 }: SidebarHeaderProps) {
 	const t = useTranslations("sidebar");
-	const router = useRouter();
-	const params = useParams();
-	const searchSpaceId = params.search_space_id as string;
 
 	return (
 		<div className={cn("flex min-w-0 flex-1 items-center", className)}>


### PR DESCRIPTION
## Summary

- Remove unused `useRouter()`, `useParams()`, and `searchSpaceId` declarations
- Remove the now-unnecessary `next/navigation` import

## Changes

- **`surfsense_web/components/layout/ui/sidebar/SidebarHeader.tsx`**

Closes #944

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR removes unused imports and variable declarations from the `SidebarHeader` component. Specifically, it removes the `useRouter` and `useParams` hooks from `next/navigation`, along with the `searchSpaceId` variable that was derived from `params` but never used in the component.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/components/layout/ui/sidebar/SidebarHeader.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/a72a4bb12a66622fe39a6f46c42bad6d524d3cfc6410245417533051f75e2974/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=957)
<!-- RECURSEML_SUMMARY:END -->