### PR TITLE
fix: clean up onboarding tour timer leaks

### DIFF
--- a/surfsense_web/components/onboarding-tour.tsx
+++ b/surfsense_web/components/onboarding-tour.tsx
@@ -429,6 +429,7 @@ export function OnboardingTour() {
 	const pathname = usePathname();
 	const retryCountRef = useRef(0);
 	const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const startCheckTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 	const maxRetries = 10;
 	// Track previous user ID to detect user changes
 	const previousUserIdRef = useRef<string | null>(null);
@@ -460,6 +461,7 @@ export function OnboardingTour() {
 
 	// Find and track target element with retry logic
 	const updateTarget = useCallback(() => {
+		if (retryTimerRef.current) clearTimeout(retryTimerRef.current);
 		if (!currentStep) return;
 
 		const el = document.querySelector(currentStep.target);
@@ -480,11 +482,13 @@ export function OnboardingTour() {
 				}
 			}, 200);
 		}
+	}, [currentStep]);
 
+	useEffect(() => {
 		return () => {
 			if (retryTimerRef.current) clearTimeout(retryTimerRef.current);
 		};
-	}, [currentStep]);
+	}, []);
 
 	// Check if tour should run: localStorage + data validation with user ID tracking
 	useEffect(() => {
@@ -573,15 +577,15 @@ export function OnboardingTour() {
 				setPosition(calculatePosition(connectorEl, TOUR_STEPS[0].placement));
 			} else {
 				// Retry after delay
-				setTimeout(checkAndStartTour, 200);
+				startCheckTimerRef.current = setTimeout(checkAndStartTour, 200);
 			}
 		};
 
 		// Start checking after initial delay
-		const timer = setTimeout(checkAndStartTour, 500);
+		startCheckTimerRef.current = setTimeout(checkAndStartTour, 500);
 		return () => {
 			cancelled = true;
-			clearTimeout(timer);
+			if (startCheckTimerRef.current) clearTimeout(startCheckTimerRef.current);
 		};
 	}, [mounted, user?.id, searchSpaceId, pathname, threadsData, documentTypeCounts, connectors]);
 


### PR DESCRIPTION
## Summary

Two timer cleanup bugs in the onboarding tour component cause leaked timers on unmount.

## Changes

`surfsense_web/components/onboarding-tour.tsx`:

**Bug 1 (line 462):** `updateTarget` returned a cleanup function from `useCallback`, but cleanup returns only work in `useEffect`. The cleanup was never called, leaking `retryTimerRef` timers. Fixed by clearing the ref at the start of each `updateTarget` call and adding a dedicated `useEffect` cleanup.

**Bug 2 (line 576):** Recursive `setTimeout(checkAndStartTour, 200)` calls were not tracked in a ref. Only the initial 500ms timer was cleared on unmount. Fixed by storing all timer IDs in `startCheckTimerRef` and clearing it in the cleanup.

## Testing

- Onboarding tour still retries finding DOM elements before starting
- Timer refs are cleared on unmount (no setState on unmounted component warnings)
- Step transitions still work correctly with retry logic

Fixes #1091

This contribution was developed with AI assistance (Claude Code).

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes two timer memory leaks in the onboarding tour component. The first bug involved a cleanup function incorrectly returned from `useCallback` instead of `useEffect`, causing `retryTimerRef` timers to never be cleared. The second bug failed to track recursive `setTimeout` calls in the tour start logic, leaving timers running after component unmount. Both issues are resolved by properly clearing timer refs at the start of callbacks and adding dedicated `useEffect` cleanup handlers.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/components/onboarding-tour.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/90cdb33969e253f070af387a40363d46a93a4a71c049c4166d4302d92b0d84c2/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=1109)
<!-- RECURSEML_SUMMARY:END -->