### PR TITLE
fix(hitl-edit-panel): move duplicate-tag check into functional setTags (#1248)

### DIFF
--- a/surfsense_web/components/hitl-edit-panel/hitl-edit-panel.tsx
+++ b/surfsense_web/components/hitl-edit-panel/hitl-edit-panel.tsx
@@ -65,16 +65,15 @@ function EmailsTagField({
 		setTags((prev) => (typeof newTags === "function" ? newTags(prev) : newTags));
 	}, []);
 
-	const handleAddTag = useCallback(
-		(text: string) => {
-			const trimmed = text.trim();
-			if (!trimmed) return;
-			if (tags.some((tag) => tag.text === trimmed)) return;
+	const handleAddTag = useCallback((text: string) => {
+		const trimmed = text.trim();
+		if (!trimmed) return;
+		setTags((prev) => {
+			if (prev.some((tag) => tag.text === trimmed)) return prev;
 			const newTag: TagType = { id: Date.now().toString(), text: trimmed };
-			setTags((prev) => [...prev, newTag]);
-		},
-		[tags]
-	);
+			return [...prev, newTag];
+		});
+	}, []);
 
 	return (
 		<TagInput


### PR DESCRIPTION
## Summary

Fixes #1248

`handleAddTag` in `EmailsTagField` (`surfsense_web/components/hitl-edit-panel/hitl-edit-panel.tsx`) listed `tags` in its `useCallback` dependency array only so the closure-level duplicate check could read it. That had two side effects the issue calls out:

1. The callback re-created on every tag mutation, invalidating memoization for downstream consumers.
2. The duplicate check saw closure-level `tags`, not the latest state, so rapid adds could race.

## Change

Move the duplicate check inside the functional `setTags` updater so it always sees the latest state, and drop `tags` from the dependency array. The callback is now stable for the component's lifetime.

```diff
-const handleAddTag = useCallback(
-    (text: string) => {
-        const trimmed = text.trim();
-        if (!trimmed) return;
-        if (tags.some((tag) => tag.text === trimmed)) return;
-        const newTag: TagType = { id: Date.now().toString(), text: trimmed };
-        setTags((prev) => [...prev, newTag]);
-    },
-    [tags]
-);
+const handleAddTag = useCallback((text: string) => {
+    const trimmed = text.trim();
+    if (!trimmed) return;
+    setTags((prev) => {
+        if (prev.some((tag) => tag.text === trimmed)) return prev;
+        const newTag: TagType = { id: Date.now().toString(), text: trimmed };
+        return [...prev, newTag];
+    });
+}, []);
```

## Testing

- `pnpm biome check components/hitl-edit-panel/hitl-edit-panel.tsx` - clean
- `pnpm biome lint components/hitl-edit-panel/hitl-edit-panel.tsx` - clean

Pre-existing tsc errors in `app/(home)/blog/[slug]/page.tsx` are unrelated to this change.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a React hooks optimization issue in the `EmailsTagField` component by moving the duplicate-tag check from the closure scope into the functional state updater. This eliminates unnecessary callback re-creation on every tag mutation and prevents race conditions when adding tags rapidly, ensuring the duplicate check always sees the latest state while maintaining a stable callback reference.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/components/hitl-edit-panel/hitl-edit-panel.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/e6d59bbd2d248b87ad5ac242d9b14a2dc0ebc3e4242046270b379995bc4e7214/?repo_owner=MODSetter&repo_name=SurfSense&pr_number=1281)
<!-- RECURSEML_SUMMARY:END -->