### PR TITLE
fix: avoid mutating shared arrays in changelog and comments sync issue 1046 immutable sort

### DIFF
--- a/surfsense_web/app/(home)/changelog/page.tsx
+++ b/surfsense_web/app/(home)/changelog/page.tsx
@@ -29,7 +29,7 @@ interface ChangelogPageItem {
 
 export default async function ChangelogPage() {
 	const allPages = source.getPages() as ChangelogPageItem[];
-	const sortedChangelogs = allPages.sort((a, b) => {
+	const sortedChangelogs = allPages.toSorted((a, b) => {
 		const dateA = new Date(a.data.date).getTime();
 		const dateB = new Date(b.data.date).getTime();
 		return dateB - dateA;

--- a/surfsense_web/hooks/use-comments-sync.ts
+++ b/surfsense_web/hooks/use-comments-sync.ts
@@ -118,8 +118,9 @@ function transformComments(
 
 	for (const [messageId, group] of byMessage) {
 		const comments: Comment[] = group.topLevel.map((raw) => {
-			const replies = (group.replies.get(raw.id) || [])
-				.sort((a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime())
+			const replies = (group.replies.get(raw.id) ?? []).toSorted(
+				(a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+			)
 				.map((r) => transformReply(r, memberMap, currentUserId, isOwner));
 
 			return {

--- a/surfsense_web/hooks/use-comments-sync.ts
+++ b/surfsense_web/hooks/use-comments-sync.ts
@@ -118,9 +118,8 @@ function transformComments(
 
 	for (const [messageId, group] of byMessage) {
 		const comments: Comment[] = group.topLevel.map((raw) => {
-			const replies = (group.replies.get(raw.id) ?? []).toSorted(
-				(a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
-			)
+			const replies = (group.replies.get(raw.id) ?? [])
+				.toSorted((a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime())
 				.map((r) => transformReply(r, memberMap, currentUserId, isOwner));
 
 			return {


### PR DESCRIPTION
<!--- Summarize your pull request in a few sentences -->
This PR fixes issue #1046 by avoiding in-place array mutation in two frontend locations. It replaces 'sort()' with 'toSorted()' in the changelog page and in comment reply sorting so shared arrays are not mutated.

## Description
<!--- Clearly describe what has changed in this pull request -->
- updated the changelog page to use 'toSorted()' instead of 'sort()'
- updated comment reply sorting in 'use-comments-sync' to use 'toSorted()'

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If this PR relates to an open issue, please link to the issue here: FIX #123 -->

This change is required to avoid mutating arrays returned from shared data sources or caches. The previous implementation used 'sort()', which mutates the original array in place. This PR preserves the same ordering logic without mutating the source data.

FIX #1046


## Screenshots
<!-- If applicable, add screenshots or images to demonstrate the changes visually -->

## API Changes
<!-- Document any API changes if applicable -->
- [ ] This PR includes API changes

## Change Type
<!--- Indicate what kind(s) of changes this PR includes: -->
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Dependency/Build system
- [ ] Breaking change
- [ ] Other (specify):

## Testing Performed
<!--- Briefly describe how you have tested these changes and what verification was performed -->
- [x] Tested locally
- [ ] Manual/QA verification

## Checklist
<!--- Please confirm the following by marking with an 'x' as appropriate -->
- [x] Follows project coding standards and conventions
- [ ] Documentation updated as needed
- [ ] Dependencies updated as needed
- [x] No lint/build errors or new warnings
- [ ] All relevant tests are passing

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a bug where shared arrays were being mutated in-place during sorting operations. The changes replace the mutating `sort()` method with the non-mutating `toSorted()` method in two locations: the changelog page component and the comment reply sorting logic in the comments synchronization hook. This prevents unintended side effects from modifying shared data sources or cached arrays.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/app/(home)/changelog/page.tsx` |
| 2 | `surfsense_web/hooks/use-comments-sync.ts` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/30c8a2973393c34f92fe9fe0399bbaa741c1a02413f8c200294c83acc37b0d2d/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=1073)
<!-- RECURSEML_SUMMARY:END -->