### PR TITLE
fix(ui): show skeleton instead of fake star count while loading

### DIFF
--- a/surfsense_web/components/homepage/github-stars-badge.tsx
+++ b/surfsense_web/components/homepage/github-stars-badge.tsx
@@ -4,6 +4,7 @@ import { IconBrandGithub } from "@tabler/icons-react";
 import { motion, useMotionValue, useSpring } from "motion/react";
 import * as React from "react";
 import { cn } from "@/lib/utils";
+import { Skeleton } from "@/components/ui/skeleton";
 
 // ---------------------------------------------------------------------------
 // Per-digit scrolling wheel
@@ -277,12 +278,16 @@ function NavbarGitHubStars({
 			)}
 		>
 			<IconBrandGithub className="h-5 w-5 text-neutral-700 dark:text-neutral-300 shrink-0" />
-			<AnimatedStarCount
-				value={isLoading ? 10000 : stars}
-				itemSize={ITEM_SIZE}
-				isRolling={isLoading}
-				className="text-sm font-semibold tabular-nums text-neutral-700 dark:text-neutral-300 group-hover:text-neutral-900 dark:group-hover:text-neutral-100 transition-colors"
-			/>
+			{isLoading ? (
+				<Skeleton className="h-4 w-10" />
+			) : (
+				<AnimatedStarCount
+					value={stars}
+					itemSize={ITEM_SIZE}
+					isRolling={false}
+					className="text-sm font-semibold tabular-nums text-neutral-700 dark:text-neutral-300 group-hover:text-neutral-900 dark:group-hover:text-neutral-100 transition-colors"
+				/>
+			)}
 		</a>
 	);
 }


### PR DESCRIPTION
## Problem
The GitHub stars badge displays `10000` as a placeholder with a rolling animation while loading. This misleads users into thinking that's the actual star count.

## Solution
Replace the fake number with a `Skeleton` placeholder component during loading. Once the real star count loads, the `AnimatedStarCount` displays with `isRolling={false}`.

## Changes
- `surfsense_web/components/homepage/github-stars-badge.tsx`:
  - Import `Skeleton` from UI components
  - Show `<Skeleton className="h-4 w-10" />` during loading
  - Display actual star count (no rolling) after load

Closes #918

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR improves the GitHub stars badge UX by replacing the misleading placeholder count of `10000` with a `Skeleton` component during the loading state. Once the actual star count is fetched, it displays without the rolling animation to avoid confusion about the real number.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/components/homepage/github-stars-badge.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/8e9f8f937e63479633e7ccf91f5f4b93f3ef167f10b3f4997cd33bef82005bfe/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=977)
<!-- RECURSEML_SUMMARY:END -->