### PR TITLE
fix: make migration 109 idempotent

### DIFF
--- a/surfsense_backend/alembic/versions/109_add_folders_table.py
+++ b/surfsense_backend/alembic/versions/109_add_folders_table.py
@@ -11,6 +11,7 @@ index to correctly handle NULL parent_id at root level.
 from collections.abc import Sequence
 
 import sqlalchemy as sa
+from sqlalchemy import inspect
 
 from alembic import op
 
@@ -21,67 +22,76 @@ depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:
-    op.create_table(
-        "folders",
-        sa.Column("id", sa.Integer(), primary_key=True, index=True),
-        sa.Column("name", sa.String(255), nullable=False, index=True),
-        sa.Column("position", sa.String(50), nullable=False, index=True),
-        sa.Column(
-            "parent_id",
-            sa.Integer(),
-            sa.ForeignKey("folders.id", ondelete="CASCADE"),
-            nullable=True,
-            index=True,
-        ),
-        sa.Column(
-            "search_space_id",
-            sa.Integer(),
-            sa.ForeignKey("searchspaces.id", ondelete="CASCADE"),
-            nullable=False,
-            index=True,
-        ),
-        sa.Column(
-            "created_by_id",
-            sa.Uuid(),
-            sa.ForeignKey("user.id", ondelete="SET NULL"),
-            nullable=True,
-            index=True,
-        ),
-        sa.Column(
-            "created_at",
-            sa.TIMESTAMP(timezone=True),
-            nullable=False,
-            server_default=sa.func.now(),
-        ),
-        sa.Column(
-            "updated_at",
-            sa.TIMESTAMP(timezone=True),
-            nullable=False,
-            server_default=sa.func.now(),
-        ),
-    )
+    conn = op.get_bind()
+    inspector = inspect(conn)
+    existing_tables = inspector.get_table_names()
+
+    if "folders" not in existing_tables:
+        op.create_table(
+            "folders",
+            sa.Column("id", sa.Integer(), primary_key=True, index=True),
+            sa.Column("name", sa.String(255), nullable=False, index=True),
+            sa.Column("position", sa.String(50), nullable=False, index=True),
+            sa.Column(
+                "parent_id",
+                sa.Integer(),
+                sa.ForeignKey("folders.id", ondelete="CASCADE"),
+                nullable=True,
+                index=True,
+            ),
+            sa.Column(
+                "search_space_id",
+                sa.Integer(),
+                sa.ForeignKey("searchspaces.id", ondelete="CASCADE"),
+                nullable=False,
+                index=True,
+            ),
+            sa.Column(
+                "created_by_id",
+                sa.Uuid(),
+                sa.ForeignKey("user.id", ondelete="SET NULL"),
+                nullable=True,
+                index=True,
+            ),
+            sa.Column(
+                "created_at",
+                sa.TIMESTAMP(timezone=True),
+                nullable=False,
+                server_default=sa.func.now(),
+            ),
+            sa.Column(
+                "updated_at",
+                sa.TIMESTAMP(timezone=True),
+                nullable=False,
+                server_default=sa.func.now(),
+            ),
+        )
 
     # Expression-based unique index: COALESCE(parent_id, 0) handles NULL correctly.
     # PostgreSQL treats NULL != NULL in regular unique constraints, so a standard
     # UniqueConstraint(search_space_id, parent_id, name) would allow duplicate
     # folder names at the root level.
-    op.execute(
-        """
-        CREATE UNIQUE INDEX uq_folder_space_parent_name
-        ON folders (search_space_id, COALESCE(parent_id, 0), name);
-        """
-    )
+    existing_indexes = [idx["name"] for idx in inspector.get_indexes("folders")]
+    if "uq_folder_space_parent_name" not in existing_indexes:
+        op.execute(
+            """
+            CREATE UNIQUE INDEX uq_folder_space_parent_name
+            ON folders (search_space_id, COALESCE(parent_id, 0), name);
+            """
+        )
 
-    op.add_column(
-        "documents",
-        sa.Column(
-            "folder_id",
-            sa.Integer(),
-            sa.ForeignKey("folders.id", ondelete="SET NULL"),
-            nullable=True,
-            index=True,
-        ),
-    )
+    existing_columns = [col["name"] for col in inspector.get_columns("documents")]
+    if "folder_id" not in existing_columns:
+        op.add_column(
+            "documents",
+            sa.Column(
+                "folder_id",
+                sa.Integer(),
+                sa.ForeignKey("folders.id", ondelete="SET NULL"),
+                nullable=True,
+                index=True,
+            ),
+        )
 
 
 def downgrade() -> None:


### PR DESCRIPTION
<!--- Summarize your pull request in a few sentences -->

## Description
<!--- Clearly describe what has changed in this pull request -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If this PR relates to an open issue, please link to the issue here: FIX #123 -->
FIX #


## Screenshots
<!-- If applicable, add screenshots or images to demonstrate the changes visually -->

## API Changes
<!-- Document any API changes if applicable -->
- [ ] This PR includes API changes

## Change Type
<!--- Indicate what kind(s) of changes this PR includes: -->
- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Dependency/Build system
- [ ] Breaking change
- [ ] Other (specify):

## Testing Performed
<!--- Briefly describe how you have tested these changes and what verification was performed -->
- [ ] Tested locally
- [ ] Manual/QA verification

## Checklist
<!--- Please confirm the following by marking with an 'x' as appropriate -->
- [ ] Follows project coding standards and conventions
- [ ] Documentation updated as needed
- [ ] Dependencies updated as needed
- [ ] No lint/build errors or new warnings
- [ ] All relevant tests are passing

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR makes database migration 109 idempotent by adding existence checks before creating the `folders` table, the unique index `uq_folder_space_parent_name`, and the `folder_id` column in the `documents` table. The migration now uses SQLAlchemy's `inspect` module to check if these database objects already exist, preventing errors when the migration is run multiple times on the same database.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_backend/alembic/versions/109_add_folders_table.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/0ddfa5efa72be7b6c38b26335ef7183b828bc4ea703c2354465d42d38e72df6b/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=1070)
<!-- RECURSEML_SUMMARY:END -->