### PR TITLE
fix: remove unnecessary useEffect + useState for AUTH_TYPE constant

### DIFF
--- a/surfsense_web/app/(home)/login/LocalLoginForm.tsx
+++ b/surfsense_web/app/(home)/login/LocalLoginForm.tsx
@@ -5,7 +5,7 @@ import { AnimatePresence, motion } from "motion/react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { loginMutationAtom } from "@/atoms/auth/auth-mutation.atoms";
 import { Spinner } from "@/components/ui/spinner";
 import { getAuthErrorDetails, isNetworkError } from "@/lib/auth-errors";
@@ -25,14 +25,9 @@ export function LocalLoginForm() {
 		title: null,
 		message: null,
 	});
-	const [authType, setAuthType] = useState<string | null>(null);
+	const authType = AUTH_TYPE;
 	const router = useRouter();
 	const [{ mutateAsync: login, isPending: isLoggingIn }] = useAtom(loginMutationAtom);
-
-	useEffect(() => {
-		// Get the auth type from centralized config
-		setAuthType(AUTH_TYPE);
-	}, []);
 
 	const handleSubmit = async (e: React.FormEvent) => {
 		e.preventDefault();


### PR DESCRIPTION
## Summary
- Replace `useState` + `useEffect` pattern with a direct constant for `AUTH_TYPE` in `LocalLoginForm`, since it's a build-time constant that never changes
- Remove unused `useEffect` import

## Test plan
- Verify login form still shows "Sign up" link when AUTH_TYPE is LOCAL
- Verify register redirect still works when AUTH_TYPE is not LOCAL

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR simplifies the `LocalLoginForm` component by removing an unnecessary `useState` and `useEffect` pattern used to manage the `AUTH_TYPE` constant. Since `AUTH_TYPE` is a build-time constant that never changes at runtime, it can be used directly without state management. The unused `useEffect` import is also removed as a result of this cleanup.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/app/(home)/login/LocalLoginForm.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/5c2045f4793c2aee54fcded3c2e1cfcb40227d225c79c21aeed0f3384825969a/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=974)
<!-- RECURSEML_SUMMARY:END -->