### PR TITLE
fix(web): memoize Zero provider opts to prevent reconnect churn

### DIFF
--- a/surfsense_web/components/providers/ZeroProvider.tsx
+++ b/surfsense_web/components/providers/ZeroProvider.tsx
@@ -6,7 +6,7 @@ import {
 	ZeroProvider as ZeroReactProvider,
 } from "@rocicorp/zero/react";
 import { useAtomValue } from "jotai";
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { currentUserAtom } from "@/atoms/user/user-query.atoms";
 import { getBearerToken, handleUnauthorized, refreshAccessToken } from "@/lib/auth-utils";
 import { queries } from "@/zero/queries";
@@ -43,19 +43,30 @@ function ZeroAuthSync() {
 export function ZeroProvider({ children }: { children: React.ReactNode }) {
 	const { data: user } = useAtomValue(currentUserAtom);
 
-	const hasUser = !!user?.id;
-	const userID = hasUser ? String(user.id) : "anon";
-	const context = hasUser ? { userId: String(user.id) } : undefined;
+	const userId = user?.id;
+	const hasUser = !!userId;
+	const userID = hasUser ? String(userId) : "anon";
+	// getBearerToken() returns a string (a primitive), so it's safe to read
+	// on every render — reference equality holds as long as the token is
+	// unchanged, which keeps the memoized `opts` below stable.
 	const auth = hasUser ? getBearerToken() || undefined : undefined;
 
-	const opts = {
-		userID,
-		schema,
-		queries,
-		context,
-		cacheURL,
-		auth,
-	};
+	const context = useMemo(
+		() => (hasUser ? { userId: String(userId) } : undefined),
+		[hasUser, userId],
+	);
+
+	const opts = useMemo(
+		() => ({
+			userID,
+			schema,
+			queries,
+			context,
+			cacheURL,
+			auth,
+		}),
+		[userID, context, auth],
+	);
 
 	return (
 		<ZeroReactProvider {...opts}>


### PR DESCRIPTION
## Summary

Closes #1097.

`ZeroProvider` rebuilt its `opts` object and its derived `context` on
every render, then spread them into `<ZeroReactProvider>`. If the
underlying Rocicorp Zero provider compares props by reference
(internally or for effect deps), that can trigger extra reconnects or
state churn every time anything above `ZeroProvider` re-renders.

## Change

Wrap `opts` and `context` in `useMemo`:

```tsx
const context = useMemo(
  () => (hasUser ? { userId: String(userId) } : undefined),
  [hasUser, userId],
);

const opts = useMemo(
  () => ({ userID, schema, queries, context, cacheURL, auth }),
  [userID, context, auth],
);
```

`auth` comes from `getBearerToken()` which returns a string (a
primitive), so reference equality already holds for unchanged tokens —
no `useMemo` needed. When the token changes, `auth` becomes a different
string and `opts` is rebuilt as expected.

`schema`, `queries`, and `cacheURL` are module-level constants so they
are already stable across renders.

## Testing

- Static analysis only — I do not have the Zero sync running locally.
  Please verify that the existing Zero sync / subscription behavior is
  unchanged for both anonymous and authenticated sessions.

## Acceptance criteria (from #1097)

- [x] `opts` is memoized with `useMemo`
- [x] `context` is a stable reference
- [x] `auth` read path unchanged (primitive comparison keeps reference
      stable without an extra `useMemo`)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a performance issue in the `ZeroProvider` component where the `opts` and `context` objects were being recreated on every render, causing unnecessary reconnections to the Zero provider. The fix wraps both objects in `useMemo` hooks with appropriate dependencies to ensure stable references across renders, preventing connection churn when parent components re-render.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/components/providers/ZeroProvider.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/81ee47dfe0519d05eb3234b5755c96a8eae82ee026a3ffd3a37a2acefbb43e64/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=1230)
<!-- RECURSEML_SUMMARY:END -->