### PR TITLE
fix: add `rel="noopener noreferrer"` to external link in link-toolbar

### DIFF
--- a/surfsense_web/components/ui/link-toolbar.tsx
+++ b/surfsense_web/components/ui/link-toolbar.tsx
@@ -187,6 +187,7 @@ function LinkOpenButton() {
 			}}
 			aria-label="Open link in a new tab"
 			target="_blank"
+			rel="noopener noreferrer"
 		>
 			<ExternalLink width={18} />
 		</a>


### PR DESCRIPTION
## Summary

- Add missing `rel="noopener noreferrer"` to `target="_blank"` link, preventing `window.opener` exposure

## Changes

- **`surfsense_web/components/ui/link-toolbar.tsx`** (line 189)

Closes #938

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds a security fix by including `rel="noopener noreferrer"` attribute to an external link that opens in a new tab, preventing potential security vulnerabilities where the opened page could access the `window.opener` object of the originating page.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/components/ui/link-toolbar.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/09182eb68ebdc78652af439a7a2ddc830babc4c12eab77333d47c19055cd50cc/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=959)
<!-- RECURSEML_SUMMARY:END -->