### PR TITLE
fix: memoize formatRelativeTime in thread list

### DIFF
--- a/surfsense_web/components/assistant-ui/thread-list.tsx
+++ b/surfsense_web/components/assistant-ui/thread-list.tsx
@@ -9,7 +9,7 @@ import {
 	TrashIcon,
 } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { memo, useCallback, useEffect, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
 	DropdownMenu,
@@ -224,6 +224,11 @@ const ThreadListItemComponent = memo(function ThreadListItemComponent({
 	onUnarchive,
 	onDelete,
 }: ThreadListItemComponentProps) {
+	const relativeTime = useMemo(
+		() => formatRelativeTime(new Date(thread.updatedAt)),
+		[thread.updatedAt]
+	);
+
 	return (
 		<button
 			type="button"
@@ -237,7 +242,7 @@ const ThreadListItemComponent = memo(function ThreadListItemComponent({
 			<div className="flex-1 min-w-0">
 				<p className="truncate text-sm font-medium">{thread.title || "New Chat"}</p>
 				<p className="truncate text-xs text-muted-foreground">
-					{formatRelativeTime(new Date(thread.updatedAt))}
+					{relativeTime}
 				</p>
 			</div>
 			<DropdownMenu>


### PR DESCRIPTION
## Summary
Fixes #1100

Wrapped `formatRelativeTime` call in `useMemo` to avoid creating `new Date()` on every render for each thread item. This prevents unnecessary object allocations during re-renders.

Re-opening against `dev` branch as requested in #1111.

## How did you test this?
- Verified thread list renders correctly with memoized values
- Confirmed relative timestamps update appropriately

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR optimizes performance in the thread list component by memoizing the `formatRelativeTime` function call. Previously, a new `Date` object was created on every render for each thread item. By wrapping the call in `useMemo` with `thread.updatedAt` as a dependency, the relative time is only recalculated when the timestamp changes, preventing unnecessary object allocations during re-renders.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/components/assistant-ui/thread-list.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/8872730eb145805b7f25dd781a75aceb40ce6b12cb6aa612222cffce4c4e0efe/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=1122)
<!-- RECURSEML_SUMMARY:END -->