### PR TITLE
fix: add cancelAnimationFrame cleanup in animated-tabs useEffect

### DIFF
--- a/surfsense_web/components/ui/animated-tabs.tsx
+++ b/surfsense_web/components/ui/animated-tabs.tsx
@@ -306,7 +306,8 @@ const TabsList = forwardRef<
 		}, [updateActiveIndicator]);
 
 		useEffect(() => {
-			requestAnimationFrame(updateActiveIndicator);
+			const frameId = requestAnimationFrame(updateActiveIndicator);
+			return () => cancelAnimationFrame(frameId);
 		}, [updateActiveIndicator]);
 
 		const scrollTabToCenter = useCallback((index: number) => {


### PR DESCRIPTION
## Summary

- Added proper cleanup for `requestAnimationFrame` in `animated-tabs.tsx`
- Fixes issue #1093

## Changes

- Store the frame ID returned by `requestAnimationFrame`
- Return a cleanup function that calls `cancelAnimationFrame(frameId)` to prevent memory leaks

## Testing

- Tab indicator still animates correctly when switching tabs
- No console errors when component unmounts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds proper cleanup for `requestAnimationFrame` in the animated tabs component by storing the frame ID and calling `cancelAnimationFrame` when the component unmounts, preventing potential memory leaks.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/components/ui/animated-tabs.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/3c68b2af156528cd5eb1e3f529e4e20eac9f8f539291c8c8795ea6c00345ea98/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=1131)
<!-- RECURSEML_SUMMARY:END -->