### PR TITLE
fix: resolve setTimeout memory leak on unmounted component

### DIFF
--- a/surfsense_web/components/report-panel/report-panel.tsx
+++ b/surfsense_web/components/report-panel/report-panel.tsx
@@ -123,6 +123,13 @@ export function ReportPanelContent({
 	const [copied, setCopied] = useState(false);
 	const [exporting, setExporting] = useState<string | null>(null);
 	const [saving, setSaving] = useState(false);
+	const copyTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+	useEffect(() => {
+		return () => {
+			if (copyTimerRef.current) clearTimeout(copyTimerRef.current);
+		};
+	}, []);
 
 	// Editor state — tracks the latest markdown from the Plate editor
 	const [editedMarkdown, setEditedMarkdown] = useState<string | null>(null);
@@ -197,7 +204,8 @@ export function ReportPanelContent({
 		try {
 			await navigator.clipboard.writeText(currentMarkdown);
 			setCopied(true);
-			setTimeout(() => setCopied(false), 2000);
+			if (copyTimerRef.current) clearTimeout(copyTimerRef.current);
+			copyTimerRef.current = setTimeout(() => setCopied(false), 2000);
 		} catch (err) {
 			console.error("Failed to copy:", err);
 		}

--- a/surfsense_web/hooks/use-api-key.ts
+++ b/surfsense_web/hooks/use-api-key.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { getBearerToken } from "@/lib/auth-utils";
 import { copyToClipboard as copyToClipboardUtil } from "@/lib/utils";
@@ -14,6 +14,13 @@ export function useApiKey(): UseApiKeyReturn {
 	const [apiKey, setApiKey] = useState<string | null>(null);
 	const [copied, setCopied] = useState(false);
 	const [isLoading, setIsLoading] = useState(true);
+	const copyTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+	useEffect(() => {
+		return () => {
+			if (copyTimerRef.current) clearTimeout(copyTimerRef.current);
+		};
+	}, []);
 
 	useEffect(() => {
 		// Load API key from localStorage
@@ -41,7 +48,8 @@ export function useApiKey(): UseApiKeyReturn {
 		if (success) {
 			setCopied(true);
 			toast.success("API key copied to clipboard");
-			setTimeout(() => {
+			if (copyTimerRef.current) clearTimeout(copyTimerRef.current);
+			copyTimerRef.current = setTimeout(() => {
 				setCopied(false);
 			}, 2000);
 		} else {


### PR DESCRIPTION
This PR fixes a bug where `setTimeout` timers were not cleared upon component unmount after a user initiates a copy action. It tracks the timeouts using `useRef` and clears them in a `useEffect` cleanup function, preventing state updates on unmounted components and avoiding memory leaks.

## Description

Updated `surfsense_web/hooks/use-api-key.ts` and `surfsense_web/components/report-panel/report-panel.tsx` to handle the "Copied" status timeouts appropriately:
- Added a `useRef` (`copyTimerRef`) to store the ID of the `setTimeout` function.  
- Added logic to `clearTimeout` before setting a new one to prevent multiple timers overlapping during rapid back-to-back clicks.  
- Added a `useEffect` cleanup function that calls `clearTimeout(copyTimerRef.current)` when the component unmounts.

## Motivation and Context

When a user copies their API key or report content, a visual feedback timer is started using `setTimeout(() => setCopied(false), 2000)`. If the user immediately navigates away from the page, the component unmounts, but the timer is still active, causing a React state update on an unmounted component. This PR resolves the issue and ensures that rapid clicks and component unmounting are handled safely.

FIX #1095

## API Changes

- [ ] This PR includes API changes

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Dependency/Build system
- [ ] Breaking change
- [ ] Other (specify):

## Testing Performed
- [x] Tested locally
- [x] Manual/QA verification

## Checklist
- [x] Follows project coding standards and conventions
- [ ] Documentation updated as needed
- [ ] Dependencies updated as needed
- [x] No lint/build errors or new warnings
- [x] All relevant tests are passing

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a memory leak where `setTimeout` timers were not being cleaned up when components unmount. Two components that provide "Copied" visual feedback after copy actions (`use-api-key` hook and `report-panel` component) now use `useRef` to track timer IDs and clear them in `useEffect` cleanup functions. The fix also prevents multiple overlapping timers during rapid consecutive copy clicks.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/hooks/use-api-key.ts` |
| 2 | `surfsense_web/components/report-panel/report-panel.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/74f9e7fa0d83d67e674bb782cdf578a0cf1e9e0090dd92e854d069b1d8671e86/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=1123)
<!-- RECURSEML_SUMMARY:END -->