### PR TITLE
refactor(settings): use key prop to reset LLM role manager form state

### DIFF
--- a/surfsense_web/components/settings/llm-role-manager.tsx
+++ b/surfsense_web/components/settings/llm-role-manager.tsx
@@ -11,7 +11,7 @@ import {
 	RefreshCw,
 	ScanEye,
 } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useState } from "react";
 import { toast } from "sonner";
 import {
 	globalImageGenConfigsAtom,
@@ -143,23 +143,6 @@ export function LLMRoleManager({ searchSpaceId }: LLMRoleManagerProps) {
 	}));
 
 	const [savingRole, setSavingRole] = useState<string | null>(null);
-	const savingRef = useRef(false);
-
-	useEffect(() => {
-		if (!savingRef.current) {
-			setAssignments({
-				agent_llm_id: preferences.agent_llm_id ?? "",
-				document_summary_llm_id: preferences.document_summary_llm_id ?? "",
-				image_generation_config_id: preferences.image_generation_config_id ?? "",
-				vision_llm_config_id: preferences.vision_llm_config_id ?? "",
-			});
-		}
-	}, [
-		preferences?.agent_llm_id,
-		preferences?.document_summary_llm_id,
-		preferences?.image_generation_config_id,
-		preferences?.vision_llm_config_id,
-	]);
 
 	const handleRoleAssignment = useCallback(
 		async (prefKey: string, configId: string) => {
@@ -167,7 +150,6 @@ export function LLMRoleManager({ searchSpaceId }: LLMRoleManagerProps) {
 
 			setAssignments((prev) => ({ ...prev, [prefKey]: value }));
 			setSavingRole(prefKey);
-			savingRef.current = true;
 
 			try {
 				await updatePreferences({
@@ -177,7 +159,6 @@ export function LLMRoleManager({ searchSpaceId }: LLMRoleManagerProps) {
 				toast.success("Role assignment updated");
 			} finally {
 				setSavingRole(null);
-				savingRef.current = false;
 			}
 		},
 		[updatePreferences, searchSpaceId]

--- a/surfsense_web/components/settings/search-space-settings-dialog.tsx
+++ b/surfsense_web/components/settings/search-space-settings-dialog.tsx
@@ -116,7 +116,7 @@ export function SearchSpaceSettingsDialog({ searchSpaceId }: SearchSpaceSettings
 	const content: Record<string, React.ReactNode> = {
 		general: <GeneralSettingsManager searchSpaceId={searchSpaceId} />,
 		models: <AgentModelManager searchSpaceId={searchSpaceId} />,
-		roles: <LLMRoleManager searchSpaceId={searchSpaceId} />,
+		roles: <LLMRoleManager key={searchSpaceId} searchSpaceId={searchSpaceId} />,
 		"image-models": <ImageModelManager searchSpaceId={searchSpaceId} />,
 		"vision-models": <VisionModelManager searchSpaceId={searchSpaceId} />,
 		"team-roles": <RolesManager searchSpaceId={searchSpaceId} />,


### PR DESCRIPTION
Fixes #1018

Remove the sync useEffect that copied preferences into local state, along with the savingRef guard that prevented mid-save overwrites. Instead, pass key={searchSpaceId} on the LLMRoleManager component so React remounts the form with correct initial state whenever the search space changes — no extra re-render, no effect dependency array.

Changes:
- llm-role-manager.tsx: remove useEffect + useRef + savingRef pattern; drop useEffect and useRef from imports (now only useCallback, useState)
- search-space-settings-dialog.tsx: add key={searchSpaceId} to <LLMRoleManager> so the component remounts on search-space change

Before: useEffect synced preferences → assignments on each preference
  update, with savingRef to avoid overwriting an in-flight save.
After:  React remounts the component with correct initial state from
  the preferences selector; no mid-save race possible.

<!--- Summarize your pull request in a few sentences -->
## Summary

Fixes #1018. Replace the sync `useEffect` + `useRef` pattern in `LLMRoleManager` with a `key={searchSpaceId}` prop on the parent component, so React remounts the form with correct initial state whenever the search space changes — eliminating the extra re-render and the savingRef guard.

## Description

**Before:**
`llm-role-manager.tsx` used a `useEffect` to copy `preferences` into local `assignments` state whenever preferences changed, with a `savingRef` guard to avoid overwriting an in-flight save. This adds an extra re-render per preference update and requires manual synchronization.

**After:**
The parent `SearchSpaceSettingsDialog` passes `key={searchSpaceId}` to `<LLMRoleManager>`. React remounts the component when the search space changes, initializing state from the current `preferences` value via the lazy `useState` initializer — no effect needed.

**Files changed:**
- `surfsense_web/components/settings/llm-role-manager.tsx`:
  - Removed `useEffect` that copied preferences → assignments
  - Removed `useRef(false)` / `savingRef` pattern
  - Removed `useEffect` and `useRef` from React imports (now only `useCallback`, `useState`)
- `surfsense_web/components/settings/search-space-settings-dialog.tsx`:
  - Added `key={searchSpaceId}` to `<LLMRoleManager>`

## Type of Changes

- [ ] 🐛 Bug Fix
- [ ] ✨ New Feature/Enhancement
- [ ] 📝 Documentation
- [x] 🔥 Performance Improvement
- [x] 🔧 Refactoring

## Testing

1. Open Settings → Roles tab
2. Switch between different search spaces — form should reset to each space's assignments
3. Change a role assignment — save should still work correctly
4. No stale state from a previous search space should appear

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR refactors the `LLMRoleManager` component to use React's `key` prop for state management instead of a synchronization `useEffect`. By adding `key={searchSpaceId}` to the component, React now automatically remounts it with fresh initial state when the search space changes, eliminating the need for manual state synchronization, the `savingRef` guard against mid-save overwrites, and an extra re-render cycle.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/components/settings/search-space-settings-dialog.tsx` |
| 2 | `surfsense_web/components/settings/llm-role-manager.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->