### PR TITLE
feat: implement session storage for tabs state management and optimiz…

### DIFF
--- a/surfsense_web/atoms/tabs/tabs.atom.ts
+++ b/surfsense_web/atoms/tabs/tabs.atom.ts
@@ -1,4 +1,5 @@
 import { atom } from "jotai";
+import { atomWithStorage, createJSONStorage } from "jotai/utils";
 
 export type TabType = "chat" | "document";
 
@@ -32,7 +33,16 @@ const initialState: TabsState = {
 	activeTabId: "chat-new",
 };
 
-export const tabsStateAtom = atom<TabsState>(initialState);
+const sessionStorageAdapter = createJSONStorage<TabsState>(
+	() => (typeof window !== "undefined" ? sessionStorage : undefined) as Storage
+);
+
+export const tabsStateAtom = atomWithStorage<TabsState>(
+	"surfsense:tabs",
+	initialState,
+	sessionStorageAdapter,
+	{ getOnInit: true },
+);
 
 export const tabsAtom = atom((get) => get(tabsStateAtom).tabs);
 export const activeTabIdAtom = atom((get) => get(tabsStateAtom).activeTabId);

--- a/surfsense_web/components/layout/providers/LayoutDataProvider.tsx
+++ b/surfsense_web/components/layout/providers/LayoutDataProvider.tsx
@@ -268,9 +268,14 @@ export function LayoutDataProvider({ searchSpaceId, children }: LayoutDataProvid
 	}, [pendingNewChat, params?.chat_id, router, searchSpaceId, resetCurrentThread]);
 
 	// Reset transient slide-out panels and tabs when switching search spaces.
+	// Use a ref to skip the initial mount — only reset when the space actually changes.
+	const prevSearchSpaceIdRef = useRef(searchSpaceId);
 	useEffect(() => {
-		setActiveSlideoutPanel(null);
-		resetTabs();
+		if (prevSearchSpaceIdRef.current !== searchSpaceId) {
+			prevSearchSpaceIdRef.current = searchSpaceId;
+			setActiveSlideoutPanel(null);
+			resetTabs();
+		}
 	}, [searchSpaceId, resetTabs]);
 
 	const searchSpaces: SearchSpace[] = useMemo(() => {


### PR DESCRIPTION
…e tab reset logic on search space change

<!--- Summarize your pull request in a few sentences -->

## Description
<!--- Clearly describe what has changed in this pull request -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If this PR relates to an open issue, please link to the issue here: FIX #123 -->
FIX #


## Screenshots
<!-- If applicable, add screenshots or images to demonstrate the changes visually -->

## API Changes
<!-- Document any API changes if applicable -->
- [ ] This PR includes API changes

## Change Type
<!--- Indicate what kind(s) of changes this PR includes: -->
- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Dependency/Build system
- [ ] Breaking change
- [ ] Other (specify):

## Testing Performed
<!--- Briefly describe how you have tested these changes and what verification was performed -->
- [ ] Tested locally
- [ ] Manual/QA verification

## Checklist
<!--- Please confirm the following by marking with an 'x' as appropriate -->
- [ ] Follows project coding standards and conventions
- [ ] Documentation updated as needed
- [ ] Dependencies updated as needed
- [ ] No lint/build errors or new warnings
- [ ] All relevant tests are passing

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR implements session storage persistence for tabs state management using Jotai's `atomWithStorage` utility, allowing tabs to survive page refreshes. It also optimizes the tab reset logic to prevent unnecessary resets on component mount by using a ref to track when the search space ID actually changes, ensuring tabs are only reset when users switch between different search spaces rather than on every render.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/atoms/tabs/tabs.atom.ts` |
| 2 | `surfsense_web/components/layout/providers/LayoutDataProvider.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/e91f84820e709e8164ab2f33f181757326ddf66b06247dcbaef240913c73ed3a/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=994)
<!-- RECURSEML_SUMMARY:END -->