### PR TITLE
fix: add error toast to invite creation failure

### DIFF
--- a/surfsense_web/app/dashboard/[search_space_id]/team/team-content.tsx
+++ b/surfsense_web/app/dashboard/[search_space_id]/team/team-content.tsx
@@ -595,6 +595,7 @@ function CreateInviteDialog({
 			});
 		} catch (error) {
 			console.error("Failed to create invite:", error);
+			toast.error("Failed to create invite. Please try again.");
 		} finally {
 			setCreating(false);
 		}


### PR DESCRIPTION
## Summary

Added a toast notification when invite creation fails in the team management page.

## Why this matters

When `onCreateInvite` threw an error, the only feedback was `console.error` in the browser devtools. Users had no visible indication that the invite failed.

## Changes

- `surfsense_web/app/dashboard/[search_space_id]/team/team-content.tsx` line 598: Added `toast.error("Failed to create invite. Please try again.")` in the catch block. The `toast` import from `sonner` was already present on line 25 (used for copy-to-clipboard toasts on lines 618 and 792).

## Testing

One line addition using the existing toast import. Matches the project's existing error handling pattern.

Fixes #920

This contribution was developed with AI assistance (Claude Code).

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds user-facing error feedback when team invite creation fails by displaying a toast notification. Previously, failures only logged to the console without any visible indication to the user. The change leverages the existing `toast` import from `sonner` that's already used elsewhere in the component.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/app/dashboard/[search_space_id]/team/team-content.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyzing latest changes...](https://img.shields.io/badge/Analyzing%20latest%20changes...-lightgray?style=plastic)](https://github.com/MODSetter/SurfSense/pull/992)
<!-- RECURSEML_SUMMARY:END -->