### PR TITLE
fix: avoid stale event reference in register page retry action

### DIFF
--- a/surfsense_web/app/(home)/register/page.tsx
+++ b/surfsense_web/app/(home)/register/page.tsx
@@ -43,9 +43,12 @@ export default function RegisterPage() {
 		}
 	}, [router]);
 
-	const handleSubmit = async (e: React.FormEvent) => {
+	const handleSubmit = (e: React.FormEvent) => {
 		e.preventDefault();
+		submitForm();
+	};
 
+	const submitForm = async () => {
 		// Form validation
 		if (password !== confirmPassword) {
 			setError({ title: t("password_mismatch"), message: t("passwords_no_match_desc") });
@@ -140,7 +143,7 @@ export default function RegisterPage() {
 			if (shouldRetry(errorCode)) {
 				toastOptions.action = {
 					label: tCommon("retry"),
-					onClick: () => handleSubmit(e),
+					onClick: () => submitForm(),
 				};
 			}
 


### PR DESCRIPTION
## Summary
- Extract `submitForm()` from `handleSubmit` so the retry toast action calls the current function reference instead of capturing a stale event object

## Test plan
- Verify registration form submit still works
- Verify retry button in error toast triggers a fresh submission

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a bug where the retry button on the registration error toast was capturing a stale event reference. The fix extracts the form submission logic into a separate `submitForm()` function that can be called both from the event handler and from the retry action, ensuring fresh submissions without relying on captured event objects.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/app/(home)/register/page.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/dbd2d81e9eea3f725f6040512146d022ae07894e2200341c87b3af79219f2ebc/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=976)
<!-- RECURSEML_SUMMARY:END -->