### PR TITLE
refactor: extract duplicate TYPE_ICONS constant into shared module

### DIFF
--- a/surfsense_web/components/tool-ui/citation/citation-list.tsx
+++ b/surfsense_web/components/tool-ui/citation/citation-list.tsx
@@ -1,22 +1,13 @@
 "use client";
 
-import type { LucideIcon } from "lucide-react";
-import { Code2, Database, ExternalLink, File, FileText, Globe, Newspaper } from "lucide-react";
+import { ExternalLink, Globe } from "lucide-react";
 import NextImage from "next/image";
 import * as React from "react";
 import { openSafeNavigationHref, resolveSafeNavigationHref } from "../shared/media";
 import { cn, Popover, PopoverContent, PopoverTrigger } from "./_adapter";
 import { Citation } from "./citation";
-import type { CitationType, CitationVariant, SerializableCitation } from "./schema";
-
-const TYPE_ICONS: Record<CitationType, LucideIcon> = {
-	webpage: Globe,
-	document: FileText,
-	article: Newspaper,
-	api: Database,
-	code: Code2,
-	other: File,
-};
+import type { CitationVariant, SerializableCitation } from "./schema";
+import { TYPE_ICONS } from "./type-icons";
 
 function useHoverPopover(delay = 100) {
 	const [open, setOpen] = React.useState(false);

--- a/surfsense_web/components/tool-ui/citation/citation.tsx
+++ b/surfsense_web/components/tool-ui/citation/citation.tsx
@@ -1,23 +1,14 @@
 "use client";
 
-import type { LucideIcon } from "lucide-react";
-import { Code2, Database, ExternalLink, File, FileText, Globe, Newspaper } from "lucide-react";
+import { ExternalLink, Globe } from "lucide-react";
 import NextImage from "next/image";
 import * as React from "react";
 import { openSafeNavigationHref, sanitizeHref } from "../shared/media";
 import { cn, Popover, PopoverContent, PopoverTrigger } from "./_adapter";
-import type { CitationType, CitationVariant, SerializableCitation } from "./schema";
+import type { CitationVariant, SerializableCitation } from "./schema";
+import { TYPE_ICONS } from "./type-icons";
 
 const FALLBACK_LOCALE = "en-US";
-
-const TYPE_ICONS: Record<CitationType, LucideIcon> = {
-	webpage: Globe,
-	document: FileText,
-	article: Newspaper,
-	api: Database,
-	code: Code2,
-	other: File,
-};
 
 function extractDomain(url: string): string | undefined {
 	try {

--- a/surfsense_web/components/tool-ui/citation/type-icons.ts
+++ b/surfsense_web/components/tool-ui/citation/type-icons.ts
@@ -1,0 +1,12 @@
+import type { LucideIcon } from "lucide-react";
+import { Code2, Database, File, FileText, Globe, Newspaper } from "lucide-react";
+import type { CitationType } from "./schema";
+
+export const TYPE_ICONS: Record<CitationType, LucideIcon> = {
+	webpage: Globe,
+	document: FileText,
+	article: Newspaper,
+	api: Database,
+	code: Code2,
+	other: File,
+};


### PR DESCRIPTION
<!--- Summarize your pull request in a few sentences -->
Extract the duplicated `TYPE_ICONS` record from `citation.tsx` and `citation-list.tsx` into a new shared `type-icons.ts` module so the `CitationType` → Lucide icon mapping lives in one place.

## Description

Prior to this change, both `surfsense_web/components/tool-ui/citation/citation.tsx` (lines 13–20) and `surfsense_web/components/tool-ui/citation/citation-list.tsx` (lines 12–19) defined the exact same `TYPE_ICONS` record, with the same 6 Lucide icon imports (`Code2`, `Database`, `File`, `FileText`, `Globe`, `Newspaper`). This PR:

- Adds `surfsense_web/components/tool-ui/citation/type-icons.ts` exporting the shared `TYPE_ICONS` constant.
- Updates `citation.tsx` and `citation-list.tsx` to import `TYPE_ICONS` from the new module and drop their local copies and the icon imports only needed to build it.
- Leaves `Globe` and `ExternalLink` imports in each file where still used outside the mapping (e.g. fallback `?? Globe`, external-link affordance).

## Motivation and Context

Issue #1190 — the `TYPE_ICONS` mapping was byte-for-byte duplicated. Any change to the mapping required editing two files in lockstep.

FIX #1190

## API Changes

- [ ] This PR includes API changes

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [x] Refactoring
- [ ] Documentation
- [ ] Dependency/Build system
- [ ] Breaking change

## Testing Performed

- [x] Tested locally
  - `pnpm exec biome check components/tool-ui/citation/citation.tsx components/tool-ui/citation/citation-list.tsx components/tool-ui/citation/type-icons.ts` — clean
  - `pnpm exec tsc --noEmit` — no new type errors in the modified files (one pre-existing unrelated error in `components/assistant-ui/citation-metadata-context.tsx` remains)

## Checklist

- [x] Follows project coding standards and conventions
- [x] Documentation updated as needed (N/A, no public API change)
- [x] Dependencies updated as needed (none)
- [x] No lint/build errors or new warnings
- [x] All relevant tests are passing


[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR extracts a duplicated `TYPE_ICONS` constant that maps citation types to Lucide icons from two component files (`citation.tsx` and `citation-list.tsx`) into a new shared module (`type-icons.ts`). This eliminates code duplication and ensures the mapping is defined in a single location, making future updates easier to maintain.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/components/tool-ui/citation/type-icons.ts` |
| 2 | `surfsense_web/components/tool-ui/citation/citation.tsx` |
| 3 | `surfsense_web/components/tool-ui/citation/citation-list.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/6b6f1bd80a9f013bd0836d982555c89ea62fa606454176bc2f2c88d76df53b7b/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=1228)
<!-- RECURSEML_SUMMARY:END -->