### PR TITLE
fix: add error toast to invite creation failure

### DIFF
--- a/surfsense_web/app/dashboard/[search_space_id]/team/team-content.tsx
+++ b/surfsense_web/app/dashboard/[search_space_id]/team/team-content.tsx
@@ -595,6 +595,7 @@ function CreateInviteDialog({
 			});
 		} catch (error) {
 			console.error("Failed to create invite:", error);
+			toast.error("Failed to create invite. Please try again.");
 		} finally {
 			setCreating(false);
 		}


### PR DESCRIPTION
## Summary
- Adds error toast notification when invite creation fails in the roles manager
- Replaces silent failure with user-visible feedback

Re-submitted targeting `dev` branch per maintainer request on #992.

## Test plan
- [ ] Trigger invite creation failure and verify error toast appears

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds user-facing error feedback by displaying a toast notification when invite creation fails in the team roles manager. Previously, failures were only logged to the console without notifying the user.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/app/dashboard/[search_space_id]/team/team-content.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/81ad464c3a59aee5c929ba7ad7843d852adaf2710aea3a11ad2a6cd4b03857a0/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=1001)
<!-- RECURSEML_SUMMARY:END -->