### PR TITLE
fix: remove unnecessary useMemo from simple boolean expressions

### DIFF
--- a/surfsense_web/components/new-chat/model-selector.tsx
+++ b/surfsense_web/components/new-chat/model-selector.tsx
@@ -96,9 +96,7 @@ export function ModelSelector({
 		return llmUserConfigs?.find((c) => c.id === agentLlmId) ?? null;
 	}, [preferences, llmGlobalConfigs, llmUserConfigs]);
 
-	const isLLMAutoMode = useMemo(() => {
-		return currentLLMConfig && "is_auto_mode" in currentLLMConfig && currentLLMConfig.is_auto_mode;
-	}, [currentLLMConfig]);
+	const isLLMAutoMode = currentLLMConfig && "is_auto_mode" in currentLLMConfig && currentLLMConfig.is_auto_mode;
 
 	// ─── Image current config ───
 	const currentImageConfig = useMemo(() => {
@@ -110,11 +108,7 @@ export function ModelSelector({
 		return imageUserConfigs?.find((c) => c.id === id) ?? null;
 	}, [preferences, imageGlobalConfigs, imageUserConfigs]);
 
-	const isImageAutoMode = useMemo(() => {
-		return (
-			currentImageConfig && "is_auto_mode" in currentImageConfig && currentImageConfig.is_auto_mode
-		);
-	}, [currentImageConfig]);
+	const isImageAutoMode = currentImageConfig && "is_auto_mode" in currentImageConfig && currentImageConfig.is_auto_mode;
 
 	// ─── LLM filtering ───
 	const filteredLLMGlobal = useMemo(() => {


### PR DESCRIPTION
This PR removes `useMemo` from simple boolean calculations in `ModelSelector` where the memoization overhead outweighs the cost of the calculation. Fixes #1052

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR removes unnecessary `useMemo` hooks from two simple boolean expressions (`isLLMAutoMode` and `isImageAutoMode`) in the `ModelSelector` component, as the computational cost of these simple checks is lower than the overhead of memoization itself.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/components/new-chat/model-selector.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/3281de8fc7cefe264f5e0e74aaf6e7007b2170180fc3cdf5b65f2fe320ed815b/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=1057)
<!-- RECURSEML_SUMMARY:END -->