### PR TITLE
feat: migrate GitHub stars fetch to TanStack Query

### DIFF
--- a/surfsense_web/components/homepage/github-stars-badge.tsx
+++ b/surfsense_web/components/homepage/github-stars-badge.tsx
@@ -1,10 +1,12 @@
 "use client";
 
 import { IconBrandGithub } from "@tabler/icons-react";
+import { useQuery } from "@tanstack/react-query";
 import { motion, useMotionValue, useSpring } from "motion/react";
 import * as React from "react";
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
+import { cacheKeys } from "@/lib/query-client/cache-keys";
 
 // ---------------------------------------------------------------------------
 // Per-digit scrolling wheel
@@ -244,28 +246,21 @@ function NavbarGitHubStars({
 	href = "https://github.com/MODSetter/SurfSense",
 	className,
 }: NavbarGitHubStarsProps) {
-	const [stars, setStars] = React.useState(0);
-	const [isLoading, setIsLoading] = React.useState(true);
-
-	React.useEffect(() => {
-		const abortController = new AbortController();
-		fetch(`https://api.github.com/repos/${username}/${repo}`, {
-			signal: abortController.signal,
-		})
-			.then((res) => res.json())
-			.then((data) => {
-				if (data && typeof data.stargazers_count === "number") {
-					setStars(data.stargazers_count);
-				}
-			})
-			.catch((err) => {
-				if (err instanceof Error && err.name !== "AbortError") {
-					console.error("Error fetching stars:", err);
-				}
-			})
-			.finally(() => setIsLoading(false));
-		return () => abortController.abort();
-	}, [username, repo]);
+	const { data: stars = 0, isLoading } = useQuery({
+		queryKey: cacheKeys.github.repoStars(username, repo),
+		queryFn: async ({ signal }) => {
+			const res = await fetch(
+				`https://api.github.com/repos/${username}/${repo}`,
+				{ signal },
+			);
+			const data = await res.json();
+			if (data && typeof data.stargazers_count === "number") {
+				return data.stargazers_count as number;
+			}
+			return 0;
+		},
+		staleTime: 5 * 60 * 1000,
+	});
 
 	return (
 		<a

--- a/surfsense_web/lib/query-client/cache-keys.ts
+++ b/surfsense_web/lib/query-client/cache-keys.ts
@@ -92,6 +92,10 @@ export const cacheKeys = {
 	publicChat: {
 		byToken: (shareToken: string) => ["public-chat", shareToken] as const,
 	},
+	github: {
+		repoStars: (username: string, repo: string) =>
+			["github", "repo-stars", username, repo] as const,
+	},
 	publicChatSnapshots: {
 		all: ["public-chat-snapshots"] as const,
 		bySearchSpace: (searchSpaceId: number) =>


### PR DESCRIPTION
Replaces the manual `useEffect` + `fetch` pattern in `NavbarGitHubStars` with `useQuery` from `@tanstack/react-query`, matching how the rest of the codebase handles data fetching.

What changed:
- `github-stars-badge.tsx`: Replaced `useState` + `useEffect` + manual `AbortController` with a single `useQuery` call. The abort signal is provided by TanStack Query automatically. Added a 5-minute `staleTime` so the star count isn't re-fetched on every navigation.
- `cache-keys.ts`: Added `github.repoStars` cache key for the query.

Note: The `useLatestRelease` hook in `hero-section.tsx` mentioned in #1198 has already been removed from the codebase, so only the stars badge needed migration.

Re-submitting against `dev` per maintainer request (previously #1213 which targeted `main`).

Closes #1198

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR migrates the GitHub stars fetching logic from a manual `useEffect` and `fetch` pattern to TanStack Query's `useQuery` hook, aligning with the existing data fetching conventions in the codebase. The changes replace manual state management and abort controller handling with TanStack Query's built-in capabilities, and add a 5-minute stale time to prevent unnecessary refetches during navigation.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/lib/query-client/cache-keys.ts` |
| 2 | `surfsense_web/components/homepage/github-stars-badge.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/441caaa9a9cf294cf8382e78d5c9ba0b29587866758e1d5057e3dce278b2a905/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=1215)
<!-- RECURSEML_SUMMARY:END -->