### PR TITLE
refactor(anon-chat): dedupe upload via anonymousChatApiService

### DIFF
--- a/surfsense_web/components/free-chat/free-composer.tsx
+++ b/surfsense_web/components/free-chat/free-composer.tsx
@@ -9,7 +9,7 @@ import { Switch } from "@/components/ui/switch";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useAnonymousMode } from "@/contexts/anonymous-mode";
 import { useLoginGate } from "@/contexts/login-gate";
-import { BACKEND_URL } from "@/lib/env-config";
+import { anonymousChatApiService } from "@/lib/apis/anonymous-chat-api.service";
 import { cn } from "@/lib/utils";
 
 const ANON_ALLOWED_EXTENSIONS = new Set([
@@ -128,24 +128,12 @@ export const FreeComposer: FC = () => {
 			}
 
 			try {
-				const formData = new FormData();
-				formData.append("file", file);
-				const res = await fetch(`${BACKEND_URL}/api/v1/public/anon-chat/upload`, {
-					method: "POST",
-					credentials: "include",
-					body: formData,
-				});
-
-				if (res.status === 409) {
-					gate("upload more documents");
+				const result = await anonymousChatApiService.uploadDocument(file);
+				if (!result.ok) {
+					if (result.reason === "quota_exceeded") gate("upload more documents");
 					return;
 				}
-				if (!res.ok) {
-					const body = await res.json().catch(() => ({}));
-					throw new Error(body.detail || `Upload failed: ${res.status}`);
-				}
-
-				const data = await res.json();
+				const data = result.data;
 				if (anonMode.isAnonymous) {
 					anonMode.setUploadedDoc({
 						filename: data.filename,

--- a/surfsense_web/components/layout/ui/sidebar/DocumentsSidebar.tsx
+++ b/surfsense_web/components/layout/ui/sidebar/DocumentsSidebar.tsx
@@ -68,11 +68,11 @@ import type { DocumentTypeEnum } from "@/contracts/types/document.types";
 import { useDebouncedValue } from "@/hooks/use-debounced-value";
 import { useMediaQuery } from "@/hooks/use-media-query";
 import { useElectronAPI } from "@/hooks/use-platform";
+import { anonymousChatApiService } from "@/lib/apis/anonymous-chat-api.service";
 import { documentsApiService } from "@/lib/apis/documents-api.service";
 import { foldersApiService } from "@/lib/apis/folders-api.service";
 import { searchSpacesApiService } from "@/lib/apis/search-spaces-api.service";
 import { authenticatedFetch } from "@/lib/auth-utils";
-import { BACKEND_URL } from "@/lib/env-config";
 import { uploadFolderScan } from "@/lib/folder-sync-upload";
 import { getSupportedExtensionsSet } from "@/lib/supported-extensions";
 import { queries } from "@/zero/queries/index";
@@ -1312,24 +1312,12 @@ function AnonymousDocumentsSidebar({
 
 			setIsUploading(true);
 			try {
-				const formData = new FormData();
-				formData.append("file", file);
-				const res = await fetch(`${BACKEND_URL}/api/v1/public/anon-chat/upload`, {
-					method: "POST",
-					credentials: "include",
-					body: formData,
-				});
-
-				if (res.status === 409) {
-					gate("upload more documents");
+				const result = await anonymousChatApiService.uploadDocument(file);
+				if (!result.ok) {
+					if (result.reason === "quota_exceeded") gate("upload more documents");
 					return;
 				}
-				if (!res.ok) {
-					const body = await res.json().catch(() => ({}));
-					throw new Error(body.detail || `Upload failed: ${res.status}`);
-				}
-
-				const data = await res.json();
+				const data = result.data;
 				if (anonMode.isAnonymous) {
 					anonMode.setUploadedDoc({
 						filename: data.filename,

--- a/surfsense_web/lib/apis/anonymous-chat-api.service.ts
+++ b/surfsense_web/lib/apis/anonymous-chat-api.service.ts
@@ -12,6 +12,10 @@ import { ValidationError } from "../error";
 
 const BASE = "/api/v1/public/anon-chat";
 
+export type AnonUploadResult =
+	| { ok: true; data: { filename: string; size_bytes: number } }
+	| { ok: false; reason: "quota_exceeded" };
+
 class AnonymousChatApiService {
 	private baseUrl: string;
 
@@ -71,7 +75,7 @@ class AnonymousChatApiService {
 		});
 	};
 
-	uploadDocument = async (file: File): Promise<{ filename: string; size_bytes: number }> => {
+	uploadDocument = async (file: File): Promise<AnonUploadResult> => {
 		const formData = new FormData();
 		formData.append("file", file);
 		const res = await fetch(this.fullUrl("/upload"), {
@@ -79,11 +83,15 @@ class AnonymousChatApiService {
 			credentials: "include",
 			body: formData,
 		});
+		if (res.status === 409) {
+			return { ok: false, reason: "quota_exceeded" };
+		}
 		if (!res.ok) {
 			const body = await res.json().catch(() => ({}));
 			throw new Error(body.detail || `Upload failed: ${res.status}`);
 		}
-		return res.json();
+		const data = await res.json();
+		return { ok: true, data };
 	};
 
 	getDocument = async (): Promise<{ filename: string; size_bytes: number } | null> => {


### PR DESCRIPTION
Dedupe the anonymous-chat upload request across two UI call sites by routing both through the existing `anonymousChatApiService.uploadDocument` method.

## Description

Two components were inlining the same `fetch` call to `/api/v1/public/anon-chat/upload` verbatim -- including duplicate 409 handling and error parsing -- while `anonymousChatApiService.uploadDocument` in `surfsense_web/lib/apis/anonymous-chat-api.service.ts` already existed. This PR routes both call sites through the service and tweaks the service's return type so callers can still distinguish the 409 quota-exceeded case without catching an exception.

The service now returns a discriminated result:

```ts
export type AnonUploadResult =
    | { ok: true; data: { filename: string; size_bytes: number } }
    | { ok: false; reason: "quota_exceeded" };
```

Non-409 non-OK responses still throw, matching the prior behavior. Both call sites now read:

```ts
const result = await anonymousChatApiService.uploadDocument(file);
if (!result.ok) {
    if (result.reason === "quota_exceeded") gate("upload more documents");
    return;
}
const data = result.data;
```

After the refactor, `grep -rn "/api/v1/public/anon-chat/upload" surfsense_web/` returns zero hits. `BACKEND_URL` is no longer imported in either call site.

## Motivation and Context

FIX #1245

The duplication was a maintenance hazard called out in the issue: any change to the endpoint path, FormData key, credentials flag, or error-handling shape had to be made in three places. This centralizes the request so the service is the single source of truth for all anonymous-chat upload requests.

## Screenshots

Not applicable -- refactor preserves UI behavior. The upload flow, the 409 -> `gate("upload more documents")` branch, and the "Uploaded 'filename'" toast all remain identical.

## API Changes

- [ ] This PR includes API changes

No external API surface changes. The internal TypeScript return type of `AnonymousChatApiService.uploadDocument` changes from `Promise<{ filename, size_bytes }>` to `Promise<AnonUploadResult>`. The only two callers of this method are the two files updated in this PR, so no consumers are left unchanged.

## Change Type

- [x] Refactoring

## Testing Performed

- [x] Tested locally
- [x] Manual/QA verification

- Verified both call sites behaviorally match the prior inline code: 409 triggers `gate("upload more documents")` and returns early; non-OK non-409 still throws and is caught by the existing `catch (err)` block; successful uploads still populate `anonMode.setUploadedDoc` and fire the success toast.
- `rg "api/v1/public/anon-chat/upload" surfsense_web/` returns zero matches after the refactor.
- `pnpm exec tsc --noEmit` and `pnpm lint` were run but surface ~66 pre-existing project-wide TypeScript errors in 34 files unrelated to this diff (same state as the `dev` branch tip before my changes). The three files touched in this PR have no new TS errors introduced by the change.
- Diff is minimal: 3 files, +20/-36 lines net.

## Checklist

- [x] Follows project coding standards and conventions
- [x] Documentation updated as needed (n/a -- no public API docs)
- [x] Dependencies updated as needed (n/a -- no deps touched)
- [x] No lint/build errors or new warnings introduced by this PR

---

This contribution was developed with AI assistance (Codex).

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR eliminates code duplication by consolidating duplicate anonymous-chat upload requests from two UI components into a single `anonymousChatApiService.uploadDocument` method. The service now returns a discriminated union type (`AnonUploadResult`) to allow callers to distinguish quota-exceeded (409) responses without exception handling, while preserving all original behavior including error handling and upload flow.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/lib/apis/anonymous-chat-api.service.ts` |
| 2 | `surfsense_web/components/free-chat/free-composer.tsx` |
| 3 | `surfsense_web/components/layout/ui/sidebar/DocumentsSidebar.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->