### PR TITLE
fix: deduplicate getpage cache

### DIFF
--- a/surfsense_web/app/docs/[[...slug]]/page.tsx
+++ b/surfsense_web/app/docs/[[...slug]]/page.tsx
@@ -2,10 +2,15 @@ import { DocsBody, DocsDescription, DocsPage, DocsTitle } from "fumadocs-ui/page
 import { notFound } from "next/navigation";
 import { source } from "@/lib/source";
 import { getMDXComponents } from "@/mdx-components";
+import { cache } from "react";
+
+const getDocPage = cache((slug?: string[]) => {
+	return source.getPage(slug);
+});
 
 export default async function Page(props: { params: Promise<{ slug?: string[] }> }) {
 	const params = await props.params;
-	const page = source.getPage(params.slug);
+	const page = getDocPage(params.slug);
 	if (!page) notFound();
 
 	const MDX = page.data.body;
@@ -37,7 +42,7 @@ export async function generateStaticParams() {
 
 export async function generateMetadata(props: { params: Promise<{ slug?: string[] }> }) {
 	const params = await props.params;
-	const page = source.getPage(params.slug);
+	const page = getDocPage(params.slug);
 	if (!page) notFound();
 
 	return {


### PR DESCRIPTION
## Description
Wrap `source.getPage()` in React's `cache()` to create a shared `getDocPage` function. 
Both `Page` and `generateMetadata` now call `getDocPage()` instead of calling 
`source.getPage()` independently, so the underlying work executes only once per request.

## Motivation and Context
FIX #1055

`Page` and `generateMetadata` were each calling `source.getPage(params.slug)` 
independently on every request, duplicating CPU work. React's `cache()` deduplicates 
function calls with the same arguments within a single server request, making the 
second call a free cache hit.

## Screenshots
N/A — this is a server-side performance fix with no visual changes.

## API Changes
- [x] This PR includes API changes  ← uncheck this, no API changes

## Change Type
- [x] Bug fix
- [x] Performance improvement

## Testing Performed
- Verified `getDocPage` executes only once per request by adding a temporary 
  `console.log` inside the cached function and confirming it printed once (not twice) 
  when visiting a `/docs` page.
- Confirmed docs pages still render with correct content and metadata.
- Confirmed docs navigation between pages works without regression.
- [x] Tested locally
- [x] Manual/QA verification

## Checklist
- [x] Follows project coding standards and conventions
- [x] Documentation updated as needed
- [x] Dependencies updated as needed
- [x] No lint/build errors or new warnings
- [x] All relevant tests are passing

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a performance issue where `source.getPage()` was being called twice per request (once by the `Page` component and once by `generateMetadata`), duplicating CPU work. The fix wraps `source.getPage()` in React's `cache()` function to create a shared `getDocPage()` function that both callers now use, ensuring the underlying work executes only once per request through automatic deduplication.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/app/docs/[[...slug]]/page.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/c2cb86a58a4d15007290c7ff5ba5879a23d73e774b63bc2da3c894d915eb103c/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=1075)
<!-- RECURSEML_SUMMARY:END -->