### PR TITLE
fix(navbar): remove key prop causing unnecessary remount in mobile na…

### DIFF
--- a/surfsense_web/components/homepage/features-bento-grid.tsx
+++ b/surfsense_web/components/homepage/features-bento-grid.tsx
@@ -408,6 +408,7 @@ const AudioCommentIllustration = () => (
 			src="/homepage/comments-audio.webp"
 			alt="Audio Comment Illustration"
 			fill
+			sizes="(max-width: 768px) 100vw, (max-width: 1024px) 50vw, 33vw"
 			className="object-cover"
 		/>
 	</div>

--- a/surfsense_web/components/homepage/navbar.tsx
+++ b/surfsense_web/components/homepage/navbar.tsx
@@ -143,7 +143,6 @@ const MobileNav = ({ navItems, isScrolled, scrolledBgClassName }: any) => {
 		<motion.div
 			ref={navRef}
 			animate={{ borderRadius: open ? "4px" : "2rem" }}
-			key={String(open)}
 			className={cn(
 				"relative mx-auto flex w-full max-w-[calc(100vw-2rem)] flex-col items-center justify-between px-4 py-2 lg:hidden transition-all duration-300",
 				isScrolled

--- a/surfsense_web/components/tool-ui/image/index.tsx
+++ b/surfsense_web/components/tool-ui/image/index.tsx
@@ -307,6 +307,7 @@ export function Image({
 							src={src}
 							alt={alt}
 							fill
+							sizes="(max-width: 512px) 100vw, 512px"
 							className={cn(
 								"transition-transform duration-300",
 								fit === "cover" ? "object-cover" : "object-contain",

--- a/surfsense_web/mdx-components.tsx
+++ b/surfsense_web/mdx-components.tsx
@@ -15,8 +15,9 @@ export function getMDXComponents(components?: MDXComponents): MDXComponents {
 		img: ({ className, alt, ...props }: React.ComponentProps<"img">) => (
 			<Image
 				{...(props as ImageProps)}
-				className={cn("rounded-md border", className)}
 				alt={alt ?? ""}
+				sizes="(max-width: 768px) 100vw, 896px"
+				className={cn("rounded-md border", className)}
 			/>
 		),
 		Video: ({ className, ...props }: React.ComponentProps<"video">) => (


### PR DESCRIPTION
## Description

Removed `key={String(open)}` from the mobile navbar container.

This key caused React to fully unmount and remount the component tree whenever the mobile menu was toggled. Since Framer Motion already handles the animation through the `animate` prop, the key was unnecessary.

## Motivation and Context

Removing the key prevents unnecessary remounting and preserves component state while keeping the border-radius animation working correctly.

Fix #1098

## Change Type

* [x] Bug fix
* [ ] New feature
* [x] Performance improvement

## Testing Performed

* [x] Tested locally
* [x] Manual verification

Verified that the mobile navbar opens and closes smoothly and the border-radius animation still works.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a performance issue in the mobile navigation component by removing an unnecessary `key` prop that was causing React to unmount and remount the entire component tree on every toggle. Since Framer Motion already handles the border-radius animation through the `animate` prop, the key was redundant and caused unnecessary performance overhead and loss of component state.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/components/homepage/navbar.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/fde9036de6212ddf2a0427e58edabafc58cd914aea43d1e1d8dc9c8a1a466e02/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=1119)
<!-- RECURSEML_SUMMARY:END -->