### PR TITLE
feat(announcements): add SEO metadata via server layout.tsx

### DIFF
--- a/surfsense_web/app/(home)/announcements/layout.tsx
+++ b/surfsense_web/app/(home)/announcements/layout.tsx
@@ -1,0 +1,25 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+
+export const metadata: Metadata = {
+	title: "Announcements | SurfSense",
+	description: "Latest product updates, feature releases, and news from SurfSense.",
+	alternates: {
+		canonical: "https://surfsense.com/announcements",
+	},
+	openGraph: {
+		title: "Announcements | SurfSense",
+		description: "Latest product updates, feature releases, and news from SurfSense.",
+		url: "https://surfsense.com/announcements",
+		type: "website",
+	},
+	twitter: {
+		card: "summary_large_image",
+		title: "Announcements | SurfSense",
+		description: "Latest product updates, feature releases, and news from SurfSense.",
+	},
+};
+
+export default function AnnouncementsLayout({ children }: { children: ReactNode }) {
+	return <>{children}</>;
+}


### PR DESCRIPTION
Resubmitting #1300 against `dev` per maintainer request.

Same change as before: single file adds Next.js App Router metadata export for the `/announcements` route (title, description, canonical URL, Open Graph, Twitter card tags).

File: `surfsense_web/app/(home)/announcements/layout.tsx` (+25 lines)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds SEO metadata to the `/announcements` route by creating a new Next.js App Router layout file. The metadata includes page title, description, canonical URL, Open Graph tags, and Twitter card configuration to improve search engine optimization and social media sharing for the announcements page.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/app/(home)/announcements/layout.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->