### PR TITLE
fix(ui): add type to useEffect dependency in DocumentTypeChip

### DIFF
--- a/surfsense_web/app/dashboard/[search_space_id]/documents/(manage)/components/DocumentTypeIcon.tsx
+++ b/surfsense_web/app/dashboard/[search_space_id]/documents/(manage)/components/DocumentTypeIcon.tsx
@@ -63,7 +63,7 @@ export function DocumentTypeChip({ type, className }: { type: string; className?
 		checkTruncation();
 		window.addEventListener("resize", checkTruncation);
 		return () => window.removeEventListener("resize", checkTruncation);
-	}, []);
+	}, [type]);
 
 	const chip = (
 		<span


### PR DESCRIPTION
## Problem
The `DocumentTypeChip` component checks if the label text is truncated using a `useEffect` with an empty dependency array `[]`. If the `type` prop changes (which changes the label text), the truncation state won't update until a window resize event fires.

## Solution
Add the `type` prop to the `useEffect` dependency array so the truncation check re-runs whenever the document type (and thus the label) changes.

## Changes
- `surfsense_web/app/dashboard/[search_space_id]/documents/(manage)/components/DocumentTypeIcon.tsx`:
  - Changed `useEffect(..., [])` to `useEffect(..., [type])`

Closes #946

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a bug in the `DocumentTypeChip` component where the text truncation state wouldn't update when the `type` prop changes. The fix adds `type` to the `useEffect` dependency array so the truncation check re-runs whenever the document type (and thus the label text) changes, ensuring the truncation detection stays accurate.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/app/dashboard/[search_space_id]/documents/(manage)/components/DocumentTypeIcon.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/aa3b4ff1983e59f8e24d9d9d9319322d29855d806ca032442ff51a50f80550ba/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=979)
<!-- RECURSEML_SUMMARY:END -->