### PR TITLE
fix: clear scroll-to-citation timers on panel close/unmount

### DIFF
--- a/surfsense_web/components/new-chat/source-detail-panel.tsx
+++ b/surfsense_web/components/new-chat/source-detail-panel.tsx
@@ -130,6 +130,7 @@ export function SourceDetailPanel({
 	const t = useTranslations("dashboard");
 	const scrollAreaRef = useRef<HTMLDivElement>(null);
 	const hasScrolledRef = useRef(false); // Use ref to avoid stale closures
+	const scrollTimersRef = useRef<ReturnType<typeof setTimeout>[]>([]);
 	const [activeChunkIndex, setActiveChunkIndex] = useState<number | null>(null);
 	const [mounted, setMounted] = useState(false);
 	const [_hasScrolledToCited, setHasScrolledToCited] = useState(false);
@@ -314,18 +315,22 @@ export function SourceDetailPanel({
 				const scrollAttempts = [50, 150, 300, 600, 1000];
 
 				scrollAttempts.forEach((delay) => {
-					setTimeout(() => {
-						scrollToCitedChunk();
-					}, delay);
+					scrollTimersRef.current.push(
+						setTimeout(() => {
+							scrollToCitedChunk();
+						}, delay)
+					);
 				});
 
 				// After final attempt, mark state as scrolled
-				setTimeout(
-					() => {
-						setHasScrolledToCited(true);
-						setActiveChunkIndex(citedChunkIndex);
-					},
-					scrollAttempts[scrollAttempts.length - 1] + 50
+				scrollTimersRef.current.push(
+					setTimeout(
+						() => {
+							setHasScrolledToCited(true);
+							setActiveChunkIndex(citedChunkIndex);
+						},
+						scrollAttempts[scrollAttempts.length - 1] + 50
+					)
 				);
 			}
 		},
@@ -335,10 +340,16 @@ export function SourceDetailPanel({
 	// Reset scroll state when panel closes
 	useEffect(() => {
 		if (!open) {
+			scrollTimersRef.current.forEach(clearTimeout);
+			scrollTimersRef.current = [];
 			hasScrolledRef.current = false;
 			setHasScrolledToCited(false);
 			setActiveChunkIndex(null);
 		}
+		return () => {
+			scrollTimersRef.current.forEach(clearTimeout);
+			scrollTimersRef.current = [];
+		};
 	}, [open]);
 
 	// Handle escape key


### PR DESCRIPTION
Stores scroll timer IDs in a ref and clears them on panel close/unmount.

## Description

`source-detail-panel.tsx` fires 6 `setTimeout` calls at staggered delays (50-1050ms) to scroll to a cited chunk. These timer IDs were never tracked. Closing the panel mid-scroll left dangling timers calling `setHasScrolledToCited` and `setActiveChunkIndex` on an unmounted component.

This PR adds a `scrollTimersRef` to collect all timer IDs, then clears them in the existing `useEffect` that handles panel close. The cleanup function also runs on unmount.

## Motivation and Context

Matches the exact fix described in #1092. The three changes:
1. `scrollTimersRef` declaration (line 133)
2. Push timer IDs in `citedChunkRefCallback` (lines 318-332)
3. Clear timers in the panel-close `useEffect` + return cleanup (lines 343-352)

FIX #1092

## Screenshots
N/A - internal cleanup, no visual change.

## API Changes
- [ ] This PR includes API changes

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Dependency/Build system
- [ ] Breaking change
- [ ] Other (specify):

## Testing Performed
- [x] Tested locally
- [x] Manual/QA verification

TypeScript compilation passes with zero errors in the modified file.

## Checklist
- [x] Follows project coding standards and conventions
- [x] Documentation updated as needed
- [x] Dependencies updated as needed
- [x] No lint/build errors or new warnings
- [x] All relevant tests are passing

This contribution was developed with AI assistance (Codex).

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a memory leak issue where multiple `setTimeout` timers were not being cleaned up when the source detail panel is closed or unmounted. The fix introduces a `scrollTimersRef` to track all timer IDs created during the scroll-to-citation animation (6 timers total with staggered delays), and ensures they are properly cleared when the panel closes or when the component unmounts. This prevents state updates (`setHasScrolledToCited` and `setActiveChunkIndex`) from being called on an unmounted component.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/components/new-chat/source-detail-panel.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/15fe1614463511bfb3441a978cec6a9d21eb0d4349eb36a503d22288e4f190f5/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=1233)
<!-- RECURSEML_SUMMARY:END -->