### PR TITLE
refactor(documents-sidebar): convert discarded isExportingKB state to ref

### DIFF
--- a/surfsense_web/components/layout/ui/sidebar/DocumentsSidebar.tsx
+++ b/surfsense_web/components/layout/ui/sidebar/DocumentsSidebar.tsx
@@ -478,7 +478,7 @@ function AuthenticatedDocumentsSidebar({
 		setFolderPickerOpen(true);
 	}, []);
 
-	const [, setIsExportingKB] = useState(false);
+	const isExportingKBRef = useRef(false);
 	const [exportWarningOpen, setExportWarningOpen] = useState(false);
 	const [exportWarningContext, setExportWarningContext] = useState<{
 		folder: FolderDisplay;
@@ -508,7 +508,7 @@ function AuthenticatedDocumentsSidebar({
 		const ctx = exportWarningContext;
 		if (!ctx?.folder) return;
 
-		setIsExportingKB(true);
+		isExportingKBRef.current = true;
 		try {
 			const safeName =
 				ctx.folder.name
@@ -524,7 +524,7 @@ function AuthenticatedDocumentsSidebar({
 			console.error("Folder export failed:", err);
 			toast.error(err instanceof Error ? err.message : "Export failed");
 		} finally {
-			setIsExportingKB(false);
+			isExportingKBRef.current = false;
 		}
 		setExportWarningContext(null);
 	}, [exportWarningContext, searchSpaceId, doExport]);
@@ -560,7 +560,7 @@ function AuthenticatedDocumentsSidebar({
 				return;
 			}
 
-			setIsExportingKB(true);
+			isExportingKBRef.current = true;
 			try {
 				const safeName =
 					folder.name
@@ -576,7 +576,7 @@ function AuthenticatedDocumentsSidebar({
 				console.error("Folder export failed:", err);
 				toast.error(err instanceof Error ? err.message : "Export failed");
 			} finally {
-				setIsExportingKB(false);
+				isExportingKBRef.current = false;
 			}
 		},
 		[searchSpaceId, getPendingCountInSubtree, doExport]


### PR DESCRIPTION
<!--- Summarize your pull request in a few sentences -->

## Description

Converts the discarded `isExportingKB` state in `DocumentsSidebar.tsx` to a `useRef` — Option A from the issue. The value was never read (no spinner, no disabled-button, no UI consumer), so every setter call was scheduling a re-render of the entire sidebar for no visible change.

## Motivation and Context

FIX #1250

The issue laid this out exactly: `surfsense_web/components/layout/ui/sidebar/DocumentsSidebar.tsx:481` declares `const [, setIsExportingKB] = useState(false);` — tuple position 0 destructured into `_` — with the setter called in two export callbacks (`handleExportWarningConfirm`, `handleExportFolder`) and reset in their `finally` blocks. Greping `isExportingKB` outside this file returns nothing, confirming there's no consumer. That makes `useRef` a one-for-one swap that preserves the runtime tracking and skips the wasted renders.

Shipping Option A (not Option B) per the issue's explicit preference: "Pick one path — prefer Option A unless you intend to ship loading UX in the same PR."

## Screenshots
N/A — behavior-preserving refactor, no UI change.

## API Changes
- [ ] This PR includes API changes

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Performance improvement
- [x] Refactoring
- [ ] Documentation
- [ ] Dependency/Build system
- [ ] Breaking change
- [ ] Other (specify):

## Testing Performed

- `grep -n "isExportingKB" surfsense_web/components/layout/ui/sidebar/DocumentsSidebar.tsx` — confirms 5 occurrences (1 ref declaration, 4 mutations at lines 511, 527, 563, 579), zero leftover `setIsExportingKB`.
- `grep -rn "isExportingKBRef" surfsense_web/` — confirmed no unintended call sites elsewhere.
- `useRef` was already imported in the existing `react` import (line 21); no import changes needed.
- Both export paths still set the flag true before the request and reset it to false in `finally`, matching the pre-refactor behavior exactly.

## Checklist
<!--- Please confirm the following by marking with an 'x' as appropriate -->
- [x] Follows project coding standards and conventions
- [x] Documentation updated as needed
- [x] Dependencies updated as needed
- [x] No lint/build errors or new warnings
- [x] All relevant tests are passing

Closes #1250

_This contribution was developed with AI assistance (Codex)._

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/0003dd6d67e14726d2a4e6c1f235dabe7c8d4592097496ec0b3322b78eda0096/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=1267)

[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->