### PR TITLE
feat: migrate GitHub stars fetch to TanStack Query

### DIFF
--- a/surfsense_web/components/homepage/github-stars-badge.tsx
+++ b/surfsense_web/components/homepage/github-stars-badge.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import { IconBrandGithub } from "@tabler/icons-react";
+import { useQuery } from "@tanstack/react-query";
 import { motion, useMotionValue, useSpring } from "motion/react";
 import * as React from "react";
 import { cn } from "@/lib/utils";
+import { cacheKeys } from "@/lib/query-client/cache-keys";
 
 // ---------------------------------------------------------------------------
 // Per-digit scrolling wheel
@@ -243,28 +245,21 @@ function NavbarGitHubStars({
 	href = "https://github.com/MODSetter/SurfSense",
 	className,
 }: NavbarGitHubStarsProps) {
-	const [stars, setStars] = React.useState(0);
-	const [isLoading, setIsLoading] = React.useState(true);
-
-	React.useEffect(() => {
-		const abortController = new AbortController();
-		fetch(`https://api.github.com/repos/${username}/${repo}`, {
-			signal: abortController.signal,
-		})
-			.then((res) => res.json())
-			.then((data) => {
-				if (data && typeof data.stargazers_count === "number") {
-					setStars(data.stargazers_count);
-				}
-			})
-			.catch((err) => {
-				if (err instanceof Error && err.name !== "AbortError") {
-					console.error("Error fetching stars:", err);
-				}
-			})
-			.finally(() => setIsLoading(false));
-		return () => abortController.abort();
-	}, [username, repo]);
+	const { data: stars = 0, isLoading } = useQuery({
+		queryKey: cacheKeys.github.repoStars(username, repo),
+		queryFn: async ({ signal }) => {
+			const res = await fetch(
+				`https://api.github.com/repos/${username}/${repo}`,
+				{ signal },
+			);
+			const data = await res.json();
+			if (data && typeof data.stargazers_count === "number") {
+				return data.stargazers_count as number;
+			}
+			return 0;
+		},
+		staleTime: 5 * 60 * 1000,
+	});
 
 	return (
 		<a

--- a/surfsense_web/lib/query-client/cache-keys.ts
+++ b/surfsense_web/lib/query-client/cache-keys.ts
@@ -91,6 +91,10 @@ export const cacheKeys = {
 	publicChat: {
 		byToken: (shareToken: string) => ["public-chat", shareToken] as const,
 	},
+	github: {
+		repoStars: (username: string, repo: string) =>
+			["github", "repo-stars", username, repo] as const,
+	},
 	publicChatSnapshots: {
 		all: ["public-chat-snapshots"] as const,
 		bySearchSpace: (searchSpaceId: number) =>


### PR DESCRIPTION
Replaces the manual `useEffect` + `fetch` pattern in `NavbarGitHubStars` with `useQuery` from `@tanstack/react-query`, matching how the rest of the codebase handles data fetching.

**What changed:**
- `github-stars-badge.tsx`: Replaced `useState` + `useEffect` + manual `AbortController` with a single `useQuery` call. The abort signal is provided by TanStack Query automatically. Added a 5-minute `staleTime` so the star count isn't re-fetched on every navigation.
- `cache-keys.ts`: Added `github.repoStars` cache key for the query.

**Note:** The `useLatestRelease` hook in `hero-section.tsx` mentioned in #1198 has already been removed from the codebase, so only the stars badge needed migration.

Closes #1198

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR migrates the GitHub stars fetching logic from a manual `useEffect` and `fetch` pattern to TanStack Query's `useQuery` hook, aligning with the codebase's standard data fetching approach. The change introduces a cache key for the GitHub stars query and adds a 5-minute `staleTime` to reduce unnecessary API calls during navigation. The migration simplifies the component by removing manual state management and `AbortController` handling, which TanStack Query provides automatically.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/lib/query-client/cache-keys.ts` |
| 2 | `surfsense_web/components/homepage/github-stars-badge.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyzing latest changes...](https://img.shields.io/badge/Analyzing%20latest%20changes...-lightgray?style=plastic)](https://github.com/MODSetter/SurfSense/pull/1213)
<!-- RECURSEML_SUMMARY:END -->