### PR TITLE
fix: remove unnecessary "use client" from pure presentational components

### DIFF
--- a/surfsense_web/app/docs/sidebar-separator.tsx
+++ b/surfsense_web/app/docs/sidebar-separator.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import type { Separator } from "fumadocs-core/page-tree";
 
 export function SidebarSeparator({ item }: { item: Separator }) {

--- a/surfsense_web/components/Logo.tsx
+++ b/surfsense_web/components/Logo.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import Image from "next/image";
 import Link from "next/link";
 import { cn } from "@/lib/utils";

--- a/surfsense_web/components/announcements/AnnouncementsEmptyState.tsx
+++ b/surfsense_web/components/announcements/AnnouncementsEmptyState.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { BellOff } from "lucide-react";
 
 export function AnnouncementsEmptyState() {

--- a/surfsense_web/components/public-chat-snapshots/public-chat-snapshots-empty-state.tsx
+++ b/surfsense_web/components/public-chat-snapshots/public-chat-snapshots-empty-state.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { Link2Off } from "lucide-react";
 
 interface PublicChatSnapshotsEmptyStateProps {


### PR DESCRIPTION
## Summary
- Remove `"use client"` directive from 4 components that are purely presentational:
  - `AnnouncementsEmptyState.tsx`
  - `sidebar-separator.tsx`
  - `public-chat-snapshots-empty-state.tsx`
  - `Logo.tsx`
- None of these use hooks, event handlers, or browser APIs

## Test plan
- Verify each component renders correctly
- Verify no client-only API errors introduced

Closes #935

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR optimizes the Next.js application by removing unnecessary `"use client"` directives from four purely presentational components (`Logo.tsx`, `sidebar-separator.tsx`, `AnnouncementsEmptyState.tsx`, and `public-chat-snapshots-empty-state.tsx`) that don't require client-side interactivity. This allows these components to be rendered on the server, improving performance and reducing the client-side JavaScript bundle size.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/components/Logo.tsx` |
| 2 | `surfsense_web/app/docs/sidebar-separator.tsx` |
| 3 | `surfsense_web/components/announcements/AnnouncementsEmptyState.tsx` |
| 4 | `surfsense_web/components/public-chat-snapshots/public-chat-snapshots-empty-state.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/ec4afce53d4213e0c860cfcaae0fb80811fabf3caf15d2c40d8a54d89cbb013e/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=984)
<!-- RECURSEML_SUMMARY:END -->