### PR TITLE
fix: avoid stale event reference in register page retry action

### DIFF
--- a/surfsense_web/app/(home)/register/page.tsx
+++ b/surfsense_web/app/(home)/register/page.tsx
@@ -43,9 +43,12 @@ export default function RegisterPage() {
 		}
 	}, [router]);
 
-	const handleSubmit = async (e: React.FormEvent) => {
+	const handleSubmit = (e: React.FormEvent) => {
 		e.preventDefault();
+		submitForm();
+	};
 
+	const submitForm = async () => {
 		// Form validation
 		if (password !== confirmPassword) {
 			setError({ title: t("password_mismatch"), message: t("passwords_no_match_desc") });
@@ -140,7 +143,7 @@ export default function RegisterPage() {
 			if (shouldRetry(errorCode)) {
 				toastOptions.action = {
 					label: tCommon("retry"),
-					onClick: () => handleSubmit(e),
+					onClick: () => submitForm(),
 				};
 			}
 


### PR DESCRIPTION
## Summary

- Extract async submission logic into `submitForm()` (event-independent)
- Keep `handleSubmit` as a thin wrapper that calls `e.preventDefault()` then `submitForm()`
- Retry action calls `submitForm()` directly instead of `handleSubmit(e)`

## Changes

- **`surfsense_web/app/(home)/register/page.tsx`** (lines 46–143)

Closes #945

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a bug in the register page where retry actions were using a stale event reference. The solution refactors the form submission logic by extracting the async submission logic into a separate `submitForm()` function that doesn't depend on the event object, while keeping `handleSubmit()` as a thin wrapper that handles `preventDefault()` and calls `submitForm()`. The retry action now calls `submitForm()` directly, avoiding the stale event reference issue.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/app/(home)/register/page.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/435f8ecf3c4773870047f67884c91fc7c0e99bf7a00865ccfa99cedf1f7618d3/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=969)
<!-- RECURSEML_SUMMARY:END -->