### PR TITLE
fix: add missing `setTimeout` cleanup in hero section collision effect

### DIFF
--- a/surfsense_web/components/homepage/hero-section.tsx
+++ b/surfsense_web/components/homepage/hero-section.tsx
@@ -277,21 +277,24 @@ const CollisionMechanism = ({
 	}, [cycleCollisionDetected, parentRef]);
 
 	useEffect(() => {
-		if (collision.detected && collision.coordinates) {
-			setTimeout(() => {
-				setCollision({ detected: false, coordinates: null });
-				setCycleCollisionDetected(false);
-				// Set beam opacity to 0
-				if (beamRef.current) {
-					beamRef.current.style.opacity = "1";
-				}
-			}, 2000);
+		if (!collision.detected || !collision.coordinates) return;
 
-			// Reset the beam animation after a delay
-			setTimeout(() => {
-				setBeamKey((prevKey) => prevKey + 1);
-			}, 2000);
-		}
+		const timer1 = setTimeout(() => {
+			setCollision({ detected: false, coordinates: null });
+			setCycleCollisionDetected(false);
+			if (beamRef.current) {
+				beamRef.current.style.opacity = "1";
+			}
+		}, 2000);
+
+		const timer2 = setTimeout(() => {
+			setBeamKey((prevKey) => prevKey + 1);
+		}, 2000);
+
+		return () => {
+			clearTimeout(timer1);
+			clearTimeout(timer2);
+		};
 	}, [collision]);
 
 	return (


### PR DESCRIPTION
## Summary

- Store timeout IDs and clear them in the useEffect cleanup function
- Add early return when collision is not detected

## Changes

- **`surfsense_web/components/homepage/hero-section.tsx`** (lines 279–295)

Closes #940

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a memory leak in the hero section's collision effect by properly cleaning up `setTimeout` timers. The changes store timeout IDs in variables (`timer1` and `timer2`) and clear them in the useEffect cleanup function, preventing potential memory leaks when the component unmounts or the collision state changes. Additionally, an early return was added for better readability when no collision is detected.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/components/homepage/hero-section.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/ff25d30d8b96c54b238f8e6a20214e3fdc53e6ba90f819239e97f3153131d985/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=958)
<!-- RECURSEML_SUMMARY:END -->