### PR TITLE
perf: normalize query keys and add placeholderData to optimize…

### DIFF
--- a/surfsense_web/components/layout/ui/sidebar/AllPrivateChatsSidebar.tsx
+++ b/surfsense_web/components/layout/ui/sidebar/AllPrivateChatsSidebar.tsx
@@ -109,6 +109,7 @@ export function AllPrivateChatsSidebarContent({
 		queryKey: ["all-threads", searchSpaceId],
 		queryFn: () => fetchThreads(Number(searchSpaceId)),
 		enabled: !!searchSpaceId && !isSearchMode,
+		placeholderData: () => queryClient.getQueryData(["threads", searchSpaceId, { limit: 40 }]),
 	});
 
 	const {

--- a/surfsense_web/components/onboarding-tour.tsx
+++ b/surfsense_web/components/onboarding-tour.tsx
@@ -439,8 +439,8 @@ export function OnboardingTour() {
 
 	// Fetch threads data
 	const { data: threadsData } = useQuery({
-		queryKey: ["threads", searchSpaceId, { limit: 1 }],
-		queryFn: () => fetchThreads(Number(searchSpaceId), 1), // Only need to check if any exist
+		queryKey: ["threads", searchSpaceId, { limit: 40 }], // Same key as layout
+		queryFn: () => fetchThreads(Number(searchSpaceId), 40),
 		enabled: !!searchSpaceId,
 	});
 


### PR DESCRIPTION
## Description
This PR addresses an issue where multiple components were triggering separate overlapping network calls to fetch thread lists on mount. I've standardized the TanStack Query keys across `onboarding-tour.tsx` and `AllPrivateChatsSidebar.tsx` to map cleanly with the primary provider feed.

## Motivation and Context
Previously, components used mismatched query configurations (`["threads", ..., { limit: 1 }]` and `["all-threads", ...]`), firing 3 separate requests for similar data. 
By pulling from the `LayoutDataProvider`'s cached query keys and using `.getQueryData()` to inject `placeholderData` into the sidebar, we've successfully reduced the overlapping requests to a maximum of 2, significantly accelerating sidebar rendering.

FIX #1101

## API Changes
<!-- Document any API changes if applicable -->
- [ ] This PR includes API changes

## Change Type
<!--- Indicate what kind(s) of changes this PR includes: -->
- [ ] Bug fix
- [ ] New feature
- [x] Performance improvement
- [x] Refactoring
- [ ] Documentation
- [ ] Dependency/Build system
- [ ] Breaking change
- [ ] Other (specify):

## Testing Performed
<!--- Briefly describe how you have tested these changes and what verification was performed -->
- [x] Tested locally
- [ ] Manual/QA verification

## Checklist
<!--- Please confirm the following by marking with an 'x' as appropriate -->
- [x] Follows project coding standards and conventions
- [ ] Documentation updated as needed
- [ ] Dependencies updated as needed
- [x] No lint/build errors or new warnings
- [x] All relevant tests are passing

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR optimizes network performance by standardizing TanStack Query keys across multiple components that fetch thread lists. The changes align query keys in `onboarding-tour.tsx` and `AllPrivateChatsSidebar.tsx` to use `["threads", searchSpaceId, { limit: 40 }]` consistently, and leverage `placeholderData` from the `LayoutDataProvider`'s cached query to prevent duplicate network requests. This optimization reduces overlapping requests from 3 to a maximum of 2, improving sidebar rendering speed.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/components/onboarding-tour.tsx` |
| 2 | `surfsense_web/components/layout/ui/sidebar/AllPrivateChatsSidebar.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/6db086af18ca56bd5a40fafd91142ddb8d6df9ae9982882cfe0e8cc3e323660b/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=1113)
<!-- RECURSEML_SUMMARY:END -->