### PR TITLE
fix(new-chat): remove unused _hasScrolledToCited state in source-detail-panel

### DIFF
--- a/surfsense_web/components/new-chat/source-detail-panel.tsx
+++ b/surfsense_web/components/new-chat/source-detail-panel.tsx
@@ -133,7 +133,6 @@ export function SourceDetailPanel({
 	const scrollTimersRef = useRef<ReturnType<typeof setTimeout>[]>([]);
 	const [activeChunkIndex, setActiveChunkIndex] = useState<number | null>(null);
 	const [mounted, setMounted] = useState(false);
-	const [_hasScrolledToCited, setHasScrolledToCited] = useState(false);
 	const shouldReduceMotion = useReducedMotion();
 
 	useEffect(() => {
@@ -322,11 +321,10 @@ export function SourceDetailPanel({
 					);
 				});
 
-				// After final attempt, mark state as scrolled
+				// After final attempt, mark the cited chunk as active
 				scrollTimersRef.current.push(
 					setTimeout(
 						() => {
-							setHasScrolledToCited(true);
 							setActiveChunkIndex(citedChunkIndex);
 						},
 						scrollAttempts[scrollAttempts.length - 1] + 50
@@ -343,7 +341,6 @@ export function SourceDetailPanel({
 			scrollTimersRef.current.forEach(clearTimeout);
 			scrollTimersRef.current = [];
 			hasScrolledRef.current = false;
-			setHasScrolledToCited(false);
 			setActiveChunkIndex(null);
 		}
 		return () => {


### PR DESCRIPTION
## Summary

Closes #1249. Removes the unused `_hasScrolledToCited` `useState` in `surfsense_web/components/new-chat/source-detail-panel.tsx` (Option A from the issue: delete the state entirely).

## Why this matters

The state's value was never read in render - only the setter was called (lines 329 and 346 of the pre-change file). Each call to `setHasScrolledToCited` scheduled a re-render that changed nothing visible. The actual scroll/highlight behavior is already driven by:

- `hasScrolledRef` (line 132) - for scroll-once latch
- `setActiveChunkIndex` (line 134) - for the citation highlight

## Changes

`surfsense_web/components/new-chat/source-detail-panel.tsx`:

1. Removed the `const [_hasScrolledToCited, setHasScrolledToCited] = useState(false);` declaration (was line 136).
2. Removed the `setHasScrolledToCited(true)` call inside the "after final scroll attempt" timer — the surrounding `setActiveChunkIndex(citedChunkIndex)` call in the same timer still runs, so active-chunk highlighting is preserved.
3. Removed the `setHasScrolledToCited(false)` call inside the panel-close reset effect — `hasScrolledRef.current = false` and `setActiveChunkIndex(null)` still run, so reset behaviour is preserved.
4. Updated the inline comment from "mark state as scrolled" to "mark the cited chunk as active" to reflect what the code now does.

Net diff: 1 insertion, 4 deletions.

## Verify

1. Open a chat with citations.
2. Click a citation → source detail panel opens and scrolls to the cited chunk (same as before).
3. Close the panel and open it with a different citation → scroll-to-cited still works.
4. Biome check on the file: no new warnings (pre-existing `useExhaustiveDependencies` warnings in the same file are unrelated to this PR).

## Acceptance criteria from the issue

- [x] No `useState` in the file whose value is discarded/unused in render
- [x] Source detail panel scroll-to-citation behavior unchanged
- [x] Build passes (pre-existing build errors in `components/assistant-ui/*` and `free-chat/*` are unrelated to this PR)

Closes #1249

This contribution was developed with AI assistance (Claude Code).

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR removes an unused React state variable `_hasScrolledToCited` from the source detail panel component. The state setter was being called but the value was never read during render, causing unnecessary re-renders without any visible effect. The actual scroll-to-citation behavior is preserved through existing mechanisms: `hasScrolledRef` for scroll-once logic and `setActiveChunkIndex` for highlighting the cited chunk.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/components/new-chat/source-detail-panel.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/a53cef2c81651f594efe30881067ef323db58d38cd7661ff0551d622f9e3b956/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=1255)
<!-- RECURSEML_SUMMARY:END -->