### PR TITLE
feat: add loading states for roles and invites in TeamContent component

### DIFF
--- a/surfsense_web/app/dashboard/[search_space_id]/team/team-content.tsx
+++ b/surfsense_web/app/dashboard/[search_space_id]/team/team-content.tsx
@@ -188,13 +188,13 @@ export function TeamContent({ searchSpaceId }: TeamContentProps) {
 		[deleteMember, searchSpaceId]
 	);
 
-	const { data: roles = [] } = useQuery({
+	const { data: roles = [], isLoading: rolesLoading } = useQuery({
 		queryKey: cacheKeys.roles.all(searchSpaceId.toString()),
 		queryFn: () => rolesApiService.getRoles({ search_space_id: searchSpaceId }),
 		enabled: !!searchSpaceId,
 	});
 
-	const { data: invites = [] } = useQuery({
+	const { data: invites = [], isLoading: invitesLoading } = useQuery({
 		queryKey: cacheKeys.invites.all(searchSpaceId.toString()),
 		queryFn: () => invitesApiService.getInvites({ search_space_id: searchSpaceId }),
 		staleTime: 5 * 60 * 1000,
@@ -294,15 +294,23 @@ export function TeamContent({ searchSpaceId }: TeamContentProps) {
 	return (
 		<div className="space-y-4 md:space-y-6">
 			<div className="flex items-center gap-2 flex-wrap">
-				{canInvite && (
-					<CreateInviteDialog
-						roles={roles}
-						onCreateInvite={handleCreateInvite}
-						searchSpaceId={searchSpaceId}
-					/>
+				{rolesLoading ? (
+					<Skeleton className="h-9 w-32 rounded-md" />
+				) : (
+					canInvite && (
+						<CreateInviteDialog
+							roles={roles}
+							onCreateInvite={handleCreateInvite}
+							searchSpaceId={searchSpaceId}
+						/>
+					)
 				)}
-				{canInvite && activeInvites.length > 0 && (
-					<AllInvitesDialog invites={activeInvites} onRevokeInvite={handleRevokeInvite} />
+				{invitesLoading ? (
+					<Skeleton className="h-9 w-32 rounded-md" />
+				) : (
+					canInvite && activeInvites.length > 0 && (
+						<AllInvitesDialog invites={activeInvites} onRevokeInvite={handleRevokeInvite} />
+					)
 				)}
 				<p className="text-xs md:text-sm text-muted-foreground whitespace-nowrap">
 					{members.length} {members.length === 1 ? "member" : "members"}


### PR DESCRIPTION
<!--- Summarize your pull request in a few sentences -->

## Description
<!--- Clearly describe what has changed in this pull request -->
Changes Made:
- Updated role query (line 191):
 Added `[isLoading: rolesLoading]` destructuring to the roles `useQuery` hook
- Updated invites query (line 197): Added `[isLoading: invitesLoading]` destructuring to the invites `useQuery` hook
- Added skeleton placeholders (lines 289-305):
 Wrapped "Invite members" button with conditional rendering showing a skeleton while `rolesLoading` is true
Wrapped "Active invites" button with conditional rendering showing a skeleton while [invitesLoading] is true
Both show skeleton loaders (h-9 w-32 rounded-md) that match the button dimensions

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If this PR relates to an open issue, please link to the issue here: FIX #123 -->
FIX #910 


## Screenshots
<!-- If applicable, add screenshots or images to demonstrate the changes visually -->

## API Changes
<!-- Document any API changes if applicable -->
- [ ] This PR includes API changes

## Change Type
<!--- Indicate what kind(s) of changes this PR includes: -->
- [ ] Bug fix
- [ ] New feature
- [X] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Dependency/Build system
- [ ] Breaking change
- [ ] Other (specify):

## Testing Performed
<!--- Briefly describe how you have tested these changes and what verification was performed -->
- [X] Tested locally
- [ ] Manual/QA verification

## Checklist
<!--- Please confirm the following by marking with an 'x' as appropriate -->
- [X] Follows project coding standards and conventions
- [ ] Documentation updated as needed
- [ ] Dependencies updated as needed
- [ ] No lint/build errors or new warnings
- [ ] All relevant tests are passing

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR enhances the user experience of the TeamContent component by adding loading states for roles and invites data fetching. When the roles or invites queries are loading, skeleton placeholders are displayed instead of the "Invite members" and "Active invites" buttons, preventing layout shifts and providing visual feedback to users that data is being loaded.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/app/dashboard/[search_space_id]/team/team-content.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/03aa6564433f00803fe8a0803f38abc9f3482b219e258263b833c2a33664119f/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=1028)
<!-- RECURSEML_SUMMARY:END -->