### PR TITLE
fix: add missing type dependency in DocumentTypeChip truncation useEffect

### DIFF
--- a/surfsense_web/app/dashboard/[search_space_id]/documents/(manage)/components/DocumentTypeIcon.tsx
+++ b/surfsense_web/app/dashboard/[search_space_id]/documents/(manage)/components/DocumentTypeIcon.tsx
@@ -63,7 +63,7 @@ export function DocumentTypeChip({ type, className }: { type: string; className?
 		checkTruncation();
 		window.addEventListener("resize", checkTruncation);
 		return () => window.removeEventListener("resize", checkTruncation);
-	}, []);
+	}, [type]);
 
 	const chip = (
 		<span


### PR DESCRIPTION
## Summary
- Add `type` to the useEffect dependency array in `DocumentTypeChip` so the truncation check re-runs when document type changes

## Test plan
- Verify truncation tooltip updates correctly when document type prop changes

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a React hook dependency issue in the `DocumentTypeChip` component by adding the `type` prop to the `useEffect` dependency array. This ensures that the truncation check re-runs whenever the document type changes, allowing the tooltip to update correctly when the component receives a new type prop.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/app/dashboard/[search_space_id]/documents/(manage)/components/DocumentTypeIcon.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/3417a3e62d0de7c823f63f79e5873435c3b78939de3cc5557a8940a447c632d7/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=972)
<!-- RECURSEML_SUMMARY:END -->