### PR TITLE
feat: improve Obsidian connector visibility and desktop sync flow

### DIFF
--- a/surfsense_web/atoms/folder-sync/folder-sync.atoms.ts
+++ b/surfsense_web/atoms/folder-sync/folder-sync.atoms.ts
@@ -1,0 +1,12 @@
+import { atom } from "jotai";
+
+export interface SelectedFolder {
+	path: string;
+	name: string;
+}
+
+// Atom to control the folder watch dialog open state
+export const folderWatchDialogOpenAtom = atom(false);
+
+// Atom to store initial folder selection for the dialog
+export const folderWatchInitialFolderAtom = atom<SelectedFolder | null>(null);

--- a/surfsense_web/components/assistant-ui/connector-popup/constants/connector-constants.ts
+++ b/surfsense_web/components/assistant-ui/connector-popup/constants/connector-constants.ts
@@ -180,9 +180,8 @@ export const OTHER_CONNECTORS = [
 	{
 		id: "obsidian-connector",
 		title: "Obsidian",
-		description: "Index your Obsidian vault (self-hosted only)",
+		description: "Index your Obsidian vault (Local folder scan on Desktop)",
 		connectorType: EnumConnectorName.OBSIDIAN_CONNECTOR,
-		selfHostedOnly: true,
 	},
 ] as const;
 

--- a/surfsense_web/components/assistant-ui/connector-popup/hooks/use-connector-dialog.ts
+++ b/surfsense_web/components/assistant-ui/connector-popup/hooks/use-connector-dialog.ts
@@ -1,5 +1,5 @@
 import { format } from "date-fns";
-import { useAtom, useAtomValue } from "jotai";
+import { useAtom, useAtomValue, useSetAtom } from "jotai";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { connectorDialogOpenAtom } from "@/atoms/connector-dialog/connector-dialog.atoms";
@@ -33,6 +33,13 @@ import {
 	OAUTH_CONNECTORS,
 	OTHER_CONNECTORS,
 } from "../constants/connector-constants";
