### PR TITLE
perf(docs): replace full lucide icons barrel with explicit whitelist

### DIFF
--- a/surfsense_web/lib/source.ts
+++ b/surfsense_web/lib/source.ts
@@ -1,12 +1,39 @@
 import { loader } from "fumadocs-core/source";
-import { icons } from "lucide-react";
+import {
+	BookOpen,
+	ClipboardCheck,
+	Compass,
+	Container,
+	Download,
+	FlaskConical,
+	Heart,
+	Unplug,
+	Wrench,
+	type LucideIcon,
+} from "lucide-react";
 import { createElement } from "react";
 import { docs } from "@/.source/server";
+
+// Explicit whitelist of icons used in docs MDX frontmatter.
+// Avoids pulling the full lucide-react icon registry into the docs bundle:
+// the barrel `icons` object prevents tree-shaking even with
+// `optimizePackageImports` enabled, because the key is resolved dynamically.
+const ICON_MAP: Record<string, LucideIcon> = {
+	BookOpen,
+	ClipboardCheck,
+	Compass,
+	Container,
+	Download,
+	FlaskConical,
+	Heart,
+	Unplug,
+	Wrench,
+};
 
 export const source = loader({
 	baseUrl: "/docs",
 	source: docs.toFumadocsSource(),
 	icon(icon) {
-		if (icon && icon in icons) return createElement(icons[icon as keyof typeof icons]);
+		if (icon && icon in ICON_MAP) return createElement(ICON_MAP[icon]);
 	},
 });


### PR DESCRIPTION

## Description

`surfsense_web/lib/source.ts` imported the entire `icons` barrel from `lucide-react`:

```ts
import { icons } from "lucide-react";
// ...
icon(icon) {
    if (icon && icon in icons) return createElement(icons[icon as keyof typeof icons]);
}
```

The `icons` object contains all ~1500 Lucide icons. Because the lookup is dynamic (`icons[key]`), the `optimizePackageImports` tree-shaking in `next.config.ts` cannot eliminate unused icons — every icon ends up in the docs bundle.

A full scan of `surfsense_web/content/docs/**/*.mdx` and `**/meta.json` frontmatter reveals exactly **9 icon names** are used:

`BookOpen`, `ClipboardCheck`, `Compass`, `Container`, `Download`, `FlaskConical`, `Heart`, `Unplug`, `Wrench`

This PR replaces the barrel import with a typed `ICON_MAP` constant containing only these 9 icons. Future icons can be added to the map as documentation expands.

## Motivation and Context

FIX #1241

Reduces the Lucide icon footprint in the docs bundle from ~1500 icons to 9, improving initial load performance for the `/docs` routes.

## Screenshots

N/A (bundle size improvement, not a visual change)

## API Changes

- [ ] This PR includes API changes

(No API changes — internal source configuration only)

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Dependency/Build system
- [ ] Breaking change
- [ ] Other (specify):

## Testing Performed

- [x] Tested locally
- [x] Manual/QA verification

Verified that all 9 icons render correctly in their respective doc pages. The `source.icon()` function continues to return the correct React element for each icon name.

## Checklist

- [x] Follows project coding standards and conventions
- [x] Documentation updated as needed
- [x] Dependencies updated as needed
- [x] No lint/build errors or new warnings
- [x] All relevant tests are passing

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR optimizes bundle size by replacing the full `lucide-react` icons barrel import with an explicit whitelist of only the 9 icons actually used in the documentation. Previously, the dynamic lookup prevented tree-shaking from eliminating unused icons, resulting in all ~1500 icons being bundled. The new `ICON_MAP` constant contains only `BookOpen`, `ClipboardCheck`, `Compass`, `Container`, `Download`, `FlaskConical`, `Heart`, `Unplug`, and `Wrench`, significantly reducing the Lucide icon footprint in the docs bundle and improving initial load performance.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/lib/source.ts` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved icon handling system for enhanced reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->