### PR TITLE
perf: throttle scroll handlers with requestAnimationFrame

### DIFF
--- a/surfsense_web/app/dashboard/[search_space_id]/documents/(manage)/components/DocumentsTableShell.tsx
+++ b/surfsense_web/app/dashboard/[search_space_id]/documents/(manage)/components/DocumentsTableShell.tsx
@@ -267,11 +267,16 @@ export function DocumentsTableShell({
 	const [metadataJson, setMetadataJson] = useState<Record<string, unknown> | null>(null);
 	const [metadataLoading, setMetadataLoading] = useState(false);
 	const [previewScrollPos, setPreviewScrollPos] = useState<"top" | "middle" | "bottom">("top");
+	const previewScrollRafRef = useRef<number | null>(null);
 	const handlePreviewScroll = useCallback((e: React.UIEvent<HTMLDivElement>) => {
 		const el = e.currentTarget;
-		const atTop = el.scrollTop <= 2;
-		const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight <= 2;
-		setPreviewScrollPos(atTop ? "top" : atBottom ? "bottom" : "middle");
+		if (previewScrollRafRef.current !== null) return;
+		previewScrollRafRef.current = requestAnimationFrame(() => {
+			const atTop = el.scrollTop <= 2;
+			const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight <= 2;
+			setPreviewScrollPos(atTop ? "top" : atBottom ? "bottom" : "middle");
+			previewScrollRafRef.current = null;
+		});
 	}, []);
 
 	const [deleteDoc, setDeleteDoc] = useState<Document | null>(null);
@@ -301,6 +306,14 @@ export function DocumentsTableShell({
 	const mobileSentinelRef = useRef<HTMLDivElement>(null);
 	const desktopScrollRef = useRef<HTMLDivElement>(null);
 	const mobileScrollRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		return () => {
+			if (previewScrollRafRef.current !== null) {
+				cancelAnimationFrame(previewScrollRafRef.current);
+			}
+		};
+	}, []);
 
 	useEffect(() => {
 		if (!onLoadMore || !hasMore || loadingMore) return;

--- a/surfsense_web/components/assistant-ui/thread.tsx
+++ b/surfsense_web/components/assistant-ui/thread.tsx
@@ -816,11 +816,23 @@ const ComposerAction: FC<ComposerActionProps> = ({ isBlockedByOtherUser = false 
 	const isDesktop = useMediaQuery("(min-width: 640px)");
 	const { openDialog: openUploadDialog } = useDocumentUploadDialog();
 	const [toolsScrollPos, setToolsScrollPos] = useState<"top" | "middle" | "bottom">("top");
+	const toolsScrollRafRef = useRef<number | null>(null);
 	const handleToolsScroll = useCallback((e: React.UIEvent<HTMLDivElement>) => {
 		const el = e.currentTarget;
-		const atTop = el.scrollTop <= 2;
-		const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight <= 2;
-		setToolsScrollPos(atTop ? "top" : atBottom ? "bottom" : "middle");
+		if (toolsScrollRafRef.current !== null) return;
+		toolsScrollRafRef.current = requestAnimationFrame(() => {
+			const atTop = el.scrollTop <= 2;
+			const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight <= 2;
+			setToolsScrollPos(atTop ? "top" : atBottom ? "bottom" : "middle");
+			toolsScrollRafRef.current = null;
+		});
+	}, []);
+	useEffect(() => {
+		return () => {
+			if (toolsScrollRafRef.current !== null) {
+				cancelAnimationFrame(toolsScrollRafRef.current);
+			}
+		};
 	}, []);
 	const isComposerTextEmpty = useAuiState(({ composer }) => {
 		const text = composer.text?.trim() || "";

--- a/surfsense_web/components/layout/ui/sidebar/InboxSidebar.tsx
+++ b/surfsense_web/components/layout/ui/sidebar/InboxSidebar.tsx
@@ -178,11 +178,16 @@ export function InboxSidebarContent({
 	const [mounted, setMounted] = useState(false);
 	const [openDropdown, setOpenDropdown] = useState<"filter" | null>(null);
 	const [connectorScrollPos, setConnectorScrollPos] = useState<"top" | "middle" | "bottom">("top");
+	const connectorScrollRafRef = useRef<number | null>(null);
 	const handleConnectorScroll = useCallback((e: React.UIEvent<HTMLDivElement>) => {
 		const el = e.currentTarget;
-		const atTop = el.scrollTop <= 2;
-		const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight <= 2;
-		setConnectorScrollPos(atTop ? "top" : atBottom ? "bottom" : "middle");
+		if (connectorScrollRafRef.current !== null) return;
+		connectorScrollRafRef.current = requestAnimationFrame(() => {
+			const atTop = el.scrollTop <= 2;
+			const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight <= 2;
+			setConnectorScrollPos(atTop ? "top" : atBottom ? "bottom" : "middle");
+			connectorScrollRafRef.current = null;
+		});
 	}, []);
 	const [filterDrawerOpen, setFilterDrawerOpen] = useState(false);
 	const [markingAsReadId, setMarkingAsReadId] = useState<number | null>(null);
@@ -208,6 +213,14 @@ export function InboxSidebarContent({
 
 	useEffect(() => {
 		setMounted(true);
+	}, []);
+
+	useEffect(() => {
+		return () => {
+			if (connectorScrollRafRef.current !== null) {
+				cancelAnimationFrame(connectorScrollRafRef.current);
+			}
+		};
 	}, []);
 
 	useEffect(() => {


### PR DESCRIPTION
Scroll handlers in `thread.tsx`, `InboxSidebar.tsx`, and `DocumentsTableShell.tsx` called setState on every scroll event (up to 60/sec at 60fps), triggering unnecessary re-renders on each frame.

Wraps each handler in requestAnimationFrame batching so the state update fires at most once per animation frame. Adds cleanup useEffect to cancel pending frames on unmount.

3 files changed w/ same pattern applied to each:
- `surfsense_web/components/assistant-ui/thread.tsx` (toolsScrollPos)
- `surfsense_web/components/layout/ui/sidebar/InboxSidebar.tsx` (connectorScrollPos)
- `surfsense_web/app/dashboard/.../DocumentsTableShell.tsx` (previewScrollPos)

This contribution was developed with AI assistance (Codex).

Fixes #1103

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR optimizes scroll event handlers across three components by throttling state updates using `requestAnimationFrame`. Previously, scroll handlers triggered state updates up to 60 times per second, causing unnecessary re-renders. The changes wrap each scroll handler to batch updates so they fire at most once per animation frame, and add cleanup logic to cancel pending animation frames on component unmount. The same pattern is applied consistently to `toolsScrollPos` in thread.tsx, `connectorScrollPos` in InboxSidebar.tsx, and `previewScrollPos` in DocumentsTableShell.tsx.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/components/assistant-ui/thread.tsx` |
| 2 | `surfsense_web/components/layout/ui/sidebar/InboxSidebar.tsx` |
| 3 | `surfsense_web/app/dashboard/[search_space_id]/documents/(manage)/components/DocumentsTableShell.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->