### PR TITLE
refactor(web): extract citation TYPE_ICONS into a shared module

### DIFF
--- a/surfsense_web/components/tool-ui/citation/citation-list.tsx
+++ b/surfsense_web/components/tool-ui/citation/citation-list.tsx
@@ -1,22 +1,13 @@
 "use client";
 
-import type { LucideIcon } from "lucide-react";
-import { Code2, Database, ExternalLink, File, FileText, Globe, Newspaper } from "lucide-react";
+import { ExternalLink, Globe } from "lucide-react";
 import NextImage from "next/image";
 import * as React from "react";
 import { openSafeNavigationHref, resolveSafeNavigationHref } from "../shared/media";
 import { cn, Popover, PopoverContent, PopoverTrigger } from "./_adapter";
 import { Citation } from "./citation";
-import type { CitationType, CitationVariant, SerializableCitation } from "./schema";
-
-const TYPE_ICONS: Record<CitationType, LucideIcon> = {
-	webpage: Globe,
-	document: FileText,
-	article: Newspaper,
-	api: Database,
-	code: Code2,
-	other: File,
-};
+import type { CitationVariant, SerializableCitation } from "./schema";
+import { TYPE_ICONS } from "./type-icons";
 
 function useHoverPopover(delay = 100) {
 	const [open, setOpen] = React.useState(false);

--- a/surfsense_web/components/tool-ui/citation/citation.tsx
+++ b/surfsense_web/components/tool-ui/citation/citation.tsx
@@ -1,23 +1,14 @@
 "use client";
 
-import type { LucideIcon } from "lucide-react";
-import { Code2, Database, ExternalLink, File, FileText, Globe, Newspaper } from "lucide-react";
+import { ExternalLink, Globe } from "lucide-react";
 import NextImage from "next/image";
 import * as React from "react";
 import { openSafeNavigationHref, sanitizeHref } from "../shared/media";
 import { cn, Popover, PopoverContent, PopoverTrigger } from "./_adapter";
-import type { CitationType, CitationVariant, SerializableCitation } from "./schema";
+import type { CitationVariant, SerializableCitation } from "./schema";
+import { TYPE_ICONS } from "./type-icons";
 
 const FALLBACK_LOCALE = "en-US";
-
-const TYPE_ICONS: Record<CitationType, LucideIcon> = {
-	webpage: Globe,
-	document: FileText,
-	article: Newspaper,
-	api: Database,
-	code: Code2,
-	other: File,
-};
 
 function extractDomain(url: string): string | undefined {
 	try {

--- a/surfsense_web/components/tool-ui/citation/type-icons.ts
+++ b/surfsense_web/components/tool-ui/citation/type-icons.ts
@@ -1,0 +1,12 @@
+import type { LucideIcon } from "lucide-react";
+import { Code2, Database, File, FileText, Globe, Newspaper } from "lucide-react";
+import type { CitationType } from "./schema";
+
+export const TYPE_ICONS: Record<CitationType, LucideIcon> = {
+	webpage: Globe,
+	document: FileText,
+	article: Newspaper,
+	api: Database,
+	code: Code2,
+	other: File,
+};


### PR DESCRIPTION
## Summary

Closes #1190.

`citation.tsx` and `citation-list.tsx` each defined the same
`TYPE_ICONS: Record<CitationType, LucideIcon>` map with byte-identical
contents. Extract it into a shared `type-icons.ts` module and import
from both call sites so the mapping has a single source of truth.

## Change

New file `surfsense_web/components/tool-ui/citation/type-icons.ts`:

```ts
import type { LucideIcon } from "lucide-react";
import { Code2, Database, File, FileText, Globe, Newspaper } from "lucide-react";
import type { CitationType } from "./schema";

export const TYPE_ICONS: Record<CitationType, LucideIcon> = {
  webpage: Globe,
  document: FileText,
  article: Newspaper,
  api: Database,
  code: Code2,
  other: File,
};
```

Both `citation.tsx` and `citation-list.tsx`:

- Import `{ TYPE_ICONS }` from `"./type-icons"`
- Drop the local `TYPE_ICONS` definition
- Drop `Code2`, `Database`, `File`, `FileText`, `Newspaper` from the
  Lucide import list (no longer used in the file body)
- Drop the now-unused `LucideIcon` type import
- Drop the `CitationType` type import (no longer referenced — the one
  use site was the local `TYPE_ICONS` generic)

The only icons still imported directly by the call sites are `Globe`
(used as the `TYPE_ICONS[...] ?? Globe` fallback) and `ExternalLink`
(used for the hover affordance) — both kept.

## Testing

- Static only. Grep confirms both `Citation` and `CitationList`
  reference `TYPE_ICONS` via the same shared export and that `Globe`
  fallback + `ExternalLink` usage are preserved.
- `next build` needs maintainer CI to run — the types line up exactly
  with the old inline definition, so this should be a no-op for
  TypeScript.

## Acceptance criteria (from #1190)

- [x] `TYPE_ICONS` is defined in exactly ONE place
- [x] Both `citation.tsx` and `citation-list.tsx` import it from the
      shared module
- [x] No duplicate Lucide icon imports remain

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR extracts a duplicated `TYPE_ICONS` constant that maps citation types to Lucide icons from two component files (`citation.tsx` and `citation-list.tsx`) into a new shared module (`type-icons.ts`). Both components now import the mapping from this single source of truth, eliminating code duplication and ensuring consistency. The refactor also cleans up unused imports from the original files, keeping only the icons still needed locally (`Globe` for fallback and `ExternalLink` for UI affordance).

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/components/tool-ui/citation/type-icons.ts` |
| 2 | `surfsense_web/components/tool-ui/citation/citation.tsx` |
| 3 | `surfsense_web/components/tool-ui/citation/citation-list.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/68f4c91d254ffa5a278e122e75735fd6082884e71b4c4110355c1453a9df120d/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=1231)
<!-- RECURSEML_SUMMARY:END -->