### PR TITLE
fix: add passive: true to scroll and touch event listeners

### DIFF
--- a/surfsense_web/components/homepage/navbar.tsx
+++ b/surfsense_web/components/homepage/navbar.tsx
@@ -32,7 +32,7 @@ export const Navbar = ({ scrolledBgClassName }: NavbarProps = {}) => {
 		};
 
 		handleScroll();
-		window.addEventListener("scroll", handleScroll);
+		window.addEventListener("scroll", handleScroll, { passive: true });
 		return () => window.removeEventListener("scroll", handleScroll);
 	}, []);
 
@@ -132,7 +132,7 @@ const MobileNav = ({ navItems, isScrolled, scrolledBgClassName }: any) => {
 		};
 
 		document.addEventListener("mousedown", handleClickOutside);
-		document.addEventListener("touchstart", handleClickOutside);
+		document.addEventListener("touchstart", handleClickOutside, { passive: true });
 		return () => {
 			document.removeEventListener("mousedown", handleClickOutside);
 			document.removeEventListener("touchstart", handleClickOutside);

--- a/surfsense_web/components/onboarding-tour.tsx
+++ b/surfsense_web/components/onboarding-tour.tsx
@@ -598,7 +598,7 @@ export function OnboardingTour() {
 		};
 
 		window.addEventListener("resize", handleUpdate);
-		window.addEventListener("scroll", handleUpdate, true);
+		window.addEventListener("scroll", handleUpdate, { capture: true, passive: true });
 
 		return () => {
 			window.removeEventListener("resize", handleUpdate);


### PR DESCRIPTION
This PR adds `{ passive: true }` to window/document level scroll and touch event listeners to improve scrolling performance and reduce main thread blocking. Fixes #1053

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR improves scrolling performance by adding the `passive: true` option to window and document level scroll and touch event listeners. This prevents the listeners from blocking the main thread during scroll operations, which is a common performance optimization for non-canceling event handlers. The changes affect the navbar component and onboarding tour, where one instance also preserves the existing `capture: true` flag.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/components/homepage/navbar.tsx` |
| 2 | `surfsense_web/components/onboarding-tour.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/de0ac913fe0e88626ade35bd7ab627d5d4a9f1fb1c91978fcc94a3c068dcee69/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=1058)
<!-- RECURSEML_SUMMARY:END -->