### PR TITLE
fix(onboarding): clean up setTimeout timers on unmount

### DIFF
--- a/surfsense_web/components/onboarding-tour.tsx
+++ b/surfsense_web/components/onboarding-tour.tsx
@@ -466,8 +466,15 @@ export function OnboardingTour() {
 	}, []);
 
 	// Find and track target element with retry logic
+	const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 	const updateTarget = useCallback(() => {
 		if (!currentStep) return;
+
+		// Clear any pending retry timer
+		if (retryTimerRef.current !== null) {
+			clearTimeout(retryTimerRef.current);
+			retryTimerRef.current = null;
+		}
 
 		const el = document.querySelector(currentStep.target);
 		if (el) {
@@ -477,7 +484,8 @@ export function OnboardingTour() {
 			retryCountRef.current = 0;
 		} else if (retryCountRef.current < maxRetries) {
 			retryCountRef.current++;
-			setTimeout(() => {
+			retryTimerRef.current = setTimeout(() => {
+				retryTimerRef.current = null;
 				const retryEl = document.querySelector(currentStep.target);
 				if (retryEl) {
 					setTargetEl(retryEl);
@@ -556,7 +564,10 @@ export function OnboardingTour() {
 		}
 
 		// User is new and hasn't seen tour - wait for DOM elements and start tour
+		let cancelled = false;
 		const checkAndStartTour = () => {
+			if (cancelled) return;
+
 			// Check if all required elements exist
 			const connectorEl = document.querySelector(TOUR_STEPS[0].target);
 			const documentsEl = document.querySelector(TOUR_STEPS[1].target);
@@ -578,7 +589,10 @@ export function OnboardingTour() {
 
 		// Start checking after initial delay
 		const timer = setTimeout(checkAndStartTour, 500);
-		return () => clearTimeout(timer);
+		return () => {
+			cancelled = true;
+			clearTimeout(timer);
+		};
 	}, [mounted, user?.id, searchSpaceId, pathname, threadsData, documentTypeCounts, connectors]);
 
 	// Update position on resize/scroll


### PR DESCRIPTION
## Problem
The onboarding tour component has two `setTimeout` patterns that can fire after component unmount, potentially causing state updates on unmounted components:

1. **`checkAndStartTour` recursion** (line ~575): Uses recursive `setTimeout` to retry finding target DOM elements, but only the initial `setTimeout` is cleaned up in the effect's teardown. Inner retries keep firing after unmount.

2. **`updateTarget` retry** (line ~480): Schedules a retry `setTimeout` that is never tracked or cancelled.

## Solution

1. Added a `cancelled` flag that's set to `true` in the cleanup function. The recursive `checkAndStartTour` checks this flag before executing, preventing state updates after unmount.

2. Added a `retryTimerRef` to track the retry timer in `updateTarget`. The timer is cleared before scheduling a new one, preventing stale callbacks.

## Changes
- `surfsense_web/components/onboarding-tour.tsx`:
  - Added `cancelled` guard to `checkAndStartTour` recursion
  - Added `retryTimerRef` to track and clean up `updateTarget` retry timer

Closes #950

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes memory leaks in the onboarding tour component by properly cleaning up `setTimeout` timers when the component unmounts. It introduces a `cancelled` flag to prevent recursive `checkAndStartTour` calls from executing after unmount, and adds a `retryTimerRef` to track and clear retry timers in the `updateTarget` function. These changes prevent state updates on unmounted components.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/components/onboarding-tour.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/c584b264c6aa71f15dfe367e0d07eec7bf6367779757f662ad4885f05e8361b1/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=980)
<!-- RECURSEML_SUMMARY:END -->