+import { usePlatform } from "@/hooks/use-platform";
+import { isSelfHosted } from "@/lib/env-config";
+import {
+	folderWatchDialogOpenAtom,
+	folderWatchInitialFolderAtom,
+} from "@/atoms/folder-sync/folder-sync.atoms";
+
 import {
 	dateRangeSchema,
 	frequencyMinutesSchema,
@@ -61,6 +68,11 @@ export const useConnectorDialog = () => {
 	const { mutateAsync: updateConnector } = useAtomValue(updateConnectorMutationAtom);
 	const { mutateAsync: deleteConnector } = useAtomValue(deleteConnectorMutationAtom);
 	const { mutateAsync: createConnector } = useAtomValue(createConnectorMutationAtom);
+	const setFolderWatchOpen = useSetAtom(folderWatchDialogOpenAtom);
+	const setFolderWatchInitialFolder = useSetAtom(folderWatchInitialFolderAtom);
+	const { isDesktop } = usePlatform();
+	const selfHosted = isSelfHosted();
+
 
 	// Use global atom for dialog open state so it can be controlled from anywhere
 	const [isOpen, setIsOpen] = useAtom(connectorDialogOpenAtom);
@@ -440,10 +452,20 @@ export const useConnectorDialog = () => {
 	const handleConnectNonOAuth = useCallback(
 		(connectorType: string) => {
 			if (!searchSpaceId) return;
+
+			// Handle Obsidian specifically on Desktop & Cloud
+			if (connectorType === EnumConnectorName.OBSIDIAN_CONNECTOR && !selfHosted && isDesktop) {
+				setIsOpen(false);
+				setFolderWatchInitialFolder(null);
+				setFolderWatchOpen(true);
+				return;
+			}
+
 			setConnectingConnectorType(connectorType);
 		},
-		[searchSpaceId]
+		[searchSpaceId, selfHosted, isDesktop, setIsOpen, setFolderWatchOpen, setFolderWatchInitialFolder]
 	);
+
 
 	// Handle submitting connect form
 	const handleSubmitConnectForm = useCallback(

--- a/surfsense_web/components/layout/ui/sidebar/DocumentsSidebar.tsx
+++ b/surfsense_web/components/layout/ui/sidebar/DocumentsSidebar.tsx
@@ -14,6 +14,10 @@ import { deleteDocumentMutationAtom } from "@/atoms/documents/document-mutation.
 import { expandedFolderIdsAtom } from "@/atoms/documents/folder.atoms";
 import { agentCreatedDocumentsAtom } from "@/atoms/documents/ui.atoms";
 import { openEditorPanelAtom } from "@/atoms/editor/editor-panel.atom";
+import {
+	folderWatchDialogOpenAtom,
+	folderWatchInitialFolderAtom,
+} from "@/atoms/folder-sync/folder-sync.atoms";
 import { rightPanelCollapsedAtom } from "@/atoms/layout/right-panel.atom";
 import { CreateFolderDialog } from "@/components/documents/CreateFolderDialog";
 import type { DocumentNodeDoc } from "@/components/documents/DocumentNode";
@@ -104,8 +108,8 @@ export function DocumentsSidebar({
 	const debouncedSearch = useDebouncedValue(search, 250);
 	const [activeTypes, setActiveTypes] = useState<DocumentTypeEnum[]>([]);
 	const [watchedFolderIds, setWatchedFolderIds] = useState<Set<number>>(new Set());
-	const [folderWatchOpen, setFolderWatchOpen] = useState(false);
-	const [watchInitialFolder, setWatchInitialFolder] = useState<SelectedFolder | null>(null);
+	const [folderWatchOpen, setFolderWatchOpen] = useAtom(folderWatchDialogOpenAtom);
+	const [watchInitialFolder, setWatchInitialFolder] = useAtom(folderWatchInitialFolderAtom);
 	const isElectron = typeof window !== "undefined" && !!window.electronAPI;
 
 	const handleWatchLocalFolder = useCallback(async () => {
@@ -118,7 +122,8 @@ export function DocumentsSidebar({
 		const folderName = folderPath.split("/").pop() || folderPath.split("\\").pop() || folderPath;
 		setWatchInitialFolder({ path: folderPath, name: folderName });
 		setFolderWatchOpen(true);
-	}, []);
+	}, [setWatchInitialFolder, setFolderWatchOpen]);
+
 
 	const refreshWatchedIds = useCallback(async () => {
 		if (!electronAPI?.getWatchedFolders) return;


### PR DESCRIPTION
<!--- Summarize your pull request in a few sentences -->
This Pull Request improves the discoverability and user experience for Obsidian users by making the Obsidian connector visible in the standard connectors list and providing a seamless setup flow for Desktop application users.

## Description
- **[connector-constants.ts](file:///Users/oscarzhou/SurfSense/surfsense_web/components/assistant-ui/connector-popup/constants/connector-constants.ts)**: Removed the `selfHostedOnly: true` restriction from the Obsidian connector and updated its description to reflect Desktop support.
- **[use-connector-dialog.ts](file:///Users/oscarzhou/SurfSense/surfsense_web/components/assistant-ui/connector-popup/hooks/use-connector-dialog.ts)**: Implemented logic to intercept Obsidian connection requests on Desktop. When a user in Cloud mode selects Obsidian, the app now automatically triggers the local folder sync flow instead of showing the server-side configuration form.
- **[folder-sync.atoms.ts](file:///Users/oscarzhou/SurfSense/surfsense_web/atoms/folder-sync/folder-sync.atoms.ts)**: Introduced global state atoms to control the folder watch dialog, allowing it to be managed from anywhere in the UI.
- **[DocumentsSidebar.tsx](file:///Users/oscarzhou/SurfSense/surfsense_web/components/layout/ui/sidebar/DocumentsSidebar.tsx)**: Refactored the sidebar to use global folder sync atoms, ensuring consistent behavior across the application.

## Motivation and Context
Obsidian is a highly requested integration, but it was previously hidden from the connectors list for most users (those not running their own self-hosted backend). While "Watch Local Folder" already supported Obsidian vaults, it was a less discoverable feature.

This change solves the discoverability problem by putting "Obsidian" front-and-center in the integrations list and automatically routing users to the correct sync mechanism for their environment.

FIX #

## Screenshots
<!-- If applicable, add screenshots or images to demonstrate the changes visually -->

## API Changes
- [ ] This PR includes API changes

## Change Type
- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [x] Refactoring
- [ ] Documentation
- [ ] Dependency/Build system
- [ ] Breaking change
- [ ] Other (specify):

## Testing Performed
- [x] Tested locally
- [x] Manual/QA verification verified that the Obsidian connector appears for desktop users and correctly triggers the folder selection UI.

## Checklist
- [x] Follows project coding standards and conventions
- [x] Documentation updated as needed
- [x] No lint/build errors or new warnings
- [x] All relevant tests are passing

Thanks for taking a look at my PR! This was inspired by SolderingIron86's question in the help channel in the Discord server around not finding an obvious way to link Obsidian.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR improves the Obsidian integration experience by making the Obsidian connector visible to all users in the connectors list (previously hidden behind `selfHostedOnly` flag) and automatically routing Desktop users in Cloud mode to the local folder sync flow when they select Obsidian. This is achieved by introducing global state atoms for folder watch dialog management and intercepting Obsidian connection requests on Desktop to trigger the appropriate sync mechanism instead of the server-side configuration form.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/atoms/folder-sync/folder-sync.atoms.ts` |
| 2 | `surfsense_web/components/assistant-ui/connector-popup/constants/connector-constants.ts` |
| 3 | `surfsense_web/components/layout/ui/sidebar/DocumentsSidebar.tsx` |
| 4 | `surfsense_web/components/assistant-ui/connector-popup/hooks/use-connector-dialog.ts` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/1382280827847c19f9618103014a4c46341b2ccd8b941cd68adbbea6ed3ccdc8/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=1225)
<!-- RECURSEML_SUMMARY:END -->