### PR TITLE
fix: add missing `type` dependency in DocumentTypeChip truncation useEffect

### DIFF
--- a/surfsense_web/app/dashboard/[search_space_id]/documents/(manage)/components/DocumentTypeIcon.tsx
+++ b/surfsense_web/app/dashboard/[search_space_id]/documents/(manage)/components/DocumentTypeIcon.tsx
@@ -63,7 +63,7 @@ export function DocumentTypeChip({ type, className }: { type: string; className?
 		checkTruncation();
 		window.addEventListener("resize", checkTruncation);
 		return () => window.removeEventListener("resize", checkTruncation);
-	}, []);
+	}, [type]);
 
 	const chip = (
 		<span


### PR DESCRIPTION
## Summary

- Add `type` to the useEffect dependency array so truncation re-checks when the label changes

## Changes

- **`surfsense_web/app/dashboard/[search_space_id]/documents/(manage)/components/DocumentTypeIcon.tsx`** (line 66)

Closes #946

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a React hook dependency issue in the `DocumentTypeChip` component by adding the `type` prop to the `useEffect` dependency array. This ensures that text truncation logic re-runs when the document type label changes, preventing stale UI states.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/app/dashboard/[search_space_id]/documents/(manage)/components/DocumentTypeIcon.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/679727c1f33055099af9e516d2aa5e1e440cfa7afc3373bad6fdd50146d4bca4/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=963)
<!-- RECURSEML_SUMMARY:END -->