### PR TITLE
fix : derive has changes and use functional setstate

### DIFF
--- a/surfsense_web/components/assistant-ui/connector-popup/connect-forms/components/mcp-connect-form.tsx
+++ b/surfsense_web/components/assistant-ui/connector-popup/connect-forms/components/mcp-connect-form.tsx
@@ -243,7 +243,7 @@ export const MCPConnectForm: FC<ConnectFormProps> = ({ onSubmit, isSubmitting })
 										onClick={(e) => {
 											e.preventDefault();
 											e.stopPropagation();
-											setShowDetails(!showDetails);
+											setShowDetails(prev => !prev);
 										}}
 									>
 										{showDetails ? (

--- a/surfsense_web/components/assistant-ui/connector-popup/connector-configs/components/composio-drive-config.tsx
+++ b/surfsense_web/components/assistant-ui/connector-popup/connector-configs/components/composio-drive-config.tsx
@@ -250,7 +250,7 @@ export const ComposioDriveConfig: FC<ConnectorConfigProps> = ({ connector, onCon
 					<div className="space-y-2">
 						<button
 							type="button"
-							onClick={() => setIsFolderTreeOpen(!isFolderTreeOpen)}
+							onClick={() => setIsFolderTreeOpen(prev => !prev)}
 							className="flex items-center gap-2 text-xs sm:text-sm text-muted-foreground hover:text-foreground transition-colors w-fit"
 						>
 							Change Selection

--- a/surfsense_web/components/assistant-ui/connector-popup/connector-configs/components/mcp-config.tsx
+++ b/surfsense_web/components/assistant-ui/connector-popup/connector-configs/components/mcp-config.tsx
@@ -248,7 +248,7 @@ export const MCPConfig: FC<MCPConfigProps> = ({ connector, onConfigChange, onNam
 										onClick={(e) => {
 											e.preventDefault();
 											e.stopPropagation();
-											setShowDetails(!showDetails);
+											setShowDetails(prev => !prev);
 										}}
 									>
 										{showDetails ? (

--- a/surfsense_web/components/assistant-ui/connector-popup/connector-configs/components/onedrive-config.tsx
+++ b/surfsense_web/components/assistant-ui/connector-popup/connector-configs/components/onedrive-config.tsx
@@ -221,7 +221,7 @@ export const OneDriveConfig: FC<ConnectorConfigProps> = ({ connector, onConfigCh
 					<div className="space-y-2">
 						<button
 							type="button"
-							onClick={() => setIsFolderTreeOpen(!isFolderTreeOpen)}
+							onClick={() => setIsFolderTreeOpen(prev => !prev)}
 							className="flex items-center gap-2 text-xs sm:text-sm text-muted-foreground hover:text-foreground transition-colors w-fit"
 						>
 							Change Selection

--- a/surfsense_web/components/assistant-ui/connector-popup/connector-configs/components/webcrawler-config.tsx
+++ b/surfsense_web/components/assistant-ui/connector-popup/connector-configs/components/webcrawler-config.tsx
@@ -86,7 +86,7 @@ export const WebcrawlerConfig: FC<ConnectorConfigProps> = ({ connector, onConfig
 						type="button"
 						variant="ghost"
 						size="sm"
-						onClick={() => setShowApiKey(!showApiKey)}
+						onClick={() => setShowApiKey(prev => !prev)}
 						className="absolute right-1 top-1/2 -translate-y-1/2 h-7 px-2 text-xs text-muted-foreground hover:text-foreground"
 					>
 						{showApiKey ? "Hide" : "Show"}

--- a/surfsense_web/components/assistant-ui/thinking-steps.tsx
+++ b/surfsense_web/components/assistant-ui/thinking-steps.tsx
@@ -65,7 +65,7 @@ export const ThinkingStepsDisplay: FC<{ steps: ThinkingStep[]; isThreadRunning?:
 			<div className="rounded-lg">
 				<button
 					type="button"
-					onClick={() => setIsOpen(!isOpen)}
+					onClick={() => setIsOpen(prev => !prev)}
 					className={cn(
 						"flex w-full items-center gap-1.5 text-left text-sm transition-colors",
 						"text-muted-foreground hover:text-foreground"

--- a/surfsense_web/components/assistant-ui/tool-fallback.tsx
+++ b/surfsense_web/components/assistant-ui/tool-fallback.tsx
@@ -45,7 +45,7 @@ export const ToolFallback: ToolCallMessagePartComponent = ({
 		>
 			<button
 				type="button"
-				onClick={() => setIsExpanded(!isExpanded)}
+			onClick={() => setIsExpanded(prev => !prev)}
 				className="flex w-full items-center gap-3 px-5 py-4 text-left transition-colors hover:bg-muted/50 focus:outline-none focus-visible:outline-none"
 			>
 				<div

--- a/surfsense_web/components/chat-comments/comment-thread/comment-thread.tsx
+++ b/surfsense_web/components/chat-comments/comment-thread/comment-thread.tsx
@@ -93,7 +93,7 @@ export function CommentThread({
 								variant="ghost"
 								size="sm"
 								className="h-6 px-2 text-xs text-muted-foreground hover:text-foreground"
-								onClick={() => setIsRepliesExpanded(!isRepliesExpanded)}
+								onClick={() => setIsRepliesExpanded(prev => !prev)}
 							>
 								{isRepliesExpanded ? (
 									<ChevronDown className="mr-1 size-3" />

--- a/surfsense_web/components/homepage/navbar.tsx
+++ b/surfsense_web/components/homepage/navbar.tsx
@@ -162,7 +162,7 @@ const MobileNav = ({ navItems, isScrolled, scrolledBgClassName }: any) => {
 				</Link>
 				<button
 					type="button"
-					onClick={() => setOpen(!open)}
+					onClick={() => setOpen(prev => !prev)}
 					className="relative z-50 flex items-center justify-center p-2 -mr-2 rounded-lg hover:bg-gray-100 dark:hover:bg-neutral-800 transition-colors touch-manipulation"
 					aria-label={open ? "Close menu" : "Open menu"}
 				>

--- a/surfsense_web/components/layout/hooks/useSidebarState.ts
+++ b/surfsense_web/components/layout/hooks/useSidebarState.ts
@@ -37,8 +37,14 @@ export function useSidebarState(defaultCollapsed = false): UseSidebarStateReturn
 	}, []);
 
 	const toggleCollapsed = useCallback(() => {
-		setIsCollapsed(!isCollapsed);
-	}, [isCollapsed, setIsCollapsed]);
+		setIsCollapsedState(prev => {
+			const next = !prev;
+			try {
+				document.cookie = `${SIDEBAR_COOKIE_NAME}=${next}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`;
+			} catch {}
+			return next;
+		});
+	}, []);
 
 	// Keyboard shortcut: Cmd/Ctrl + \
 	useEffect(() => {

--- a/surfsense_web/components/onboarding-tour.tsx
+++ b/surfsense_web/components/onboarding-tour.tsx
@@ -666,27 +666,33 @@ export function OnboardingTour() {
 	}, [targetEl, isActive]);
 
 	const handleNext = useCallback(() => {
-		if (stepIndex < TOUR_STEPS.length - 1) {
-			retryCountRef.current = 0;
-			setShouldAnimate(true);
-			setStepIndex(stepIndex + 1);
-		} else {
-			// Tour completed - save to localStorage
-			if (user?.id) {
-				const tourKey = `surfsense-tour-${user.id}`;
-				localStorage.setItem(tourKey, "true");
+		retryCountRef.current = 0;
+		setShouldAnimate(true);
+		setStepIndex(prev => {
+			if (prev < TOUR_STEPS.length - 1) {
+				return prev + 1;
+			} else {
+				// Tour completed - save to localStorage
+				if (user?.id) {
+					const tourKey = `surfsense-tour-${user.id}`;
+					localStorage.setItem(tourKey, "true");
+				}
+				setIsActive(false);
+				return prev;
 			}
-			setIsActive(false);
-		}
-	}, [stepIndex, user?.id]);
+		});
+	}, [user?.id]);
 
 	const handlePrev = useCallback(() => {
-		if (stepIndex > 0) {
-			retryCountRef.current = 0;
-			setShouldAnimate(true);
-			setStepIndex(stepIndex - 1);
-		}
-	}, [stepIndex]);
+		retryCountRef.current = 0;
+		setShouldAnimate(true);
+		setStepIndex(prev => {
+			if (prev > 0) {
+				return prev - 1;
+			}
+			return prev;
+		});
+	}, []);
 
 	const handleSkip = useCallback(() => {
 		// Tour skipped - save to localStorage

--- a/surfsense_web/components/settings/general-settings-manager.tsx
+++ b/surfsense_web/components/settings/general-settings-manager.tsx
@@ -40,26 +40,17 @@ export function GeneralSettingsManager({ searchSpaceId }: GeneralSettingsManager
 	const [name, setName] = useState("");
 	const [description, setDescription] = useState("");
 	const [saving, setSaving] = useState(false);
-	const [hasChanges, setHasChanges] = useState(false);
 
 	// Initialize state from fetched search space
 	useEffect(() => {
 		if (searchSpace) {
 			setName(searchSpace.name || "");
 			setDescription(searchSpace.description || "");
-			setHasChanges(false);
 		}
 	}, [searchSpace]);
 
-	// Track changes
-	useEffect(() => {
-		if (searchSpace) {
-			const currentName = searchSpace.name || "";
-			const currentDescription = searchSpace.description || "";
-			const changed = currentName !== name || currentDescription !== description;
-			setHasChanges(changed);
-		}
-	}, [searchSpace, name, description]);
+	// Derive hasChanges during render
+	const hasChanges = !!searchSpace && ((searchSpace.name || "") !== name || (searchSpace.description || "") !== description);
 
 	const handleSave = async () => {
 		try {
@@ -73,7 +64,6 @@ export function GeneralSettingsManager({ searchSpaceId }: GeneralSettingsManager
 				},
 			});
 
-			setHasChanges(false);
 			await fetchSearchSpace();
 		} catch (error: any) {
 			console.error("Error saving search space details:", error);

--- a/surfsense_web/components/settings/prompt-config-manager.tsx
+++ b/surfsense_web/components/settings/prompt-config-manager.tsx
@@ -32,24 +32,16 @@ export function PromptConfigManager({ searchSpaceId }: PromptConfigManagerProps)
 
 	const [customInstructions, setCustomInstructions] = useState("");
 	const [saving, setSaving] = useState(false);
-	const [hasChanges, setHasChanges] = useState(false);
 
 	// Initialize state from fetched search space
 	useEffect(() => {
 		if (searchSpace) {
 			setCustomInstructions(searchSpace.qna_custom_instructions || "");
-			setHasChanges(false);
 		}
 	}, [searchSpace]);
 
-	// Track changes
-	useEffect(() => {
-		if (searchSpace) {
-			const currentCustom = searchSpace.qna_custom_instructions || "";
-			const changed = currentCustom !== customInstructions;
-			setHasChanges(changed);
-		}
-	}, [searchSpace, customInstructions]);
+	// Derive hasChanges during render
+	const hasChanges = !!searchSpace && (searchSpace.qna_custom_instructions || "") !== customInstructions;
 
 	const handleSave = async () => {
 		try {
@@ -74,7 +66,7 @@ export function PromptConfigManager({ searchSpaceId }: PromptConfigManagerProps)
 			}
 
 			toast.success("System instructions saved successfully");
-			setHasChanges(false);
+
 			await fetchSearchSpace();
 		} catch (error: any) {
 			console.error("Error saving system instructions:", error);


### PR DESCRIPTION
<!--- Summarize your pull request in a few sentences -->

## Description
<!--- Clearly describe what has changed in this pull request -->
This PR addresses multiple React state management issues by converting direct state updates to functional setState calls (using prev => !prev pattern for toggles) and refactoring hasChanges tracking in settings components from stateful effects to derived computations during render. These changes fix bugs related to stale closures and unnecessary re-renders, improving performance and correctness across toggle buttons, sidebar state management, onboarding tour navigation, and settings forms.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If this PR relates to an open issue, please link to the issue here: FIX #123 -->
FIX #1004 
FIX #1007 
FIX #1005 


## Screenshots
<!-- If applicable, add screenshots or images to demonstrate the changes visually -->

## API Changes
<!-- Document any API changes if applicable -->
- [ ] This PR includes API changes

## Change Type
<!--- Indicate what kind(s) of changes this PR includes: -->
- [X] Bug fix
- [ ] New feature
- [X] Performance improvement
- [X] Refactoring
- [ ] Documentation
- [ ] Dependency/Build system
- [ ] Breaking change
- [ ] Other (specify):

## Testing Performed
<!--- Briefly describe how you have tested these changes and what verification was performed -->
- [X] Tested locally
- [ ] Manual/QA verification

## Checklist
<!--- Please confirm the following by marking with an 'x' as appropriate -->
- [X] Follows project coding standards and conventions
- [ ] Documentation updated as needed
- [ ] Dependencies updated as needed
- [ ] No lint/build errors or new warnings
- [ ] All relevant tests are passing

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR addresses multiple React state management issues by converting direct state updates to functional `setState` calls (using `prev => !prev` pattern for toggles) and refactoring `hasChanges` tracking in settings components from stateful effects to derived computations during render. These changes fix bugs related to stale closures and unnecessary re-renders, improving performance and correctness across toggle buttons, sidebar state management, onboarding tour navigation, and settings forms.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/components/settings/general-settings-manager.tsx` |
| 2 | `surfsense_web/components/settings/prompt-config-manager.tsx` |
| 3 | `surfsense_web/components/layout/hooks/useSidebarState.ts` |
| 4 | `surfsense_web/components/onboarding-tour.tsx` |
| 5 | `surfsense_web/components/assistant-ui/connector-popup/connect-forms/components/mcp-connect-form.tsx` |
| 6 | `surfsense_web/components/assistant-ui/connector-popup/connector-configs/components/mcp-config.tsx` |
| 7 | `surfsense_web/components/assistant-ui/connector-popup/connector-configs/components/composio-drive-config.tsx` |
| 8 | `surfsense_web/components/assistant-ui/connector-popup/connector-configs/components/onedrive-config.tsx` |
| 9 | `surfsense_web/components/assistant-ui/connector-popup/connector-configs/components/webcrawler-config.tsx` |
| 10 | `surfsense_web/components/assistant-ui/thinking-steps.tsx` |
| 11 | `surfsense_web/components/assistant-ui/tool-fallback.tsx` |
| 12 | `surfsense_web/components/chat-comments/comment-thread/comment-thread.tsx` |
| 13 | `surfsense_web/components/homepage/navbar.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/f82d28143b09aca8fe903ebd7314dfb8e9706333d1eac3533a6f85f603f4f1c4/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=1035)
<!-- RECURSEML_SUMMARY:END -->