### PR TITLE
fix(connectors): refresh heartbeat in background to prevent silent fail on long indexing phases

### DIFF
--- a/surfsense_backend/app/routes/search_source_connectors_routes.py
+++ b/surfsense_backend/app/routes/search_source_connectors_routes.py
@@ -81,6 +81,7 @@ _heartbeat_redis_client: redis.Redis | None = None
 
 # Redis key TTL - notification is stale if no heartbeat in this time
 HEARTBEAT_TTL_SECONDS = 120  # 2 minutes
+HEARTBEAT_REFRESH_INTERVAL = 60  # Refresh every 60 seconds while indexing runs
 
 
 def get_heartbeat_redis_client() -> redis.Redis:
@@ -96,6 +97,33 @@ def get_heartbeat_redis_client() -> redis.Redis:
 def _get_heartbeat_key(notification_id: int) -> str:
     """Generate Redis key for notification heartbeat."""
     return f"indexing:heartbeat:{notification_id}"
+
+
+async def _run_heartbeat_loop(notification_id: int) -> None:
+    """Refresh the Redis heartbeat key while a connector indexing task runs.
+
+    Some indexing phases (e.g. GitHub's ``gitingest`` subprocess) are blocking
+    and never call ``on_heartbeat_callback``. Without a background refresher
+    the heartbeat key expires after ``HEARTBEAT_TTL_SECONDS`` and the stale-
+    notification reaper marks the document as failed even though the task is
+    still healthy.
+
+    Mirrors ``_run_heartbeat_loop`` in ``app/tasks/celery_tasks/document_tasks``.
+    Cancelled by the caller's ``finally`` block when the task completes; if
+    the worker crashes the coroutine dies with it and the key expires.
+    """
+    key = _get_heartbeat_key(notification_id)
+    try:
+        while True:
+            await asyncio.sleep(HEARTBEAT_REFRESH_INTERVAL)
+            try:
+                get_heartbeat_redis_client().expire(key, HEARTBEAT_TTL_SECONDS)
+            except Exception as e:
+                logger.warning(
+                    f"Failed to refresh heartbeat for notification {notification_id}: {e}"
+                )
+    except asyncio.CancelledError:
+        pass  # Normal cancellation when the task completes
 
 
 router = APIRouter()
@@ -1464,6 +1492,7 @@ async def _run_indexing_with_notifications(
 
     notification = None
     connector_lock_acquired = False
+    heartbeat_task: asyncio.Task | None = None
     # Track indexed count for retry notifications and heartbeat
     current_indexed_count = 0
 
@@ -1508,6 +1537,13 @@ async def _run_indexing_with_notifications(
                     )
                 except Exception as e:
                     logger.warning(f"Failed to set initial Redis heartbeat: {e}")
+
+                # Refresh the heartbeat in the background so phases that don't
+                # call ``on_heartbeat_callback`` (e.g. GitHub's blocking
+                # ``gitingest`` subprocess) don't trigger the stale-task reaper.
+                heartbeat_task = asyncio.create_task(
+                    _run_heartbeat_loop(notification.id)
+                )
 
         # Update notification to fetching stage
         if notification:
@@ -1799,6 +1835,11 @@ async def _run_indexing_with_notifications(
             except Exception as notif_error:
                 logger.error(f"Failed to update notification: {notif_error!s}")
     finally:
+        # Stop the background heartbeat refresher before deleting the key
+        if heartbeat_task is not None:
+            heartbeat_task.cancel()
+            with suppress(Exception):
+                await heartbeat_task
         # Clean up Redis heartbeat key when task completes (success or failure)
         if notification:
             try:


### PR DESCRIPTION
Closes #1295.

## Root cause

Connector indexing in `search_source_connectors_routes.py` sets the Redis heartbeat key once at task start and then relies on the per-document `on_heartbeat_callback` to refresh it.

Phase 1 of the GitHub connector runs `gitingest` as a blocking subprocess via `asyncio.to_thread` and **never invokes** `on_heartbeat_callback`. On larger repositories Phase 1 routinely takes longer than `HEARTBEAT_TTL_SECONDS` (120s), so the Redis key expires before Phase 2 (per-document chunking/embedding) begins. `cleanup_stale_indexing_notifications_task` then marks the document as `"Sync was interrupted unexpectedly. Please retry."` even though the underlying task is still healthy — `gitingest` itself has a 900s timeout.

Symptom from the linked issue: `{"state": "failed", "reason": "Sync was interrupted unexpectedly. Please retry."}`, 0 chunks indexed, ~2.5 minutes after start.

## Fix

Mirrors the pattern already used by `app/tasks/celery_tasks/document_tasks._run_heartbeat_loop`:

1. Add a module-level `_run_heartbeat_loop(notification_id)` coroutine that calls `EXPIRE` on the heartbeat key every `HEARTBEAT_REFRESH_INTERVAL` (60s).
2. Start the loop with `asyncio.create_task` right after the initial heartbeat is written.
3. Cancel and await it in the existing `finally:` block, **before** the cleanup `DELETE` runs.

This is a strictly additive change. The existing `on_heartbeat_callback` remains the source of truth for indexed-count progress; the background loop only keeps the TTL fresh between callbacks. If the worker crashes the coroutine dies with it and the key still expires, so the stale-task reaper continues to work as designed.

## Test plan
- [x] Module parses (`python -m py_compile`).
- [ ] Re-run the original failing case: index a GitHub repo whose `gitingest` Phase 1 takes >2 minutes. Heartbeat key TTL should stay ≤120s but never expire while the task is alive; document should reach Phase 2 and finish with `state=indexed` instead of being reaped.
- [ ] Smoke-check connectors that *do* hit `on_heartbeat_callback` regularly (Slack, Notion) — the extra background refresher should be a no-op for them.
- [ ] Crash a worker mid-task in dev: confirm the heartbeat key expires within `HEARTBEAT_TTL_SECONDS` so the reaper still flags genuine stalls.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a silent failure issue where connector indexing tasks were incorrectly marked as failed during long blocking operations. The root cause was that the GitHub connector's `gitingest` subprocess runs for extended periods without invoking the heartbeat callback, causing the Redis heartbeat key to expire and triggering false failure notifications. The fix introduces a background coroutine that continuously refreshes the heartbeat key every 60 seconds, mirroring the pattern already used in `document_tasks`. This ensures the heartbeat stays alive during blocking phases while preserving the existing stale-task detection mechanism if workers genuinely crash.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_backend/app/routes/search_source_connectors_routes.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of indexing notification heartbeat during long-running indexing operations by implementing periodic refresh logic that prevents timeout during extended processing phases.
  * Enhanced background task cleanup to prevent potential race conditions during indexing completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->