### PR TITLE
fix: clear scroll-to-citation setTimeouts on panel close/unmount in source-detail-panel

### DIFF
--- a/surfsense_web/components/announcements/AnnouncementToastProvider.tsx
+++ b/surfsense_web/components/announcements/AnnouncementToastProvider.tsx
@@ -65,6 +65,8 @@ export function AnnouncementToastProvider() {
 		if (hasChecked.current) return;
 		hasChecked.current = true;
 
+		const staggerTimers: ReturnType<typeof setTimeout>[] = [];
+
 		const timer = setTimeout(() => {
 			const authed = isAuthenticated();
 			const active = getActiveAnnouncements(announcements, authed);
@@ -74,11 +76,18 @@ export function AnnouncementToastProvider() {
 
 			for (let i = 0; i < importantUntoasted.length; i++) {
 				const announcement = importantUntoasted[i];
-				setTimeout(() => showAnnouncementToast(announcement), i * 800);
+				const staggerId = setTimeout(
+					() => showAnnouncementToast(announcement),
+					i * 800
+				);
+				staggerTimers.push(staggerId);
 			}
 		}, 1500);
 
-		return () => clearTimeout(timer);
+		return () => {
+			clearTimeout(timer);
+			staggerTimers.forEach((id) => clearTimeout(id));
+		};
 	}, []);
 
 	return null;

--- a/surfsense_web/components/new-chat/source-detail-panel.tsx
+++ b/surfsense_web/components/new-chat/source-detail-panel.tsx
@@ -274,6 +274,9 @@ export function SourceDetailPanel({
 		[shouldReduceMotion]
 	);
 
+	// Track stagger scroll timers so they can be cleared on close/unmount
+	const scrollTimersRef = useRef<ReturnType<typeof setTimeout>[]>([]);
+
 	// Callback ref for the cited chunk - scrolls when the element mounts
 	const citedChunkRefCallback = useCallback(
 		(node: HTMLDivElement | null) => {
@@ -312,32 +315,41 @@ export function SourceDetailPanel({
 				// Each subsequent scroll will correct for any layout shifts
 				const scrollAttempts = [50, 150, 300, 600, 1000];
 
+				// Track all timeout IDs so they can be cleared on close/unmount
 				scrollAttempts.forEach((delay) => {
-					setTimeout(() => {
+					const id = setTimeout(() => {
 						scrollToCitedChunk();
 					}, delay);
+					scrollTimersRef.current.push(id);
 				});
 
 				// After final attempt, mark state as scrolled
-				setTimeout(
+				const doneTimer = setTimeout(
 					() => {
 						setHasScrolledToCited(true);
 						setActiveChunkIndex(citedChunkIndex);
 					},
 					scrollAttempts[scrollAttempts.length - 1] + 50
 				);
+				scrollTimersRef.current.push(doneTimer);
 			}
 		},
 		[open, citedChunkIndex]
 	);
 
-	// Reset scroll state when panel closes
+	// Clear scroll timers and reset scroll state when panel closes
 	useEffect(() => {
 		if (!open) {
+			scrollTimersRef.current.forEach(clearTimeout);
+			scrollTimersRef.current = [];
 			hasScrolledRef.current = false;
 			setHasScrolledToCited(false);
 			setActiveChunkIndex(null);
 		}
+		return () => {
+			scrollTimersRef.current.forEach(clearTimeout);
+			scrollTimersRef.current = [];
+		};
 	}, [open]);
 
 	// Handle escape key


### PR DESCRIPTION
## Fixes #1092

### Problem
The stagger `setTimeout` calls (50ms, 150ms, 300ms, 600ms, 1000ms) and the final state-update timer in `source-detail-panel.tsx` were never cleared when the panel was closed or unmounted. This causes React warnings about setState on unmounted components when the user closes the panel before all scroll attempts fire.

### Fix
- Added `scrollTimersRef` to track all timeout IDs
- All scroll timers and the done timer are pushed into the ref
- Cleanup runs when `open` becomes false AND on component unmount

### Impact
- Eliminates React setState warnings for closed/unmounted panel
- No behavioral change — scroll-to-cited still works identically when panel stays open

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a memory leak and React setState warning issue by properly cleaning up `setTimeout` timers when components close or unmount. The main fix targets the `source-detail-panel` component where multiple staggered scroll timers (50ms, 150ms, 300ms, 600ms, 1000ms) were not being cleared, causing React warnings when users closed the panel before all timers fired. The solution tracks all timeout IDs in a ref and clears them both when the panel closes and on component unmount. A similar fix is also applied to the `AnnouncementToastProvider` component.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/components/new-chat/source-detail-panel.tsx` |
| 2 | `surfsense_web/components/announcements/AnnouncementToastProvider.tsx` |
</details>

<details>
<summary>⚠️ Inconsistent Changes Detected</summary>

| File Path | Warning |
|-----------|---------|
| `surfsense_web/components/announcements/AnnouncementToastProvider.tsx` | The PR title and description specifically mention fixing scroll-to-citation timeouts in source-detail-panel, but this file contains unrelated changes to announcement toast stagger timers |
</details>

[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/def1a3721697cbcc271c1fe0c336b84f3b87148d80150b2811352b473823e87c/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=1133)
<!-- RECURSEML_SUMMARY:END -->