### PR TITLE
Add aria-label and aria-pressed to web search toggle

### DIFF
--- a/surfsense_web/components/assistant-ui/thread.tsx
+++ b/surfsense_web/components/assistant-ui/thread.tsx
@@ -944,6 +944,8 @@ const ComposerAction: FC<ComposerActionProps> = ({ isBlockedByOtherUser = false 
 				{hasWebSearchTool && (
 					<button
 						type="button"
+						aria-label={isWebSearchEnabled ? "Disable web search" : "Enable web search"}
+						aria-pressed={isWebSearchEnabled}
 						onClick={() => toggleTool("web_search")}
 						className={cn(
 							"rounded-full transition-all flex items-center gap-1 px-2 py-1 border h-8 select-none",


### PR DESCRIPTION
## Description

Adds `aria-label` and `aria-pressed` to the web search toggle button in the chat composer so it has an accessible name in both states and exposes its toggle state to assistive technology.

## Motivation and Context

Fixes #908

## API Changes

- [ ] This PR includes API changes

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Dependency/Build system
- [ ] Breaking change
- [ ] Other (specify):

## Testing Performed

- [x] Tested locally
- [ ] Manual/QA verification

Verified with:

```bash
cd surfsense_web && pnpm exec biome check components/assistant-ui/thread.tsx
```
## Checklist
<!--- Please confirm the following by marking with an 'x' as appropriate -->
- [x] Follows project coding standards and conventions
- [ ] Documentation updated as needed
- [ ] Dependencies updated as needed
- [ ] No lint/build errors or new warnings
- [ ] All relevant tests are passing

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds accessibility attributes (`aria-label` and `aria-pressed`) to the web search toggle button in the chat composer. The `aria-label` provides a descriptive name that changes based on the current state (enabled/disabled), and `aria-pressed` exposes the toggle state to assistive technologies like screen readers. This fixes issue #908 by ensuring the button has a proper accessible name and state information.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/components/assistant-ui/thread.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/30d1366562511c884cea0ad6f6e74af1c40bb8892b37c98abe26153d477eb9ec/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=1026)
<!-- RECURSEML_SUMMARY:END -->