### PR TITLE
fix: clean up recursive setTimeout calls in onboarding tour

### DIFF
--- a/surfsense_web/components/onboarding-tour.tsx
+++ b/surfsense_web/components/onboarding-tour.tsx
@@ -436,6 +436,7 @@ export function OnboardingTour() {
 	const { resolvedTheme } = useTheme();
 	const pathname = usePathname();
 	const retryCountRef = useRef(0);
+	const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 	const maxRetries = 10;
 	// Track previous user ID to detect user changes
 	const previousUserIdRef = useRef<string | null>(null);
@@ -477,7 +478,7 @@ export function OnboardingTour() {
 			retryCountRef.current = 0;
 		} else if (retryCountRef.current < maxRetries) {
 			retryCountRef.current++;
-			setTimeout(() => {
+			retryTimerRef.current = setTimeout(() => {
 				const retryEl = document.querySelector(currentStep.target);
 				if (retryEl) {
 					setTargetEl(retryEl);
@@ -487,6 +488,10 @@ export function OnboardingTour() {
 				}
 			}, 200);
 		}
+
+		return () => {
+			if (retryTimerRef.current) clearTimeout(retryTimerRef.current);
+		};
 	}, [currentStep]);
 
 	// Check if tour should run: localStorage + data validation with user ID tracking
@@ -556,7 +561,11 @@ export function OnboardingTour() {
 		}
 
 		// User is new and hasn't seen tour - wait for DOM elements and start tour
+		let cancelled = false;
+
 		const checkAndStartTour = () => {
+			if (cancelled) return;
+
 			// Check if all required elements exist
 			const connectorEl = document.querySelector(TOUR_STEPS[0].target);
 			const documentsEl = document.querySelector(TOUR_STEPS[1].target);
@@ -578,7 +587,10 @@ export function OnboardingTour() {
 
 		// Start checking after initial delay
 		const timer = setTimeout(checkAndStartTour, 500);
-		return () => clearTimeout(timer);
+		return () => {
+			cancelled = true;
+			clearTimeout(timer);
+		};
 	}, [mounted, user?.id, searchSpaceId, pathname, threadsData, documentTypeCounts, connectors]);
 
 	// Update position on resize/scroll


### PR DESCRIPTION
## Summary
- Add `cancelled` flag and `retryTimerRef` to properly clean up recursive `setTimeout` calls in the onboarding tour component
- Prevents continued retries after component unmount

## Test plan
- Verify onboarding tour still works correctly
- Verify no lingering timers after navigating away during tour

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a memory leak in the onboarding tour component by adding proper cleanup for recursive `setTimeout` calls. It introduces a `retryTimerRef` to track and clear retry timers, and adds a `cancelled` flag to prevent the tour from starting after the component has unmounted. These changes ensure that timers don't continue running after users navigate away during the tour.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/components/onboarding-tour.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/bd373594b58909e10c8ee97119dec21c067296b86d96ca27b2b1ab18fcbd72d0/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=973)
<!-- RECURSEML_SUMMARY:END -->