### PR TITLE
feat: add maxLength constraints to auth and settings form inputs

### DIFF
--- a/surfsense_web/app/(home)/login/LocalLoginForm.tsx
+++ b/surfsense_web/app/(home)/login/LocalLoginForm.tsx
@@ -158,6 +158,7 @@ export function LocalLoginForm() {
 						type="email"
 						autoComplete="username"
 						required
+						maxLength={254}
 						placeholder="you@example.com"
 						value={username}
 						onChange={(e) => setUsername(e.target.value)}

--- a/surfsense_web/app/(home)/register/page.tsx
+++ b/surfsense_web/app/(home)/register/page.tsx
@@ -237,6 +237,7 @@ export default function RegisterPage() {
 								type="email"
 								autoComplete="email"
 								required
+								maxLength={254}
 								placeholder="you@example.com"
 								value={email}
 								onChange={(e) => setEmail(e.target.value)}

--- a/surfsense_web/app/dashboard/[search_space_id]/user-settings/components/ProfileContent.tsx
+++ b/surfsense_web/app/dashboard/[search_space_id]/user-settings/components/ProfileContent.tsx
@@ -94,6 +94,7 @@ export function ProfileContent() {
 									id="display-name"
 									type="text"
 									autoComplete="name"
+									maxLength={100}
 									placeholder={user?.email?.split("@")[0]}
 									value={displayName}
 									onChange={(e) => setDisplayName(e.target.value)}

--- a/surfsense_web/components/settings/general-settings-manager.tsx
+++ b/surfsense_web/components/settings/general-settings-manager.tsx
@@ -148,6 +148,7 @@ export function GeneralSettingsManager({ searchSpaceId }: GeneralSettingsManager
 						<Label htmlFor="search-space-name">{t("general_name_label")}</Label>
 						<Input
 							id="search-space-name"
+							maxLength={100}
 							placeholder={t("general_name_placeholder")}
 							value={name}
 							onChange={(e) => setName(e.target.value)}

--- a/surfsense_web/components/settings/roles-manager.tsx
+++ b/surfsense_web/components/settings/roles-manager.tsx
@@ -876,6 +876,7 @@ function CreateRoleDialog({
 								<Label htmlFor="role-name">Role Name *</Label>
 								<Input
 									id="role-name"
+									maxLength={100}
 									placeholder="e.g., Content Manager"
 									value={name}
 									onChange={(e) => setName(e.target.value)}
@@ -885,6 +886,7 @@ function CreateRoleDialog({
 								<Label htmlFor="role-description">Description</Label>
 								<Input
 									id="role-description"
+									maxLength={500}
 									placeholder="Brief description of this role"
 									value={description}
 									onChange={(e) => setDescription(e.target.value)}
@@ -1034,6 +1036,7 @@ function EditRoleDialog({
 								<Label htmlFor="edit-role-name">Role Name *</Label>
 								<Input
 									id="edit-role-name"
+									maxLength={100}
 									placeholder="e.g., Content Manager"
 									value={name}
 									onChange={(e) => setName(e.target.value)}
@@ -1043,6 +1046,7 @@ function EditRoleDialog({
 								<Label htmlFor="edit-role-description">Description</Label>
 								<Input
 									id="edit-role-description"
+									maxLength={500}
 									placeholder="Brief description of this role"
 									value={description}
 									onChange={(e) => setDescription(e.target.value)}


### PR DESCRIPTION
Closes #948.

Follows the issue's recipe exactly; caps match Zod schema limits where they exist, email uses RFC 5321 max (254).

## Files touched (5)

| File | Input | `maxLength` |
|------|-------|-------------|
| `surfsense_web/app/(home)/login/LocalLoginForm.tsx` | email | 254 |
| `surfsense_web/app/(home)/register/page.tsx` | email | 254 |
| `surfsense_web/app/dashboard/[search_space_id]/user-settings/components/ProfileContent.tsx` | display name | 100 |
| `surfsense_web/components/settings/general-settings-manager.tsx` | search space name | 100 |
| `surfsense_web/components/settings/roles-manager.tsx` | role name (create + edit dialogs) | 100 |
| `surfsense_web/components/settings/roles-manager.tsx` | role description (create + edit dialogs) | 500 |

`roles-manager.tsx` has two dialogs (create + edit) rendering the same form, so 4 inputs get the cap instead of the 2 mentioned in the issue — same rule, applied consistently.

## Not touched (intentionally)

- Password fields — issue didn't specify a cap and the Zod schema uses `min` only
- `general-settings-manager.tsx` description — issue's table only lists search-space *name*; leaving description alone to stay within scope

## Prior art

PR #1002 by @mvanhorn attempted the same fix but was closed after merge conflicts on `dev` weren't resolved in time. This PR restarts from a fresh branch off `dev` so it's conflict-free.

## Test plan

- [x] `grep -rn 'maxLength' <touched files>` confirms 8 new attributes land
- [ ] Manual check: paste 500-char string into each capped input → input truncates at limit
- [ ] `pnpm build` in `surfsense_web/` still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds `maxLength` constraints to form inputs across authentication and settings pages to prevent users from entering data that exceeds validation limits. Email fields are capped at 254 characters (RFC 5321 standard), display names and role names at 100 characters, and role descriptions at 500 characters. These limits align with existing Zod schema validation rules where they exist.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/app/(home)/login/LocalLoginForm.tsx` |
| 2 | `surfsense_web/app/(home)/register/page.tsx` |
| 3 | `surfsense_web/app/dashboard/[search_space_id]/user-settings/components/ProfileContent.tsx` |
| 4 | `surfsense_web/components/settings/general-settings-manager.tsx` |
| 5 | `surfsense_web/components/settings/roles-manager.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/e66165a4b34e61215fa45e4742eb654ddc1759dc6490a804fe8a5ce7605ad232/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=1238)
<!-- RECURSEML_SUMMARY:END -->