### PR TITLE
fix(web): drop react-dom/server from inline-mention-editor bundle

### DIFF
--- a/surfsense_web/components/assistant-ui/inline-mention-editor.tsx
+++ b/surfsense_web/components/assistant-ui/inline-mention-editor.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { X } from "lucide-react";
+import type { ReactElement } from "react";
 import {
 	createElement,
 	forwardRef,
@@ -10,10 +11,26 @@ import {
 	useRef,
 	useState,
 } from "react";
-import ReactDOMServer from "react-dom/server";
+import { flushSync } from "react-dom";
+import { createRoot } from "react-dom/client";
 import { getConnectorIcon } from "@/contracts/enums/connectorIcons";
 import type { Document } from "@/contracts/types/document.types";
 import { cn } from "@/lib/utils";
+
+// Render a React element to an HTML string on the client without pulling
+// `react-dom/server` into the bundle. `createRoot` + `flushSync` use the
+// same `react-dom` package React itself imports, so this adds zero new
+// runtime weight.
+function renderElementToHTML(element: ReactElement): string {
+	const container = document.createElement("div");
+	const root = createRoot(container);
+	flushSync(() => {
+		root.render(element);
+	});
+	const html = container.innerHTML;
+	root.unmount();
+	return html;
+}
 
 export interface MentionedDocument {
 	id: number;
@@ -213,7 +230,7 @@ export const InlineMentionEditor = forwardRef<InlineMentionEditorRef, InlineMent
 
 				const iconSpan = document.createElement("span");
 				iconSpan.className = "flex items-center text-muted-foreground";
-				iconSpan.innerHTML = ReactDOMServer.renderToString(
+				iconSpan.innerHTML = renderElementToHTML(
 					getConnectorIcon(doc.document_type ?? "UNKNOWN", "h-3 w-3")
 				);
 
@@ -222,7 +239,7 @@ export const InlineMentionEditor = forwardRef<InlineMentionEditorRef, InlineMent
 				removeBtn.className =
 					"size-3 items-center justify-center rounded-full text-muted-foreground transition-colors";
 				removeBtn.style.display = "none";
-				removeBtn.innerHTML = ReactDOMServer.renderToString(
+				removeBtn.innerHTML = renderElementToHTML(
 					createElement(X, { className: "h-3 w-3", strokeWidth: 2.5 })
 				);
 				removeBtn.onclick = (e) => {


### PR DESCRIPTION
## Summary

Closes #1189.

`surfsense_web/components/assistant-ui/inline-mention-editor.tsx` was
statically importing `react-dom/server` only to call `renderToString`
twice — once for a connector icon and once for the X close button on
mention chips. Because this module is imported transitively by
`thread.tsx` (the main chat component), the entire server-rendering
runtime was being loaded into the client bundle on every chat page load.

## Change

Replace `ReactDOMServer.renderToString(...)` with a small client-side
helper that uses `createRoot` + `flushSync`:

```tsx
function renderElementToHTML(element: ReactElement): string {
  const container = document.createElement("div");
  const root = createRoot(container);
  flushSync(() => {
    root.render(element);
  });
  const html = container.innerHTML;
  root.unmount();
  return html;
}
```

`react-dom` and `react-dom/client` are already in the client bundle
(React itself imports them), so this swap adds **zero new runtime
weight** while dropping `react-dom/server` entirely.

## Testing

- `react-dom/server` is no longer imported by this file (grep confirms
  0 references in the file)
- Mention-chip icon and hover-to-X behavior rely purely on DOM string
  construction, so the helper produces equivalent output
- Please run `pnpm --filter surfsense_web build` locally to verify the
  bundle no longer contains `react-dom-server-legacy.production.min.js`
  on the chat route

## Acceptance criteria (from #1189)

- [x] `react-dom/server` is NOT imported anywhere in `inline-mention-editor.tsx`
- [ ] Mention chip icons still render correctly (needs manual verification)
- [ ] Chip remove (X) button still works (needs manual verification)
- [ ] `next build` succeeds (needs maintainer CI)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR removes the `react-dom/server` dependency from the client bundle by replacing two `ReactDOMServer.renderToString()` calls with a lightweight client-side helper function. The new `renderElementToHTML()` function uses `createRoot` and `flushSync` from `react-dom/client` (already in the bundle) to achieve the same result for rendering mention chip icons and close buttons, eliminating unnecessary server-rendering code from the chat page bundle without adding new runtime weight.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/components/assistant-ui/inline-mention-editor.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/a716ee43bd77d49c6970ae7e29deec68d9f9e680c2a336db649c645936700cc9/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=1229)
<!-- RECURSEML_SUMMARY:END -->