### PR TITLE
feat: add dashboard-scoped error boundary

### DIFF
--- a/surfsense_web/app/dashboard/error.tsx
+++ b/surfsense_web/app/dashboard/error.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect } from "react";
+
+export default function DashboardError({
+	error,
+	reset,
+}: {
+	error: globalThis.Error & { digest?: string };
+	reset: () => void;
+}) {
+	useEffect(() => {
+		import("posthog-js")
+			.then(({ default: posthog }) => {
+				posthog.captureException(error);
+			})
+			.catch(() => {});
+	}, [error]);
+
+	return (
+		<div className="flex flex-1 flex-col items-center justify-center gap-4 p-8 text-center">
+			<h2 className="text-xl font-semibold">Something went wrong</h2>
+			<p className="text-muted-foreground max-w-md">
+				An error occurred in this section. Your dashboard is still available.
+			</p>
+			<div className="flex gap-2">
+				<button
+					type="button"
+					onClick={reset}
+					className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"
+				>
+					Try again
+				</button>
+				<Link
+					href="/dashboard"
+					className="rounded-md border border-input bg-background px-4 py-2 text-sm font-medium hover:bg-accent hover:text-accent-foreground transition-colors"
+				>
+					Go to dashboard home
+				</Link>
+			</div>
+		</div>
+	);
+}


### PR DESCRIPTION
## Summary

Fixes #1195 - adds a dashboard-scoped error boundary so the sidebar/navigation stay visible when a route segment under `/dashboard` throws.

## Changes

- Adds `surfsense_web/app/dashboard/error.tsx` - a `"use client"` error boundary that:
  - Renders inside the existing dashboard layout so `sidebar` and nav remain mounted
  - Calls `reset()` to retry the failed segment without a full tree re-render
  - Offers a secondary "Go to dashboard home" link for unrecoverable errors
  - Reports to PostHog using the same dynamic-import pattern as the root `surfsense_web/app/error.tsx`

Uses tabs + double quotes to match the biome config enforced in the repo.

## Testing

Visual only - added an error boundary. Confirmed it renders (Next.js App Router routes `error.tsx` automatically). Not adding a test because the root `error.tsx` has none and the behavior is framework-provided.

## Checklist

- [x] Scope is limited to the one file the issue asked for
- [x] Matches the existing PostHog pattern from root `error.tsx`
- [x] Uses existing Tailwind tokens (bg-primary, muted-foreground) - no new styling

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds a dashboard-scoped error boundary component that preserves the sidebar and navigation when errors occur within dashboard routes. The error boundary captures exceptions and reports them to PostHog, provides users with a retry mechanism via the `reset()` function, and includes a fallback link to navigate back to the dashboard home for unrecoverable errors.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/app/dashboard/error.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/8881206c81152112924acc270586ec4b1bd85a6d25213c423852f9cad48b0739/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=1220)
<!-- RECURSEML_SUMMARY:END -->