### PR TITLE
fix: clear upload progress interval on unmount

### DIFF
--- a/surfsense_web/components/sources/DocumentUploadTab.tsx
+++ b/surfsense_web/components/sources/DocumentUploadTab.tsx
@@ -4,7 +4,7 @@ import { useAtom } from "jotai";
 import { CheckCircle2, FileType, FolderOpen, Info, Upload, X } from "lucide-react";
 
 import { useTranslations } from "next-intl";
-import { type ChangeEvent, useCallback, useMemo, useRef, useState } from "react";
+import { type ChangeEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useDropzone } from "react-dropzone";
 import { toast } from "sonner";
 import { uploadDocumentMutationAtom } from "@/atoms/documents/document-mutation.atoms";
@@ -132,6 +132,15 @@ export function DocumentUploadTab({
 	const { mutate: uploadDocuments, isPending: isUploading } = uploadDocumentMutation;
 	const fileInputRef = useRef<HTMLInputElement>(null);
 	const folderInputRef = useRef<HTMLInputElement>(null);
+	const progressIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+	useEffect(() => {
+		return () => {
+			if (progressIntervalRef.current) {
+				clearInterval(progressIntervalRef.current);
+			}
+		};
+	}, []);
 
 	const acceptedFileTypes = useMemo(() => {
 		const etlService = process.env.NEXT_PUBLIC_ETL_SERVICE;
@@ -236,7 +245,7 @@ export function DocumentUploadTab({
 		setUploadProgress(0);
 		trackDocumentUploadStarted(Number(searchSpaceId), files.length, totalFileSize);
 
-		const progressInterval = setInterval(() => {
+		progressIntervalRef.current = setInterval(() => {
 			setUploadProgress((prev) => (prev >= 90 ? prev : prev + Math.random() * 10));
 		}, 200);
 
@@ -249,14 +258,14 @@ export function DocumentUploadTab({
 			},
 			{
 				onSuccess: () => {
-					clearInterval(progressInterval);
+					if (progressIntervalRef.current) clearInterval(progressIntervalRef.current);
 					setUploadProgress(100);
 					trackDocumentUploadSuccess(Number(searchSpaceId), files.length);
 					toast(t("upload_initiated"), { description: t("upload_initiated_desc") });
 					onSuccess?.();
 				},
 				onError: (error: unknown) => {
-					clearInterval(progressInterval);
+					if (progressIntervalRef.current) clearInterval(progressIntervalRef.current);
 					setUploadProgress(0);
 					const message = error instanceof Error ? error.message : "Upload failed";
 					trackDocumentUploadFailure(Number(searchSpaceId), message);


### PR DESCRIPTION
## Summary

The fake upload progress `setInterval` in DocumentUploadTab leaks when the component unmounts mid-upload. Stores the interval ID in a ref and clears it in a useEffect cleanup.

## Changes

`surfsense_web/components/sources/DocumentUploadTab.tsx`:

- Added `progressIntervalRef` to store the interval ID across renders
- Added `useEffect` cleanup to clear the interval on unmount
- Replaced local `progressInterval` variable with the ref in `handleUpload`, `onSuccess`, and `onError`

## Testing

- Upload progress bar still works during normal upload flow
- Navigating away mid-upload no longer leaks the interval
- No React warnings about setState on unmounted component

Fixes #1090

This contribution was developed with AI assistance (Claude Code).

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a memory leak in the `DocumentUploadTab` component where a `setInterval` used for simulating upload progress was not being cleared when the component unmounted. The fix uses a ref to store the interval ID and adds a `useEffect` cleanup function to properly clear the interval on unmount, preventing React warnings about setState calls on unmounted components.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/components/sources/DocumentUploadTab.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/c8577d4bcf1ef02c347148a9b96f32ade8f7635f7951accbe6a04e4f777c3fc0/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=1110)
<!-- RECURSEML_SUMMARY:END -->