### PR TITLE
fix: validate redirect URL in auth flow to prevent open redirect

### DIFF
--- a/surfsense_web/lib/auth-utils.ts
+++ b/surfsense_web/lib/auth-utils.ts
@@ -70,7 +70,24 @@ export function getAndClearRedirectPath(): string | null {
 	if (redirectPath) {
 		localStorage.removeItem(REDIRECT_PATH_KEY);
 	}
+	if (redirectPath && !isValidRedirectPath(redirectPath)) {
+		return null;
+	}
 	return redirectPath;
+}
+
+/**
+ * Validates that a redirect path is a safe, relative URL on the same origin.
+ * Rejects absolute URLs, protocol-relative URLs, and scheme injections.
+ */
+function isValidRedirectPath(path: string): boolean {
+	if (!path.startsWith("/") || path.startsWith("//")) return false;
+	try {
+		const url = new URL(path, window.location.origin);
+		return url.origin === window.location.origin;
+	} catch {
+		return false;
+	}
 }
 
 /**


### PR DESCRIPTION
## Summary

- Add `isValidRedirectPath()` to reject absolute/protocol-relative URLs and scheme injections
- Apply validation in `getAndClearRedirectPath()` before returning the stored path

Prevents an attacker from crafting `/login?returnUrl=https://evil.com` to redirect users after login.

## Changes

- **`surfsense_web/lib/auth-utils.ts`** (lines 66–93)

Closes #949

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds validation to the authentication redirect flow to prevent open redirect vulnerabilities. A new `isValidRedirectPath()` helper function ensures that redirect URLs are relative paths on the same origin, rejecting absolute URLs, protocol-relative URLs (e.g., `//evil.com`), and scheme injections (e.g., `javascript:`). This validation is applied in `getAndClearRedirectPath()` before returning the stored redirect path, preventing attackers from redirecting users to external malicious sites after login.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/lib/auth-utils.ts` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/28f9e2afbb5e3466f0f7ec05053af7e31f538fd3c4ff278cc39cc706b2e70cb4/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=968)
<!-- RECURSEML_SUMMARY:END -->