### PR TITLE
fix: clear stagger toast timers on unmount in AnnouncementToastProvider

### DIFF
--- a/surfsense_web/components/announcements/AnnouncementToastProvider.tsx
+++ b/surfsense_web/components/announcements/AnnouncementToastProvider.tsx
@@ -65,6 +65,8 @@ export function AnnouncementToastProvider() {
 		if (hasChecked.current) return;
 		hasChecked.current = true;
 
+		const staggerTimers: ReturnType<typeof setTimeout>[] = [];
+
 		const timer = setTimeout(() => {
 			const authed = isAuthenticated();
 			const active = getActiveAnnouncements(announcements, authed);
@@ -74,11 +76,18 @@ export function AnnouncementToastProvider() {
 
 			for (let i = 0; i < importantUntoasted.length; i++) {
 				const announcement = importantUntoasted[i];
-				setTimeout(() => showAnnouncementToast(announcement), i * 800);
+				const staggerId = setTimeout(
+					() => showAnnouncementToast(announcement),
+					i * 800
+				);
+				staggerTimers.push(staggerId);
 			}
 		}, 1500);
 
-		return () => clearTimeout(timer);
+		return () => {
+			clearTimeout(timer);
+			staggerTimers.forEach((id) => clearTimeout(id));
+		};
 	}, []);
 
 	return null;


### PR DESCRIPTION
## Fixes #1094

### Problem
The stagger `setTimeout` calls inside the `for` loop in `AnnouncementToastProvider` were never cleared on component unmount. The outer `setTimeout` was cleared, but any inner timers (i * 800ms each) could still fire after the component was gone, causing potential `setState` on unmounted component warnings.

### Fix
- Added a `staggerTimers` array to track all inner `setTimeout` IDs
- Cleanup function now clears both the outer timer AND all stagger timers

### Impact
- Prevents React warnings when user navigates away before all announcement toasts fire
- No behavioral change — toasts still stagger at 800ms intervals as before

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a memory leak in the `AnnouncementToastProvider` component by properly clearing all staggered toast timers on unmount. Previously, only the outer setTimeout was cleared, but the inner staggered timers (which show announcement toasts at 800ms intervals) could still fire after component unmount, causing React warnings about setState on unmounted components. The fix introduces a `staggerTimers` array to track all timer IDs and clears them in the cleanup function.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/components/announcements/AnnouncementToastProvider.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/b02a0ec7bd0bae5c25aa8458c96a8ffb65931f68e94f91762a49e9c92da2f0d6/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=1132)
<!-- RECURSEML_SUMMARY:END -->