### PR TITLE
fix(dialogs): move open-reset effects into onOpenChange handlers

### DIFF
--- a/surfsense_web/components/documents/CreateFolderDialog.tsx
+++ b/surfsense_web/components/documents/CreateFolderDialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
 	Dialog,
@@ -29,12 +29,16 @@ export function CreateFolderDialog({
 	const [name, setName] = useState("");
 	const inputRef = useRef<HTMLInputElement>(null);
 
-	useEffect(() => {
-		if (open) {
-			setName("");
-			setTimeout(() => inputRef.current?.focus(), 0);
-		}
-	}, [open]);
+	const handleOpenChange = useCallback(
+		(next: boolean) => {
+			if (next) {
+				setName("");
+				setTimeout(() => inputRef.current?.focus(), 0);
+			}
+			onOpenChange(next);
+		},
+		[onOpenChange]
+	);
 
 	const handleSubmit = useCallback(
 		(e?: React.FormEvent) => {
@@ -50,7 +54,7 @@ export function CreateFolderDialog({
 	const isSubfolder = !!parentFolderName;
 
 	return (
-		<Dialog open={open} onOpenChange={onOpenChange}>
+		<Dialog open={open} onOpenChange={handleOpenChange}>
 			<DialogContent className="select-none max-w-[90vw] sm:max-w-sm p-4 sm:p-5 data-[state=open]:animate-none data-[state=closed]:animate-none">
 				<DialogHeader className="space-y-2 pb-2">
 					<div className="flex items-center gap-2 sm:gap-3">

--- a/surfsense_web/components/documents/FolderPickerDialog.tsx
+++ b/surfsense_web/components/documents/FolderPickerDialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { ChevronDown, ChevronRight, Folder, FolderOpen, Home } from "lucide-react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
 	Dialog,
@@ -36,12 +36,16 @@ export function FolderPickerDialog({
 	const [selectedId, setSelectedId] = useState<number | null>(null);
 	const [expandedIds, setExpandedIds] = useState<Set<number>>(new Set());
 
-	useEffect(() => {
-		if (open) {
-			setSelectedId(null);
-			setExpandedIds(new Set());
-		}
-	}, [open]);
+	const handleOpenChange = useCallback(
+		(next: boolean) => {
+			if (next) {
+				setSelectedId(null);
+				setExpandedIds(new Set());
+			}
+			onOpenChange(next);
+		},
+		[onOpenChange]
+	);
 
 	const foldersByParent = useMemo(() => {
 		const map: Record<string, FolderDisplay[]> = {};
@@ -123,7 +127,7 @@ export function FolderPickerDialog({
 	}
 
 	return (
-		<Dialog open={open} onOpenChange={onOpenChange}>
+		<Dialog open={open} onOpenChange={handleOpenChange}>
 			<DialogContent className="select-none max-w-[90vw] sm:max-w-sm p-4 sm:p-5 data-[state=open]:animate-none data-[state=closed]:animate-none">
 				<DialogHeader className="space-y-2 pb-2">
 					<div className="flex items-center gap-2 sm:gap-3">

--- a/surfsense_web/components/free-chat/free-model-selector.tsx
+++ b/surfsense_web/components/free-chat/free-model-selector.tsx
@@ -27,13 +27,14 @@ export function FreeModelSelector({ className }: { className?: string }) {
 		anonymousChatApiService.getModels().then(setModels).catch(console.error);
 	}, []);
 
-	useEffect(() => {
-		if (open) {
+	const handleOpenChange = useCallback((next: boolean) => {
+		if (next) {
 			setSearchQuery("");
 			setFocusedIndex(-1);
 			requestAnimationFrame(() => searchInputRef.current?.focus());
 		}
-	}, [open]);
+		setOpen(next);
+	}, []);
 
 	const currentModel = useMemo(
 		() => models.find((m) => m.seo_slug === currentSlug) ?? null,
@@ -94,7 +95,7 @@ export function FreeModelSelector({ className }: { className?: string }) {
 	);
 
 	return (
-		<Popover open={open} onOpenChange={setOpen}>
+		<Popover open={open} onOpenChange={handleOpenChange}>
 			<PopoverTrigger asChild>
 				<Button
 					variant="ghost"


### PR DESCRIPTION
Fixes #1251

### Problem

Three components used `useEffect(() => { if (open) {...} }, [open])` to reset form state and focus inputs when dialogs/popovers open. Per React's "you might not need an effect" guidance, logic triggered by a user action belongs in the event handler, not a `useEffect`.

### Changes

Replaced the `useEffect` block in each file with a `handleOpenChange = useCallback(...)` wrapper that resets state when `next === true`, then forwards to the parent's `onOpenChange`/`setOpen`:

- **`CreateFolderDialog.tsx`** — clears folder name input + focuses it
- **`FolderPickerDialog.tsx`** — resets selected folder + collapsed state
- **`free-model-selector.tsx`** — clears search query + resets focus index + focuses search input

Removed `useEffect` from the React import in the two files that no longer use it. The model-fetch `useEffect` in `free-model-selector.tsx` is preserved.

### What is NOT changed

- No behavioral changes — fields still clear on open, focus still moves, dialogs still close on submit/cancel
- No new dependencies
- No other files modified
- The nested button in `FolderPickerDialog` is intentionally left as-is (out of scope)

### How to verify

1. `pnpm build` — passes with no TypeScript errors
2. Open each dialog/popover in the app:
   - Create Folder dialog: name input should be empty and focused on open
   - Folder Picker dialog: selection and expansion should reset on open
   - Free model selector: search should be empty and focused on open

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR refactors three dialog components to follow React best practices by moving state reset and focus logic from `useEffect` hooks into `onOpenChange` event handlers. When dialogs open, the same initialization behavior (clearing input fields, resetting selection state, and focusing inputs) now happens directly in response to the user action rather than as a side effect of the `open` state changing.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/components/documents/CreateFolderDialog.tsx` |
| 2 | `surfsense_web/components/documents/FolderPickerDialog.tsx` |
| 3 | `surfsense_web/components/free-chat/free-model-selector.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/cb6d0a955b1ced9a26be41798899ae9c627f3d966db5a640aa585a04a069cf2a/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=1268)
<!-- RECURSEML_SUMMARY:END -->