### PR TITLE
refactor: Converted disabledTools to Set for O(1) membership checks

### DIFF
--- a/surfsense_web/components/assistant-ui/thread.tsx
+++ b/surfsense_web/components/assistant-ui/thread.tsx
@@ -834,6 +834,7 @@ const ComposerAction: FC<ComposerActionProps> = ({ isBlockedByOtherUser = false 
 
 	const { data: agentTools } = useAtomValue(agentToolsAtom);
 	const disabledTools = useAtomValue(disabledToolsAtom);
+	const disabledToolsSet = useMemo(() => new Set(disabledTools), [disabledTools]);
 	const toggleTool = useSetAtom(toggleToolAtom);
 	const setDisabledTools = useSetAtom(disabledToolsAtom);
 	const hydrateDisabled = useSetAtom(hydrateDisabledToolsAtom);
@@ -846,18 +847,18 @@ const ComposerAction: FC<ComposerActionProps> = ({ isBlockedByOtherUser = false 
 
 	const toggleToolGroup = useCallback(
 		(toolNames: string[]) => {
-			const allDisabled = toolNames.every((name) => disabledTools.includes(name));
+			const allDisabled = toolNames.every((name) => disabledToolsSet.has(name));
 			if (allDisabled) {
 				setDisabledTools((prev) => prev.filter((t) => !toolNames.includes(t)));
 			} else {
 				setDisabledTools((prev) => [...new Set([...prev, ...toolNames])]);
 			}
 		},
-		[disabledTools, setDisabledTools]
+		[disabledToolsSet, setDisabledTools]
 	);
 
 	const hasWebSearchTool = agentTools?.some((t) => t.name === "web_search") ?? false;
-	const isWebSearchEnabled = hasWebSearchTool && !disabledTools.includes("web_search");
+	const isWebSearchEnabled = hasWebSearchTool && !disabledToolsSet.has("web_search");
 	const filteredTools = useMemo(
 		() => agentTools?.filter((t) => t.name !== "web_search"),
 		[agentTools]
@@ -957,7 +958,7 @@ const ComposerAction: FC<ComposerActionProps> = ({ isBlockedByOtherUser = false 
 													{group.label}
 												</div>
 												{group.tools.map((tool) => {
-													const isDisabled = disabledTools.includes(tool.name);
+													const isDisabled = disabledToolsSet.has(tool.name);
 													const ToolIcon = getToolIcon(tool.name);
 													return (
 														<div
@@ -989,7 +990,7 @@ const ComposerAction: FC<ComposerActionProps> = ({ isBlockedByOtherUser = false 
 													const iconKey = group.connectorIcon ?? "";
 													const iconInfo = CONNECTOR_TOOL_ICON_PATHS[iconKey];
 													const toolNames = group.tools.map((t) => t.name);
-													const allDisabled = toolNames.every((n) => disabledTools.includes(n));
+													const allDisabled = toolNames.every((n) => disabledToolsSet.has(n));
 													return (
 														<div
 															key={group.label}
@@ -1078,7 +1079,7 @@ const ComposerAction: FC<ComposerActionProps> = ({ isBlockedByOtherUser = false 
 												{group.label}
 											</div>
 											{group.tools.map((tool) => {
-												const isDisabled = disabledTools.includes(tool.name);
+												const isDisabled = disabledToolsSet.has(tool.name);
 												const ToolIcon = getToolIcon(tool.name);
 												const row = (
 													<div className="flex w-full items-center gap-2 sm:gap-3 px-2.5 sm:px-3 py-1 sm:py-1.5 hover:bg-muted-foreground/10 transition-colors">
@@ -1115,7 +1116,7 @@ const ComposerAction: FC<ComposerActionProps> = ({ isBlockedByOtherUser = false 
 												const iconKey = group.connectorIcon ?? "";
 												const iconInfo = CONNECTOR_TOOL_ICON_PATHS[iconKey];
 												const toolNames = group.tools.map((t) => t.name);
-												const allDisabled = toolNames.every((n) => disabledTools.includes(n));
+												const allDisabled = toolNames.every((n) => disabledToolsSet.has(n));
 												const groupDef = TOOL_GROUPS.find((g) => g.label === group.label);
 												const row = (
 													<div className="flex w-full items-center gap-2 sm:gap-3 px-2.5 sm:px-3 py-1 sm:py-1.5 hover:bg-muted-foreground/10 transition-colors">


### PR DESCRIPTION
Replaced `disabledTools.includes()` with a memoized `Set.has()` for O(1) membership checks on every render of the composer toolbar.

Description
Added a useMemo-wrapped Set derived from the disabledTools atom and replaced all six .includes() / .every(...includes()) call sites in ComposerAction with .has() on the new set.

Motivation and Context
disabledTools is a string[] read from a Jotai atom. Every render of the thread component was calling .includes() (O(n)) multiple times across the tool UI once per individual tool check and once per group toggle check. 

Converting to a Set makes each lookup O(1) at the cost of a single allocation that is memoized and only recomputed when the array reference changes.

Addresses the js-set-map-lookups rule from Vercel React Best Practices (7.11).

FIX #1048

Screenshots
N/A internal logic update change, so no visual difference.


## Change Type
<!--- Indicate what kind(s) of changes this PR includes: -->
- [ ] Bug fix
- [ ] New feature
- [x ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Dependency/Build system
- [ ] Breaking change
- [ ] Other (specify):

## Testing Performed
<!--- Briefly describe how you have tested these changes and what verification was performed -->
- [ ] Tested locally
- [x] Manual/QA verification

## Checklist
<!--- Please confirm the following by marking with an 'x' as appropriate -->
- [x ] Follows project coding standards and conventions
- [x ] Documentation updated as needed
- [x ] Dependencies updated as needed
- [x ] No lint/build errors or new warnings
- [x ] All relevant tests are passing

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR improves performance by converting the `disabledTools` array to a memoized `Set` for O(1) membership checks. The change replaces six instances of `.includes()` calls (which have O(n) complexity) with `.has()` calls on the new Set throughout the composer toolbar rendering logic. This optimization is particularly beneficial since these checks occur on every render of the thread component.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/components/assistant-ui/thread.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/53f60825d3d92ac8a6515ad71fe5bf37d396969533570ee07403c2cbec1a5b33/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=1080)
<!-- RECURSEML_SUMMARY:END -->