### PR TITLE
refactor: use functional state updates in hero carousel callbacks

### DIFF
--- a/surfsense_web/components/ui/hero-carousel.tsx
+++ b/surfsense_web/components/ui/hero-carousel.tsx
@@ -145,21 +145,26 @@ function HeroCarousel() {
 	const [isGifExpanded, setIsGifExpanded] = useState(false);
 	const directionRef = useRef<"forward" | "backward">("forward");
 
-	const goTo = useCallback(
-		(newIndex: number) => {
-			directionRef.current = newIndex >= activeIndex ? "forward" : "backward";
-			setActiveIndex(newIndex);
-		},
-		[activeIndex]
-	);
+	const goTo = useCallback((newIndex: number) => {
+		setActiveIndex((prev) => {
+			directionRef.current = newIndex >= prev ? "forward" : "backward";
+			return newIndex;
+		});
+	}, []);
 
 	const goToPrev = useCallback(() => {
-		goTo(activeIndex <= 0 ? carouselItems.length - 1 : activeIndex - 1);
-	}, [activeIndex, goTo]);
+		setActiveIndex((prev) => {
+			directionRef.current = "backward";
+			return prev <= 0 ? carouselItems.length - 1 : prev - 1;
+		});
+	}, []);
 
 	const goToNext = useCallback(() => {
-		goTo(activeIndex >= carouselItems.length - 1 ? 0 : activeIndex + 1);
-	}, [activeIndex, goTo]);
+		setActiveIndex((prev) => {
+			directionRef.current = "forward";
+			return prev >= carouselItems.length - 1 ? 0 : prev + 1;
+		});
+	}, []);
 
 	const item = carouselItems[activeIndex];
 	const isForward = directionRef.current === "forward";


### PR DESCRIPTION
## Summary

Refactored carousel navigation callbacks to use functional state updates, making them stable references that don't change on every index update.

## Why this matters

`goTo`, `goToPrev`, and `goToNext` had `activeIndex` in their dependency arrays. Every slide change recreated these callbacks, causing unnecessary re-renders downstream. Functional updates read the previous state directly, so the callbacks become stable.

## Changes

- `surfsense_web/components/ui/hero-carousel.tsx`: Converted `goTo`, `goToPrev`, `goToNext` to use `setActiveIndex((prev) => ...)`. Removed `activeIndex` from the autoplay `useEffect` dependency array (the `setTimeout` callback already used a functional update). All three `useCallback` hooks now have empty dependency arrays.

## Testing

Carousel behavior is identical - same navigation, same animation direction logic. The direction ref is set inside the functional updater before returning the new index.

Fixes #951

Retargeted to `dev` per @MODSetter's request.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR refactors the hero carousel navigation callbacks (`goTo`, `goToPrev`, `goToNext`) to use functional state updates instead of depending on `activeIndex`. This optimization makes the callback references stable, preventing unnecessary re-renders in child components whenever the slide index changes. The autoplay effect dependency array is also cleaned up by removing `activeIndex` since the timeout callback already uses functional updates.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/components/ui/hero-carousel.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/417ca19fccc98c9aac7299bb043626778a02624b24e26498c1cd0c6bd35aedcf/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=1021)
<!-- RECURSEML_SUMMARY:END -->