### PR TITLE
perf(docs): replace full lucide barrel import with explicit icon whit…

### DIFF
--- a/surfsense_web/lib/source.ts
+++ b/surfsense_web/lib/source.ts
@@ -1,12 +1,39 @@
 import { loader } from "fumadocs-core/source";
-import { icons } from "lucide-react";
+import {
+	BookOpen,
+	ClipboardCheck,
+	Compass,
+	Container,
+	Download,
+	FlaskConical,
+	Heart,
+	Unplug,
+	Wrench,
+} from "lucide-react";
 import { createElement } from "react";
 import { docs } from "@/.source/server";
+
+/** Explicit whitelist of Lucide icons used in docs frontmatter / meta.json.
+ * Importing the full `icons` barrel would pull every Lucide icon (~1 400 SVGs)
+ * into the docs bundle even though only a handful are referenced. Add new icons
+ * here as docs pages are added.
+ */
+const DOCS_ICONS: Record<string, React.ComponentType> = {
+	BookOpen,
+	ClipboardCheck,
+	Compass,
+	Container,
+	Download,
+	FlaskConical,
+	Heart,
+	Unplug,
+	Wrench,
+};
 
 export const source = loader({
 	baseUrl: "/docs",
 	source: docs.toFumadocsSource(),
 	icon(icon) {
-		if (icon && icon in icons) return createElement(icons[icon as keyof typeof icons]);
+		if (icon && icon in DOCS_ICONS) return createElement(DOCS_ICONS[icon]);
 	},
 });


### PR DESCRIPTION
…elist

Fixes #1241

The docs bundle was importing `{ icons }` from lucide-react, which pulls the entire Lucide icon library (~1 400 SVGs, ~500 kB of JS) into the Next.js docs bundle even though only nine icons are used in docs frontmatter and meta.json files.

Replace with a hand-maintained DOCS_ICONS whitelist that imports only the icons that are actually referenced (BookOpen, ClipboardCheck, Compass, Container, Download, FlaskConical, Heart, Unplug, Wrench).

To add a new docs icon: import it from lucide-react and add it to the DOCS_ICONS record. The icon() callback remains the same for callers.

<!--- Summarize your pull request in a few sentences -->

## Description

Closes #1241

`lib/source.ts` imported `{ icons }` from `lucide-react`, which pulls the entire Lucide icon library (~1,400 SVGs, ~500 kB of JS) into the Next.js docs bundle even though only nine icons are actually used in docs frontmatter and `meta.json` files.

Replace with a hand-maintained `DOCS_ICONS` whitelist that imports only the icons that are referenced:

```ts
// Before
import { icons } from "lucide-react";
// ...
icon(icon) {
  if (icon && icon in icons) return createElement(icons[icon as keyof typeof icons]);
},
```

```ts
// After
import {
  BookOpen, ClipboardCheck, Compass, Container,
  Download, FlaskConical, Heart, Unplug, Wrench,
} from "lucide-react";

const DOCS_ICONS: Record<string, React.ComponentType> = {
  BookOpen, ClipboardCheck, Compass, Container,
  Download, FlaskConical, Heart, Unplug, Wrench,
};
// ...
icon(icon) {
  if (icon && icon in DOCS_ICONS) return createElement(DOCS_ICONS[icon]);
},
```

The icon whitelist was derived by scanning all `meta.json` and MDX frontmatter `icon:` fields in `content/docs/`.

## How Has This Been Tested?

- Verified all currently-used icons (`Compass`, `Container`, `Unplug`, `Heart`, `BookOpen`, `Download`, `Wrench`, `ClipboardCheck`, `FlaskConical`) still render correctly in the docs sidebar.
- Docs build succeeds without TypeScript errors.

## Type of Change

- [x] Performance improvement (reduced bundle size)
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update

## Adding New Icons

To use a new Lucide icon in docs: import it from `lucide-react` and add it to the `DOCS_ICONS` record in `lib/source.ts`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] No new warnings introduced

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR optimizes the docs bundle size by replacing the full `lucide-react` barrel import (which pulled in ~1,400 SVG icons totaling ~500 kB) with an explicit whitelist of only the 9 icons actually used in the documentation. The change introduces a `DOCS_ICONS` constant containing `BookOpen`, `ClipboardCheck`, `Compass`, `Container`, `Download`, `FlaskConical`, `Heart`, `Unplug`, and `Wrench`, significantly reducing the JavaScript bundle size for the Next.js docs while maintaining identical functionality.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/lib/source.ts` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->