### PR TITLE
fix: remove unnecessary `useEffect` + `useState` for `AUTH_TYPE` constant in login form

### DIFF
--- a/surfsense_web/app/(home)/login/LocalLoginForm.tsx
+++ b/surfsense_web/app/(home)/login/LocalLoginForm.tsx
@@ -5,7 +5,7 @@ import { AnimatePresence, motion } from "motion/react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { loginMutationAtom } from "@/atoms/auth/auth-mutation.atoms";
 import { Spinner } from "@/components/ui/spinner";
 import { getAuthErrorDetails, isNetworkError } from "@/lib/auth-errors";
@@ -25,14 +25,9 @@ export function LocalLoginForm() {
 		title: null,
 		message: null,
 	});
-	const [authType, setAuthType] = useState<string | null>(null);
+	const authType = AUTH_TYPE;
 	const router = useRouter();
 	const [{ mutateAsync: login, isPending: isLoggingIn }] = useAtom(loginMutationAtom);
-
-	useEffect(() => {
-		// Get the auth type from centralized config
-		setAuthType(AUTH_TYPE);
-	}, []);
 
 	const handleSubmit = async (e: React.FormEvent) => {
 		e.preventDefault();


### PR DESCRIPTION
## Summary

- Replace `useState` + `useEffect` with direct constant assignment since `AUTH_TYPE` is a static import
- Remove unused `useEffect` import

## Changes

- **`surfsense_web/app/(home)/login/LocalLoginForm.tsx`** (lines 8, 28–35)

Closes #941

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR simplifies the `LocalLoginForm` component by removing unnecessary React state management for a constant value. Since `AUTH_TYPE` is a static import that doesn't change, it's now assigned directly as a constant instead of being stored in state and set via `useEffect`. The unused `useEffect` import has also been removed.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/app/(home)/login/LocalLoginForm.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/4a29cc1e426ef463a06853962a78f3514bc83d6bf0f87033492315e707d4325c/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=967)
<!-- RECURSEML_SUMMARY:END -->