### PR TITLE
fix(react): Clear setTimeout on unmount to prevent setState on unmounted component

### DIFF
--- a/surfsense_web/components/report-panel/report-panel.tsx
+++ b/surfsense_web/components/report-panel/report-panel.tsx
@@ -140,6 +140,14 @@ export function ReportPanelContent({
 		setActiveReportId(reportId);
 	}, [reportId]);
 
+	// Clear copied state after 2 seconds
+	useEffect(() => {
+		if (copied) {
+			const timer = setTimeout(() => setCopied(false), 2000);
+			return () => clearTimeout(timer);
+		}
+	}, [copied]);
+
 	// Fetch report content (re-runs when activeReportId changes for version switching)
 	useEffect(() => {
 		let cancelled = false;
@@ -197,7 +205,6 @@ export function ReportPanelContent({
 		try {
 			await navigator.clipboard.writeText(currentMarkdown);
 			setCopied(true);
-			setTimeout(() => setCopied(false), 2000);
 		} catch (err) {
 			console.error("Failed to copy:", err);
 		}

--- a/surfsense_web/hooks/use-api-key.ts
+++ b/surfsense_web/hooks/use-api-key.ts
@@ -15,6 +15,14 @@ export function useApiKey(): UseApiKeyReturn {
 	const [copied, setCopied] = useState(false);
 	const [isLoading, setIsLoading] = useState(true);
 
+	// Clear copied state after 2 seconds
+	useEffect(() => {
+		if (copied) {
+			const timer = setTimeout(() => setCopied(false), 2000);
+			return () => clearTimeout(timer);
+		}
+	}, [copied]);
+
 	useEffect(() => {
 		// Load API key from localStorage
 		const loadApiKey = () => {
@@ -41,9 +49,6 @@ export function useApiKey(): UseApiKeyReturn {
 		if (success) {
 			setCopied(true);
 			toast.success("API key copied to clipboard");
-			setTimeout(() => {
-				setCopied(false);
-			}, 2000);
 		} else {
 			toast.error("Failed to copy API key");
 		}


### PR DESCRIPTION
## Summary
Clears setTimeout timers on component unmount to prevent the React warning "setState on unmounted component".

## Changes

### 1. `surfsense_web/hooks/use-api-key.ts`
- Added useEffect to manage copied state with automatic cleanup
- The timer now clears when the component unmounts

### 2. `surfsense_web/components/report-panel/report-panel.tsx`
- Same pattern: useEffect manages the copied state
- Timer clears on unmount via return function

## Why This Fixes The Issue
Previously, when a user copied something and navigated away within 2 seconds, `setCopied(false)` would fire on an unmounted component, causing a React warning. The fix adds proper cleanup in the useEffect return function.

## Testing
The functionality remains identical - the copied indicator still shows for 2 seconds. The only difference is proper cleanup on unmount.

Fixes #1095

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a React warning by properly cleaning up `setTimeout` timers when components unmount. Both files move inline `setTimeout` calls that set `copied` state to false into dedicated `useEffect` hooks with cleanup functions. This prevents attempts to update state on unmounted components when users navigate away within 2 seconds of copying content.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/hooks/use-api-key.ts` |
| 2 | `surfsense_web/components/report-panel/report-panel.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/716a169c502a025661e04bc627ae6c4e214daeaae8009ef9c36cb0d1ab9a1345/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=1125)
<!-- RECURSEML_SUMMARY:END -->