### PR TITLE
fix: replace router.push with Link for static navigation in UserDropdown

### DIFF
--- a/surfsense_web/components/UserDropdown.tsx
+++ b/surfsense_web/components/UserDropdown.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { BadgeCheck, LogOut } from "lucide-react";
-import { useRouter } from "next/navigation";
+import Link from "next/link";
 import { useState } from "react";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
@@ -27,7 +27,6 @@ export function UserDropdown({
 		avatar: string;
 	};
 }) {
-	const router = useRouter();
 	const [isLoggingOut, setIsLoggingOut] = useState(false);
 
 	const handleLogout = async () => {
@@ -75,12 +74,11 @@ export function UserDropdown({
 				</DropdownMenuLabel>
 				<DropdownMenuSeparator />
 				<DropdownMenuGroup>
-					<DropdownMenuItem
-						onClick={() => router.push(`/dashboard/api-key`)}
-						className="text-xs md:text-sm"
-					>
-						<BadgeCheck className="mr-2 h-3.5 w-3.5 md:h-4 md:w-4" />
-						API Key
+					<DropdownMenuItem asChild className="text-xs md:text-sm">
+						<Link href="/dashboard/api-key">
+							<BadgeCheck className="mr-2 h-3.5 w-3.5 md:h-4 md:w-4" />
+							API Key
+						</Link>
 					</DropdownMenuItem>
 				</DropdownMenuGroup>
 				<DropdownMenuSeparator />


### PR DESCRIPTION
## Summary
- Replace `onClick={() => router.push(...)}` with `<Link>` + `asChild` for the API Key menu item
- Enables route prefetching and follows Next.js best practices
- Remove unused `useRouter` import

## Test plan
- Verify API Key menu item still navigates correctly
- Verify dropdown closes after navigation

Closes #937

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR refactors the UserDropdown component to use Next.js `Link` component with `asChild` instead of `router.push()` for navigating to the API Key page. This change enables route prefetching, follows Next.js best practices for static navigation, and removes the now-unused `useRouter` import.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/components/UserDropdown.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/4ad51c8556a2d9e370b707d05418628e45f92e253664d9004927118a5386ae0c/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=983)
<!-- RECURSEML_SUMMARY:END -->