### PR TITLE
fix: clean up recursive `setTimeout` calls in onboarding tour

### DIFF
--- a/surfsense_web/components/onboarding-tour.tsx
+++ b/surfsense_web/components/onboarding-tour.tsx
@@ -436,6 +436,7 @@ export function OnboardingTour() {
 	const { resolvedTheme } = useTheme();
 	const pathname = usePathname();
 	const retryCountRef = useRef(0);
+	const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 	const maxRetries = 10;
 	// Track previous user ID to detect user changes
 	const previousUserIdRef = useRef<string | null>(null);
@@ -477,7 +478,7 @@ export function OnboardingTour() {
 			retryCountRef.current = 0;
 		} else if (retryCountRef.current < maxRetries) {
 			retryCountRef.current++;
-			setTimeout(() => {
+			retryTimerRef.current = setTimeout(() => {
 				const retryEl = document.querySelector(currentStep.target);
 				if (retryEl) {
 					setTargetEl(retryEl);
@@ -487,6 +488,10 @@ export function OnboardingTour() {
 				}
 			}, 200);
 		}
+
+		return () => {
+			if (retryTimerRef.current) clearTimeout(retryTimerRef.current);
+		};
 	}, [currentStep]);
 
 	// Check if tour should run: localStorage + data validation with user ID tracking
@@ -556,7 +561,11 @@ export function OnboardingTour() {
 		}
 
 		// User is new and hasn't seen tour - wait for DOM elements and start tour
+		let cancelled = false;
+
 		const checkAndStartTour = () => {
+			if (cancelled) return;
+
 			// Check if all required elements exist
 			const connectorEl = document.querySelector(TOUR_STEPS[0].target);
 			const documentsEl = document.querySelector(TOUR_STEPS[1].target);
@@ -578,7 +587,10 @@ export function OnboardingTour() {
 
 		// Start checking after initial delay
 		const timer = setTimeout(checkAndStartTour, 500);
-		return () => clearTimeout(timer);
+		return () => {
+			cancelled = true;
+			clearTimeout(timer);
+		};
 	}, [mounted, user?.id, searchSpaceId, pathname, threadsData, documentTypeCounts, connectors]);
 
 	// Update position on resize/scroll


### PR DESCRIPTION
## Summary

- Add `cancelled` flag to `checkAndStartTour` retry loop to skip state updates after unmount
- Store `updateTarget` retry timer in a ref and clear it on cleanup

## Changes

- **`surfsense_web/components/onboarding-tour.tsx`** (lines ~478–490, ~558–582)

Closes #950

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes memory leaks in the onboarding tour component by properly cleaning up recursive `setTimeout` calls. It adds a `cancelled` flag to prevent state updates after component unmount in the `checkAndStartTour` retry loop, and stores the `updateTarget` retry timer in a ref so it can be cleared during cleanup. These changes prevent the component from continuing to execute asynchronous operations after it has been unmounted.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/components/onboarding-tour.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/cbb9b219028f0c3bf43df0a1f14efea05dea606aa6402cf07acc8ea469f4ddf0/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=964)
<!-- RECURSEML_SUMMARY:END -->