### PR TITLE
fix: add cancelAnimationFrame cleanup in animated-tabs useEffect

### DIFF
--- a/surfsense_web/components/ui/animated-tabs.tsx
+++ b/surfsense_web/components/ui/animated-tabs.tsx
@@ -310,7 +310,8 @@ const TabsList = forwardRef<
 		}, [updateActiveIndicator]);
 
 		useEffect(() => {
-			requestAnimationFrame(updateActiveIndicator);
+			const id = requestAnimationFrame(updateActiveIndicator);
+			return () => cancelAnimationFrame(id);
 		}, [updateActiveIndicator]);
 
 		const scrollTabToCenter = useCallback((index: number) => {


### PR DESCRIPTION
## Description

Stores the `requestAnimationFrame` ID and cancels it in the useEffect cleanup. Without this, `updateActiveIndicator` can fire after the component unmounts.

## Motivation and Context

FIX #1093

## API Changes
- [ ] This PR includes API changes

## Change Type
- [x] Bug fix

## Testing Performed
- [x] Verified the cleanup return is correctly structured

## Checklist
- [x] Follows project coding standards and conventions
- [x] No lint/build errors or new warnings
- [x] All relevant tests are passing

This contribution was developed with AI assistance (Claude Code).

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a memory leak in the animated tabs component by adding proper cleanup for `requestAnimationFrame`. The change stores the animation frame ID and cancels it when the component unmounts, preventing `updateActiveIndicator` from executing after unmounting.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/components/ui/animated-tabs.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/1f90a5fe6dfafdf8b9001e7542b4e6ffb08bb359f4f5485b9200a3dd06ad75cd/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=1184)
<!-- RECURSEML_SUMMARY:END -->