### PR TITLE
fix: memoize opts object in ZeroProvider to prevent unnecessary reconnects (#1097)

### DIFF
--- a/surfsense_web/components/providers/ZeroProvider.tsx
+++ b/surfsense_web/components/providers/ZeroProvider.tsx
@@ -6,7 +6,7 @@ import {
 	ZeroProvider as ZeroReactProvider,
 } from "@rocicorp/zero/react";
 import { useAtomValue } from "jotai";
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { currentUserAtom } from "@/atoms/user/user-query.atoms";
 import { getBearerToken, handleUnauthorized, refreshAccessToken } from "@/lib/auth-utils";
 import { queries } from "@/zero/queries";
@@ -48,14 +48,17 @@ export function ZeroProvider({ children }: { children: React.ReactNode }) {
 	const context = hasUser ? { userId: String(user.id) } : undefined;
 	const auth = hasUser ? getBearerToken() || undefined : undefined;
 
-	const opts = {
-		userID,
-		schema,
-		queries,
-		context,
-		cacheURL,
-		auth,
-	};
+	const opts = useMemo(
+		() => ({
+			userID,
+			schema,
+			queries,
+			context,
+			cacheURL,
+			auth,
+		}),
+		[userID, schema, queries, context, cacheURL, auth],
+	);
 
 	return (
 		<ZeroReactProvider {...opts}>


### PR DESCRIPTION
Wrap the `opts` object in `useMemo` to prevent unnecessary reconnects.

## Problem
The `opts` object in `ZeroProvider.tsx` is recreated on every render:
```tsx
const opts = {
  userID,
  schema,
  queries,
  context,
  cacheURL,
  auth,
};
```
If `ZeroReactProvider` compares props by reference, this causes it to reconnect on every parent re-render.

## Fix
```tsx
const opts = useMemo(
  () => ({ userID, schema, queries, context, cacheURL, auth }),
  [userID, schema, queries, context, cacheURL, auth],
);
```

Stable reference = no spurious reconnects.

Fixes #1097

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes unnecessary reconnections in the `ZeroProvider` component by memoizing the options object passed to `ZeroReactProvider`. Previously, the `opts` object was recreated on every render, causing reference inequality that triggered reconnects. The fix wraps the object creation in `useMemo` with proper dependencies (`userID`, `schema`, `queries`, `context`, `cacheURL`, `auth`) to maintain a stable reference across renders unless these values actually change.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/components/providers/ZeroProvider.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/5500a48498660f4f63417cb529a8b1d21ed06ad5af2340b4ac00bf636f9c196f/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=1116)
<!-- RECURSEML_SUMMARY:END -->