### PR TITLE
fix: memoize formatRelativeTime in thread list

### DIFF
--- a/surfsense_web/components/assistant-ui/thread-list.tsx
+++ b/surfsense_web/components/assistant-ui/thread-list.tsx
@@ -9,7 +9,7 @@ import {
 	TrashIcon,
 } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { memo, useCallback, useEffect, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
 	DropdownMenu,
@@ -224,6 +224,11 @@ const ThreadListItemComponent = memo(function ThreadListItemComponent({
 	onUnarchive,
 	onDelete,
 }: ThreadListItemComponentProps) {
+	const relativeTime = useMemo(
+		() => formatRelativeTime(new Date(thread.updatedAt)),
+		[thread.updatedAt]
+	);
+
 	return (
 		<button
 			type="button"
@@ -237,7 +242,7 @@ const ThreadListItemComponent = memo(function ThreadListItemComponent({
 			<div className="flex-1 min-w-0">
 				<p className="truncate text-sm font-medium">{thread.title || "New Chat"}</p>
 				<p className="truncate text-xs text-muted-foreground">
-					{formatRelativeTime(new Date(thread.updatedAt))}
+					{relativeTime}
 				</p>
 			</div>
 			<DropdownMenu>


### PR DESCRIPTION
## Summary
Fixes #1100

Wrapped `formatRelativeTime` call in `useMemo` to avoid creating `new Date()` on every render for each thread item. This prevents unnecessary object allocations during re-renders.

## How did you test this?
- Verified thread list renders correctly with memoized values
- Confirmed relative timestamps update appropriately

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR optimizes the thread list component by memoizing the `formatRelativeTime` function call to prevent unnecessary `new Date()` object allocations on every render. The relative timestamp calculation is now cached using `useMemo` and only recalculates when the `thread.updatedAt` value changes, improving render performance for thread list items.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/components/assistant-ui/thread-list.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/2cec8e08a022a84dfef7a15f64cbec617f0d0a789e427ca0b479282a963ee02a/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=1111)
<!-- RECURSEML_SUMMARY:END -->