### PR TITLE
perf: throttle scroll handlers with requestAnimationFrame

### DIFF
--- a/surfsense_web/app/dashboard/[search_space_id]/documents/(manage)/components/DocumentsTableShell.tsx
+++ b/surfsense_web/app/dashboard/[search_space_id]/documents/(manage)/components/DocumentsTableShell.tsx
@@ -278,7 +278,12 @@ export function DocumentsTableShell({
 			previewRafRef.current = undefined;
 		});
 	}, []);
-	useEffect(() => () => { if (previewRafRef.current) cancelAnimationFrame(previewRafRef.current); }, []);
+	useEffect(
+		() => () => {
+			if (previewRafRef.current) cancelAnimationFrame(previewRafRef.current);
+		},
+		[]
+	);
 
 	const [deleteDoc, setDeleteDoc] = useState<Document | null>(null);
 	const [isDeleting, setIsDeleting] = useState(false);

--- a/surfsense_web/components/assistant-ui/thread.tsx
+++ b/surfsense_web/components/assistant-ui/thread.tsx
@@ -827,7 +827,12 @@ const ComposerAction: FC<ComposerActionProps> = ({ isBlockedByOtherUser = false 
 			toolsRafRef.current = undefined;
 		});
 	}, []);
-	useEffect(() => () => { if (toolsRafRef.current) cancelAnimationFrame(toolsRafRef.current); }, []);
+	useEffect(
+		() => () => {
+			if (toolsRafRef.current) cancelAnimationFrame(toolsRafRef.current);
+		},
+		[]
+	);
 	const isComposerTextEmpty = useAuiState(({ composer }) => {
 		const text = composer.text?.trim() || "";
 		return text.length === 0;

--- a/surfsense_web/components/layout/ui/sidebar/InboxSidebar.tsx
+++ b/surfsense_web/components/layout/ui/sidebar/InboxSidebar.tsx
@@ -189,7 +189,12 @@ export function InboxSidebarContent({
 			connectorRafRef.current = undefined;
 		});
 	}, []);
-	useEffect(() => () => { if (connectorRafRef.current) cancelAnimationFrame(connectorRafRef.current); }, []);
+	useEffect(
+		() => () => {
+			if (connectorRafRef.current) cancelAnimationFrame(connectorRafRef.current);
+		},
+		[]
+	);
 	const [filterDrawerOpen, setFilterDrawerOpen] = useState(false);
 	const [markingAsReadId, setMarkingAsReadId] = useState<number | null>(null);
 


### PR DESCRIPTION
## Summary

Scroll handlers in three components called `setState` on every scroll event (up to 60/sec at 60fps), triggering unnecessary re-renders on each frame. This wraps each handler in `requestAnimationFrame` batching so state updates fire at most once per animation frame.

## Why this matters

On lower-end devices, 60 `setState` calls per second per scrollable area causes visible jank. The scroll position state drives CSS mask gradients for fade effects at scroll boundaries. Those gradients only need to update once per painted frame, not once per scroll event.

## Changes

3 files changed with the same pattern applied to each:

- `surfsense_web/components/assistant-ui/thread.tsx` (`toolsScrollPos` handler, line 819)
- `surfsense_web/components/layout/ui/sidebar/InboxSidebar.tsx` (`connectorScrollPos` handler, line 181)
- `surfsense_web/app/dashboard/[search_space_id]/documents/(manage)/components/DocumentsTableShell.tsx` (`previewScrollPos` handler, line 270)

Each handler now:
1. Early-returns if a rAF callback is already scheduled
2. Schedules the position calculation + `setState` inside `requestAnimationFrame`
3. Clears the ref after the callback runs
4. Cancels any pending frame on component unmount via cleanup `useEffect`

## Testing

- Verified all three scroll containers still show fade mask gradients that update on scroll
- Scroll position transitions (top/middle/bottom) remain responsive
- No stale frames on unmount (cleanup cancels pending rAF)

Fixes #1103

This contribution was developed with AI assistance (Claude Code).

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR optimizes scroll event handlers across three components by throttling state updates using `requestAnimationFrame`. Previously, each scroll event triggered immediate `setState` calls (up to 60 times per second), causing unnecessary re-renders and visible jank on lower-end devices. The fix wraps each handler with rAF batching, ensuring scroll position state updates fire at most once per animation frame. Each handler now checks for pending frames before scheduling, clears the ref after execution, and includes cleanup logic to cancel pending frames on unmount. This improves performance for CSS mask gradient fade effects at scroll boundaries, which only need to update once per painted frame.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/components/assistant-ui/thread.tsx` |
| 2 | `surfsense_web/components/layout/ui/sidebar/InboxSidebar.tsx` |
| 3 | `surfsense_web/app/dashboard/[search_space_id]/documents/(manage)/components/DocumentsTableShell.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/acc8d367b5b40579bcf4927acaf71e9038918002d87f3de9101e95ac2d7d01a6/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=1108)
<!-- RECURSEML_SUMMARY:END -->