### PR TITLE
fix: avoid stale React event in register toast retry

### DIFF
--- a/surfsense_web/app/(home)/register/page.tsx
+++ b/surfsense_web/app/(home)/register/page.tsx
@@ -43,8 +43,7 @@ export default function RegisterPage() {
 		}
 	}, [router]);
 
-	const handleSubmit = async (e: React.FormEvent) => {
-		e.preventDefault();
+	const submitForm = async () => {
 
 		// Form validation
 		if (password !== confirmPassword) {
@@ -140,12 +139,17 @@ export default function RegisterPage() {
 			if (shouldRetry(errorCode)) {
 				toastOptions.action = {
 					label: tCommon("retry"),
-					onClick: () => handleSubmit(e),
+					onClick: () => submitForm(),
 				};
 			}
 
 			toast.error(errorDetails.title, toastOptions);
 		}
+	};
+
+	const handleSubmit = (e: React.FormEvent) => {
+		e.preventDefault();
+		submitForm();
 	};
 
 	return (


### PR DESCRIPTION
Fixes #945

The error toast on the register page has a retry button that was
calling handleSubmit(e), closing over the original form event. React
recycles synthetic events, so that reference was stale by the time
anyone clicked Retry.

This moves the submission logic into a standalone submitForm()
function. handleSubmit is now just a thin wrapper that calls
preventDefault and delegates to submitForm(). The retry action calls
submitForm() directly with no stale event reference.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a bug where the retry button in the register page error toast was referencing a stale React synthetic event. The form submission logic has been extracted into a standalone `submitForm()` function that the retry action can call directly, while `handleSubmit()` now serves as a thin wrapper that handles `preventDefault()` before delegating to `submitForm()`.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/app/(home)/register/page.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/3a3c7d3709c1afba6112dee9fc47b954d59dcceb4b004e55326386789b398a97/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=982)
<!-- RECURSEML_SUMMARY:END -->