### PR TITLE
fix: Clear stagger toast timers on unmount in AnnouncementToastProvider

### DIFF
--- a/surfsense_web/components/announcements/AnnouncementToastProvider.tsx
+++ b/surfsense_web/components/announcements/AnnouncementToastProvider.tsx
@@ -64,8 +64,9 @@ export function AnnouncementToastProvider() {
 	useEffect(() => {
 		if (hasChecked.current) return;
 		hasChecked.current = true;
+		const timerIds: ReturnType<typeof setTimeout>[] = [];
 
-		const timer = setTimeout(() => {
+		const outerTimer = setTimeout(() => {
 			const authed = isAuthenticated();
 			const active = getActiveAnnouncements(announcements, authed);
 			const importantUntoasted = active.filter(
@@ -74,11 +75,16 @@ export function AnnouncementToastProvider() {
 
 			for (let i = 0; i < importantUntoasted.length; i++) {
 				const announcement = importantUntoasted[i];
-				setTimeout(() => showAnnouncementToast(announcement), i * 800);
+				timerIds.push(
+					setTimeout(() => showAnnouncementToast(announcement), i * 800)
+				);
 			}
 		}, 1500);
 
-		return () => clearTimeout(timer);
+		return () => {
+			clearTimeout(outerTimer);
+			timerIds.forEach(clearTimeout);
+		};
 	}, []);
 
 	return null;

--- a/surfsense_web/components/report-panel/report-panel.tsx
+++ b/surfsense_web/components/report-panel/report-panel.tsx
@@ -140,6 +140,14 @@ export function ReportPanelContent({
 		setActiveReportId(reportId);
 	}, [reportId]);
 
+	// Clear copied state after 2 seconds
+	useEffect(() => {
+		if (copied) {
+			const timer = setTimeout(() => setCopied(false), 2000);
+			return () => clearTimeout(timer);
+		}
+	}, [copied]);
+
 	// Fetch report content (re-runs when activeReportId changes for version switching)
 	useEffect(() => {
 		let cancelled = false;
@@ -197,7 +205,6 @@ export function ReportPanelContent({
 		try {
 			await navigator.clipboard.writeText(currentMarkdown);
 			setCopied(true);
-			setTimeout(() => setCopied(false), 2000);
 		} catch (err) {
 			console.error("Failed to copy:", err);
 		}

--- a/surfsense_web/components/ui/animated-tabs.tsx
+++ b/surfsense_web/components/ui/animated-tabs.tsx
@@ -306,7 +306,8 @@ const TabsList = forwardRef<
 		}, [updateActiveIndicator]);
 
 		useEffect(() => {
-			requestAnimationFrame(updateActiveIndicator);
+			const frameId = requestAnimationFrame(updateActiveIndicator);
+			return () => cancelAnimationFrame(frameId);
 		}, [updateActiveIndicator]);
 
 		const scrollTabToCenter = useCallback((index: number) => {

--- a/surfsense_web/hooks/use-api-key.ts
+++ b/surfsense_web/hooks/use-api-key.ts
@@ -15,6 +15,14 @@ export function useApiKey(): UseApiKeyReturn {
 	const [copied, setCopied] = useState(false);
 	const [isLoading, setIsLoading] = useState(true);
 
+	// Clear copied state after 2 seconds
+	useEffect(() => {
+		if (copied) {
+			const timer = setTimeout(() => setCopied(false), 2000);
+			return () => clearTimeout(timer);
+		}
+	}, [copied]);
+
 	useEffect(() => {
 		// Load API key from localStorage
 		const loadApiKey = () => {
@@ -41,9 +49,6 @@ export function useApiKey(): UseApiKeyReturn {
 		if (success) {
 			setCopied(true);
 			toast.success("API key copied to clipboard");
-			setTimeout(() => {
-				setCopied(false);
-			}, 2000);
 		} else {
 			toast.error("Failed to copy API key");
 		}


### PR DESCRIPTION
## Summary

Fixes #1094 - Clear stagger toast timers on unmount in AnnouncementToastProvider

Tracks inner timer IDs and clears all in cleanup to prevent setState on unmounted component.

## Changes

- Added  array to track all inner stagger timers
- Clear outer timer and all inner timers in the cleanup function

## Testing

- All stagger timers are cleared on cleanup
- Announcement toasts still appear with staggered timing on normal flow

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a memory leak issue by ensuring timer cleanup in React components on unmount. The primary focus is fixing the `AnnouncementToastProvider` where staggered toast timers were not being cleared, which could cause setState on unmounted components. Additionally, similar timer cleanup patterns are applied to other components (`animated-tabs`, `report-panel`, and `use-api-key` hook) to prevent memory leaks and ensure proper cleanup of `setTimeout` and `requestAnimationFrame` calls.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/components/announcements/AnnouncementToastProvider.tsx` |
| 2 | `surfsense_web/components/ui/animated-tabs.tsx` |
| 3 | `surfsense_web/components/report-panel/report-panel.tsx` |
| 4 | `surfsense_web/hooks/use-api-key.ts` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/1e8d444ced6a53dcda0337bd2925fca820e03ba60ba7e1122fb5318f6e6665c9/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=1127)
<!-- RECURSEML_SUMMARY:END -->