### PR TITLE
fix: validate redirect URL in auth flow to prevent open redirect

### DIFF
--- a/surfsense_web/lib/auth-utils.ts
+++ b/surfsense_web/lib/auth-utils.ts
@@ -70,7 +70,24 @@ export function getAndClearRedirectPath(): string | null {
 	if (redirectPath) {
 		localStorage.removeItem(REDIRECT_PATH_KEY);
 	}
+	if (redirectPath && !isValidRedirectPath(redirectPath)) {
+		return null;
+	}
 	return redirectPath;
+}
+
+/**
+ * Validates that a redirect path is a safe, relative URL on the same origin.
+ * Rejects absolute URLs, protocol-relative URLs, and scheme injections.
+ */
+function isValidRedirectPath(path: string): boolean {
+	if (!path.startsWith("/") || path.startsWith("//")) return false;
+	try {
+		const url = new URL(path, window.location.origin);
+		return url.origin === window.location.origin;
+	} catch {
+		return false;
+	}
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add `isValidRedirectPath()` validation in `auth-utils.ts` to ensure redirect URLs are relative paths, preventing open redirect attacks
- Validates path starts with `/`, has no protocol/authority, and doesn't use `//` prefix

## Test plan
- Verify normal login redirect flow still works
- Verify malicious URLs like `https://evil.com` or `//evil.com` are rejected

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds validation to the authentication redirect flow to prevent open redirect vulnerabilities. A new `isValidRedirectPath()` function is introduced that validates redirect URLs are safe relative paths on the same origin, rejecting absolute URLs, protocol-relative URLs (like `//evil.com`), and other malicious redirect attempts. The validation is integrated into `getAndClearRedirectPath()` to ensure all redirects go through this security check.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/lib/auth-utils.ts` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/fd0cfb2c4edf7f489a0e8ebec0d5dd0356f3c4da4442ae22e8eedc5b37b5a2aa/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=975)
<!-- RECURSEML_SUMMARY:END -->