### PR TITLE
fix: add missing imports causing mobile citation crash

### DIFF
--- a/surfsense_web/components/assistant-ui/assistant-message.tsx
+++ b/surfsense_web/components/assistant-ui/assistant-message.tsx
@@ -32,6 +32,7 @@ import { TooltipIconButton } from "@/components/assistant-ui/tooltip-icon-button
 import { CommentPanelContainer } from "@/components/chat-comments/comment-panel-container/comment-panel-container";
 import { CommentSheet } from "@/components/chat-comments/comment-sheet/comment-sheet";
 import type { SerializableCitation } from "@/components/tool-ui/citation";
+import { openSafeNavigationHref, resolveSafeNavigationHref } from "@/components/tool-ui/shared/media";
 import {
 	Drawer,
 	DrawerContent,


### PR DESCRIPTION
## Summary

`MobileCitationDrawer` in `assistant-message.tsx` calls `resolveSafeNavigationHref()` and `openSafeNavigationHref()` (lines 262-263) but neither function is imported. This causes a `ReferenceError` crash when mobile users tap a citation source link.

## Root Cause

Both functions are exported from `@/components/tool-ui/shared/media` and correctly imported in `citation.tsx` and `citation-list.tsx`, but the import was missed when `MobileCitationDrawer` was added to `assistant-message.tsx`.

## Fix

Add the missing import:
```typescript
import { openSafeNavigationHref, resolveSafeNavigationHref } from "@/components/tool-ui/shared/media";
```

## Test Plan

- [ ] Open a chat with citations on a mobile device (or narrow viewport)
- [ ] Tap a citation source link in the drawer
- [ ] Verify navigation works instead of crashing

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a critical bug where mobile users experienced crashes when tapping citation source links. The issue was caused by missing imports for `openSafeNavigationHref` and `resolveSafeNavigationHref` functions that were being called in the `MobileCitationDrawer` component but never imported from the `@/components/tool-ui/shared/media` module. The fix simply adds the required import statement.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/components/assistant-ui/assistant-message.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/3e9956187ed33000f27033bb1c89edab1c1f61393db28e2c996f0f5f952c14ac/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=1205)
<!-- RECURSEML_SUMMARY:END -->