### PR TITLE
fix: add `noopener` to `window.open` call in AnnouncementToastProvider

### DIFF
--- a/surfsense_web/components/announcements/AnnouncementToastProvider.tsx
+++ b/surfsense_web/components/announcements/AnnouncementToastProvider.tsx
@@ -34,7 +34,7 @@ function showAnnouncementToast(announcement: Announcement) {
 					label: announcement.link.label,
 					onClick: () => {
 						if (announcement.link?.url.startsWith("http")) {
-							window.open(announcement.link.url, "_blank");
+							window.open(announcement.link.url, "_blank", "noopener,noreferrer");
 						} else if (announcement.link?.url) {
 							window.location.href = announcement.link.url;
 						}


### PR DESCRIPTION
## Summary

- Add `noopener,noreferrer` to `window.open()` to prevent `window.opener` exposure

## Changes

- **`surfsense_web/components/announcements/AnnouncementToastProvider.tsx`** (line 37)

Closes #939

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds security hardening to the `window.open` call in the AnnouncementToastProvider by including `noopener,noreferrer` parameters. This prevents potential security vulnerabilities where opened windows could access the parent window through the `window.opener` property, which could be exploited for phishing or other malicious activities.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/components/announcements/AnnouncementToastProvider.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/03ddb8db796ad316105f59ae0b217df3a4ff422293382baa7740fe5d33e9f154/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=962)
<!-- RECURSEML_SUMMARY:END -->