### PR TITLE
fix: add noopener to window.open call in AnnouncementToastProvider

### DIFF
--- a/surfsense_web/components/announcements/AnnouncementToastProvider.tsx
+++ b/surfsense_web/components/announcements/AnnouncementToastProvider.tsx
@@ -34,7 +34,7 @@ function showAnnouncementToast(announcement: Announcement) {
 					label: announcement.link.label,
 					onClick: () => {
 						if (announcement.link?.url.startsWith("http")) {
-							window.open(announcement.link.url, "_blank");
+							window.open(announcement.link.url, "_blank", "noopener,noreferrer");
 						} else if (announcement.link?.url) {
 							window.location.href = announcement.link.url;
 						}


### PR DESCRIPTION
## Summary
- Add `noopener,noreferrer` to `window.open()` call in `AnnouncementToastProvider` to prevent the opened page from accessing `window.opener`

## Test plan
- Verify announcement toast links still open correctly in a new tab
- Verify `window.opener` is `null` in the opened page

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds security parameters `noopener` and `noreferrer` to the `window.open()` call in the AnnouncementToastProvider component. This prevents newly opened pages from accessing the `window.opener` property, which protects against potential tabnabbing attacks where malicious sites could manipulate the opener page.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/components/announcements/AnnouncementToastProvider.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/d32e9c88239b5e2360c393414bdbd0f87c12be1e0dc25970d149783e95c15d3a/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=971)
<!-- RECURSEML_SUMMARY:END -->