### PR TITLE
fix(auth): remove unnecessary useEffect+useState for AUTH_TYPE constant

### DIFF
--- a/surfsense_web/app/(home)/login/LocalLoginForm.tsx
+++ b/surfsense_web/app/(home)/login/LocalLoginForm.tsx
@@ -5,7 +5,7 @@ import { AnimatePresence, motion } from "motion/react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { loginMutationAtom } from "@/atoms/auth/auth-mutation.atoms";
 import { Spinner } from "@/components/ui/spinner";
 import { getAuthErrorDetails, isNetworkError } from "@/lib/auth-errors";
@@ -25,14 +25,9 @@ export function LocalLoginForm() {
 		title: null,
 		message: null,
 	});
-	const [authType, setAuthType] = useState<string | null>(null);
+	const authType = AUTH_TYPE;
 	const router = useRouter();
 	const [{ mutateAsync: login, isPending: isLoggingIn }] = useAtom(loginMutationAtom);
-
-	useEffect(() => {
-		// Get the auth type from centralized config
-		setAuthType(AUTH_TYPE);
-	}, []);
 
 	const handleSubmit = async (e: React.FormEvent) => {
 		e.preventDefault();


### PR DESCRIPTION
## Problem
`LocalLoginForm.tsx` stores the `AUTH_TYPE` module-level constant into React state via a `useEffect` on mount. Since `AUTH_TYPE` is a static import that never changes at runtime, this pattern is unnecessary and causes an extra render cycle on mount.

## Solution
Replace the `useState` + `useEffect` pattern with a direct constant assignment:

```tsx
// Before
const [authType, setAuthType] = useState<string | null>(null);
useEffect(() => { setAuthType(AUTH_TYPE); }, []);

// After
const authType = AUTH_TYPE;
```

Also removed the now-unused `useEffect` import.

## Changes
- `surfsense_web/app/(home)/login/LocalLoginForm.tsx`:
  - Removed `useEffect` import (no longer needed)
  - Replaced `useState`/`useEffect` with direct constant
  - No behavioral change — `authType` still resolves to the same value

Closes #941

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR simplifies the `LocalLoginForm` component by removing an unnecessary `useEffect` and `useState` pattern that was used to store a static constant (`AUTH_TYPE`) in React state. The constant is now assigned directly, eliminating an extra render cycle on component mount without changing any behavior.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/app/(home)/login/LocalLoginForm.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/5b8bec2e21d4a4da669d3094ac9664bc0d1cec364eefb512b977d0f5d1811d0a/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=978)
<!-- RECURSEML_SUMMARY:END -->