### PR TITLE
fix: replace `key={index}` with stable keys in pricing component

### DIFF
--- a/surfsense_web/components/pricing.tsx
+++ b/surfsense_web/components/pricing.tsx
@@ -101,9 +101,9 @@ export function Pricing({
 					plans.length === 2 ? "md:grid-cols-2 max-w-5xl mx-auto" : "md:grid-cols-3"
 				)}
 			>
-				{plans.map((plan, index) => (
+				{plans.map((plan) => (
 					<motion.div
-						key={index}
+						key={plan.name}
 						initial={{ y: 50, opacity: 1 }}
 						whileInView={
 							isDesktop
@@ -193,8 +193,8 @@ export function Pricing({
 							</p>
 
 							<ul className="mt-5 gap-2 flex flex-col">
-								{plan.features.map((feature, idx) => (
-									<li key={idx} className="flex items-start gap-2">
+								{plan.features.map((feature) => (
+									<li key={feature} className="flex items-start gap-2">
 										<Check className="h-4 w-4 text-primary mt-1 flex-shrink-0" />
 										<span className="text-left">{feature}</span>
 									</li>


### PR DESCRIPTION
## Summary

- Use `plan.name` as key for plan cards instead of array index
- Use feature text as key for feature list items

## Changes

- **`surfsense_web/components/pricing.tsx`** (lines 104, 196)

Closes #942

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR improves React key prop usage in the pricing component by replacing array index-based keys with stable, content-based keys. Plan cards now use `plan.name` as their key, and feature list items use the feature text itself, which helps React better track component identity and avoid potential rendering issues.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/components/pricing.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/d33eea899b0f24c61ba6486a128d5e44fd9d3519423bd5dbcb72917cec4e9075/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=960)
<!-- RECURSEML_SUMMARY:END -->