### PR TITLE
perf: add passive option to scroll and touch event listeners

### DIFF
--- a/surfsense_web/components/homepage/navbar.tsx
+++ b/surfsense_web/components/homepage/navbar.tsx
@@ -32,7 +32,7 @@ export const Navbar = ({ scrolledBgClassName }: NavbarProps = {}) => {
 		};
 
 		handleScroll();
-		window.addEventListener("scroll", handleScroll);
+		window.addEventListener("scroll", handleScroll, { passive: true });
 		return () => window.removeEventListener("scroll", handleScroll);
 	}, []);
 
@@ -132,7 +132,7 @@ const MobileNav = ({ navItems, isScrolled, scrolledBgClassName }: any) => {
 		};
 
 		document.addEventListener("mousedown", handleClickOutside);
-		document.addEventListener("touchstart", handleClickOutside);
+		document.addEventListener("touchstart", handleClickOutside, { passive: true });
 		return () => {
 			document.removeEventListener("mousedown", handleClickOutside);
 			document.removeEventListener("touchstart", handleClickOutside);

--- a/surfsense_web/components/onboarding-tour.tsx
+++ b/surfsense_web/components/onboarding-tour.tsx
@@ -602,11 +602,11 @@ export function OnboardingTour() {
 		};
 
 		window.addEventListener("resize", handleUpdate);
-		window.addEventListener("scroll", handleUpdate, true);
+		window.addEventListener("scroll", handleUpdate, { capture: true, passive: true });
 
 		return () => {
 			window.removeEventListener("resize", handleUpdate);
-			window.removeEventListener("scroll", handleUpdate, true);
+			window.removeEventListener("scroll", handleUpdate, { capture: true });
 		};
 	}, [isActive, targetEl, currentStep?.placement]);
 


### PR DESCRIPTION
## Summary

Added `{ passive: true }` to scroll and touch event listeners across 2 components. These handlers never call `preventDefault()`, so marking them passive lets the browser scroll without waiting for the handler to complete.

## Changes

**`surfsense_web/components/homepage/navbar.tsx`**:
- `scroll` listener on window (navbar scroll detection): added `{ passive: true }`
- `touchstart` listener on document (click-outside detection): added `{ passive: true }`

**`surfsense_web/components/onboarding-tour.tsx`**:
- `scroll` listener on window with capture: changed from `true` to `{ capture: true, passive: true }`
- Updated matching `removeEventListener` to use `{ capture: true }` object form for consistency

## Testing

These are event listener option changes only. No handler logic was modified. The passive flag is safe here because none of these handlers call `preventDefault()`.

Fixes #1053

This contribution was developed with AI assistance (Claude Code).

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR improves scrolling performance by adding the `passive: true` option to scroll and touch event listeners in the navbar and onboarding tour components. Since these event handlers never call `preventDefault()`, marking them as passive allows the browser to optimize scrolling by not waiting for the JavaScript handlers to complete before rendering.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/components/homepage/navbar.tsx` |
| 2 | `surfsense_web/components/onboarding-tour.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/47a1d843b2dd035b78707ae8b89145ffc6549da5801b76f4aad1894bb41c61b2/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=1135)
<!-- RECURSEML_SUMMARY:END -->

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds the `{ passive: true }` option to scroll and touch event listeners in the navbar and onboarding tour components to improve scrolling performance. By marking these listeners as passive, the browser can optimize rendering without waiting for JavaScript handlers to complete, since none of these handlers call `preventDefault()`. The changes also update the `removeEventListener` calls in the onboarding tour to use the object form for consistency with the updated `addEventListener` syntax.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/components/homepage/navbar.tsx` |
| 2 | `surfsense_web/components/onboarding-tour.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->