### PR TITLE
perf: remove react-dom/server from client bundle

### DIFF
--- a/surfsense_web/components/assistant-ui/inline-mention-editor.tsx
+++ b/surfsense_web/components/assistant-ui/inline-mention-editor.tsx
@@ -10,10 +10,20 @@ import {
 	useRef,
 	useState,
 } from "react";
-import ReactDOMServer from "react-dom/server";
+import { flushSync } from "react-dom";
+import { createRoot } from "react-dom/client";
 import { getConnectorIcon } from "@/contracts/enums/connectorIcons";
 import type { Document } from "@/contracts/types/document.types";
 import { cn } from "@/lib/utils";
+
+function renderToHTML(element: React.ReactElement): string {
+	const container = document.createElement("div");
+	const root = createRoot(container);
+	flushSync(() => root.render(element));
+	const html = container.innerHTML;
+	root.unmount();
+	return html;
+}
 
 export interface MentionedDocument {
 	id: number;
@@ -213,7 +223,7 @@ export const InlineMentionEditor = forwardRef<InlineMentionEditorRef, InlineMent
 
 				const iconSpan = document.createElement("span");
 				iconSpan.className = "flex items-center text-muted-foreground";
-				iconSpan.innerHTML = ReactDOMServer.renderToString(
+				iconSpan.innerHTML = renderToHTML(
 					getConnectorIcon(doc.document_type ?? "UNKNOWN", "h-3 w-3")
 				);
 
@@ -222,7 +232,7 @@ export const InlineMentionEditor = forwardRef<InlineMentionEditorRef, InlineMent
 				removeBtn.className =
 					"size-3 items-center justify-center rounded-full text-muted-foreground transition-colors";
 				removeBtn.style.display = "none";
-				removeBtn.innerHTML = ReactDOMServer.renderToString(
+				removeBtn.innerHTML = renderToHTML(
 					createElement(X, { className: "h-3 w-3", strokeWidth: 2.5 })
 				);
 				removeBtn.onclick = (e) => {


### PR DESCRIPTION
## Summary

- Replace `ReactDOMServer.renderToString` with a client-side `renderToHTML` helper using `createRoot` + `flushSync`
- Removes the entire `react-dom/server` runtime from the client JS bundle

## Why

`inline-mention-editor.tsx` imports `react-dom/server` just to render two small icon elements (connector icon + X close button) to HTML strings. Since this file is imported by `thread.tsx` (the main chat component), `react-dom/server` gets loaded on every chat page.

`react-dom` and `react-dom/client` are already in the client bundle (used by React itself), so the replacement adds zero new bundle weight.

## Changes

```tsx
// Before
import ReactDOMServer from "react-dom/server";
iconSpan.innerHTML = ReactDOMServer.renderToString(/* ... */);

// After
import { flushSync } from "react-dom";
import { createRoot } from "react-dom/client";

function renderToHTML(element: React.ReactElement): string {
  const container = document.createElement("div");
  const root = createRoot(container);
  flushSync(() => root.render(element));
  const html = container.innerHTML;
  root.unmount();
  return html;
}
iconSpan.innerHTML = renderToHTML(/* ... */);
```

## Test Plan

- [ ] Mention chips display the correct connector icon
- [ ] X close button appears on hover
- [ ] Clicking X removes the chip
- [ ] `next build` succeeds

Fixes #1189

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR removes `react-dom/server` from the client bundle by replacing `ReactDOMServer.renderToString` with a custom `renderToHTML` helper that uses `createRoot` and `flushSync` from `react-dom/client`. The change targets the inline mention editor component where server-side rendering was being used client-side just to convert small icon elements to HTML strings, eliminating unnecessary bundle weight since `react-dom/client` is already present in the bundle.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/components/assistant-ui/inline-mention-editor.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/5ad5838b58d28c8889aeeff840ab662857f373421deec58dab22a67e48688f5d/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=1204)
<!-- RECURSEML_SUMMARY:END -->