### PR TITLE
fix: stripe routes

### DIFF
--- a/surfsense_backend/app/routes/stripe_routes.py
+++ b/surfsense_backend/app/routes/stripe_routes.py
@@ -26,6 +26,7 @@ from app.schemas.stripe import (
     CreateCheckoutSessionResponse,
     CreateTokenCheckoutSessionRequest,
     CreateTokenCheckoutSessionResponse,
+    FinalizeCheckoutResponse,
     PagePurchaseHistoryResponse,
     StripeStatusResponse,
     StripeWebhookResponse,
@@ -65,7 +66,15 @@ def _get_checkout_urls(search_space_id: int) -> tuple[str, str]:
         )
 
     base_url = config.NEXT_FRONTEND_URL.rstrip("/")
-    success_url = f"{base_url}/dashboard/{search_space_id}/purchase-success"
+    # Stripe substitutes ``{CHECKOUT_SESSION_ID}`` with the actual session id
+    # at redirect time. The frontend uses it to call /stripe/finalize-checkout
+    # which fulfils synchronously without waiting for the webhook — fixing the
+    # webhook-vs-redirect race where users land on /purchase-success before
+    # checkout.session.completed has been delivered.
+    success_url = (
+        f"{base_url}/dashboard/{search_space_id}/purchase-success"
+        f"?session_id={{CHECKOUT_SESSION_ID}}"
+    )
     cancel_url = f"{base_url}/dashboard/{search_space_id}/purchase-cancel"
     return success_url, cancel_url
 
@@ -104,6 +113,17 @@ def _get_metadata(checkout_session: Any) -> dict[str, str]:
     except AttributeError:
         return {}
     return {str(key): str(value) for key, value in items}
+
+
+# Canonical purchase_type metadata values. ``premium_credit`` was emitted
+# by an earlier release of ``create_token_checkout_session`` so it's still
+# accepted on the read side for backward compat with in-flight sessions.
+_PURCHASE_TYPE_TOKEN_VALUES = frozenset({"premium_tokens", "premium_credit"})
+
+
+def _is_token_purchase(metadata: dict[str, str]) -> bool:
+    """Return True for premium-credit (a.k.a. premium_token) purchases."""
+    return metadata.get("purchase_type", "page_packs") in _PURCHASE_TYPE_TOKEN_VALUES
 
 
 async def _get_or_create_purchase_from_checkout_session(
@@ -470,8 +490,7 @@ async def stripe_webhook(
                 return StripeWebhookResponse()
 
             metadata = _get_metadata(checkout_session)
-            purchase_type = metadata.get("purchase_type", "page_packs")
-            if purchase_type == "premium_tokens":
+            if _is_token_purchase(metadata):
                 return await _fulfill_completed_token_purchase(
                     db_session, checkout_session
                 )
@@ -483,8 +502,7 @@ async def stripe_webhook(
         }:
             checkout_session = event.data.object
             metadata = _get_metadata(checkout_session)
-            purchase_type = metadata.get("purchase_type", "page_packs")
-            if purchase_type == "premium_tokens":
+            if _is_token_purchase(metadata):
                 return await _mark_token_purchase_failed(
                     db_session, str(checkout_session.id)
                 )
@@ -502,6 +520,124 @@ async def stripe_webhook(
         raise
 
     return StripeWebhookResponse()
+
+
+@router.get("/finalize-checkout", response_model=FinalizeCheckoutResponse)
+async def finalize_checkout(
+    session_id: str,
+    user: User = Depends(current_active_user),
+    db_session: AsyncSession = Depends(get_async_session),
+) -> FinalizeCheckoutResponse:
+    """Synchronously fulfil a checkout session from the success page.
+
+    Solves the webhook-vs-redirect race: the user lands on
+    ``/dashboard/<id>/purchase-success?session_id=cs_...`` typically a
+    few hundred ms after paying, but Stripe's
+    ``checkout.session.completed`` webhook can take 5-30s+ to arrive.
+    Calling this endpoint on success-page mount fulfils the purchase
+    immediately by retrieving the session from Stripe's API and
+    invoking the same idempotent helpers the webhook uses.
+
+    Idempotency: if the webhook has already fulfilled this purchase
+    (status=COMPLETED), the helpers short-circuit and we just return
+    the latest balance. Concurrent webhook + finalize calls are safe
+    because both acquire ``SELECT ... FOR UPDATE`` on the purchase row.
+
+    Authorization: the session's ``client_reference_id`` must match the
+    authenticated user's id. This prevents a user from finalising
+    someone else's checkout session if they happen to know the id.
+    """
+    stripe_client = get_stripe_client()
+
+    try:
+        checkout_session = stripe_client.v1.checkout.sessions.retrieve(session_id)
+    except StripeError as exc:
+        logger.warning(
+            "finalize_checkout: stripe lookup failed for session=%s user=%s: %s",
+            session_id,
+            user.id,
+            exc,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Checkout session not found.",
+        ) from exc
+
+    # Authorization check: the user finalising must be the user who
+    # initiated the checkout. ``client_reference_id`` is set in
+    # ``create_checkout_session`` / ``create_token_checkout_session``.
+    client_reference_id = getattr(checkout_session, "client_reference_id", None)
+    if client_reference_id != str(user.id):
+        logger.warning(
+            "finalize_checkout: ownership mismatch session=%s client_ref=%s user=%s",
+            session_id,
+            client_reference_id,
+            user.id,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="This checkout session does not belong to you.",
+        )
+
+    metadata = _get_metadata(checkout_session)
+    is_token = _is_token_purchase(metadata)
+    payment_status = getattr(checkout_session, "payment_status", None)
+    session_status = getattr(checkout_session, "status", None)
+
+    is_paid = payment_status in {"paid", "no_payment_required"}
+    is_expired = session_status == "expired"
+
+    if is_paid:
+        if is_token:
+            await _fulfill_completed_token_purchase(db_session, checkout_session)
+        else:
+            await _fulfill_completed_purchase(db_session, checkout_session)
+    elif is_expired:
+        if is_token:
+            await _mark_token_purchase_failed(db_session, str(checkout_session.id))
+        else:
+            await _mark_purchase_failed(db_session, str(checkout_session.id))
+    # Otherwise (e.g. payment_status="unpaid", session_status="open"),
+    # leave the purchase row alone — frontend will keep polling and the
+    # webhook will eventually win the race.
+
+    # Refresh the user row so the response reflects any update applied
+    # by the fulfilment helpers in this same session.
+    await db_session.refresh(user)
+
+    if is_token:
+        purchase = (
+            await db_session.execute(
+                select(PremiumTokenPurchase).where(
+                    PremiumTokenPurchase.stripe_checkout_session_id
+                    == str(checkout_session.id)
+                )
+            )
+        ).scalar_one_or_none()
+        return FinalizeCheckoutResponse(
+            purchase_type="premium_tokens",
+            status=purchase.status.value if purchase else "pending",
+            premium_credit_micros_limit=user.premium_credit_micros_limit,
+            premium_credit_micros_used=user.premium_credit_micros_used,
+            premium_credit_micros_granted=(
+                purchase.credit_micros_granted if purchase else None
+            ),
+        )
+
+    purchase = (
+        await db_session.execute(
+            select(PagePurchase).where(
+                PagePurchase.stripe_checkout_session_id == str(checkout_session.id)
+            )
+        )
+    ).scalar_one_or_none()
+    return FinalizeCheckoutResponse(
+        purchase_type="page_packs",
+        status=purchase.status.value if purchase else "pending",
+        pages_limit=user.pages_limit,
+        pages_used=user.pages_used,
+        pages_granted=purchase.pages_granted if purchase else None,
+    )
 
 
 @router.get("/purchases", response_model=PagePurchaseHistoryResponse)
@@ -550,7 +686,11 @@ def _get_token_checkout_urls(search_space_id: int) -> tuple[str, str]:
             detail="NEXT_FRONTEND_URL is not configured.",
         )
     base_url = config.NEXT_FRONTEND_URL.rstrip("/")
-    success_url = f"{base_url}/dashboard/{search_space_id}/purchase-success"
+    # See ``_get_checkout_urls`` for why session_id is appended.
+    success_url = (
+        f"{base_url}/dashboard/{search_space_id}/purchase-success"
+        f"?session_id={{CHECKOUT_SESSION_ID}}"
+    )
     cancel_url = f"{base_url}/dashboard/{search_space_id}/purchase-cancel"
     return success_url, cancel_url
 
@@ -601,7 +741,11 @@ async def create_token_checkout_session(
                     "user_id": str(user.id),
                     "quantity": str(body.quantity),
                     "credit_micros_per_unit": str(config.STRIPE_CREDIT_MICROS_PER_UNIT),
-                    "purchase_type": "premium_credit",
+                    # Canonical value matched by ``_is_token_purchase``.
+                    # The legacy ``"premium_credit"`` is still accepted on
+                    # the read side for any in-flight sessions started
+                    # before this rename.
+                    "purchase_type": "premium_tokens",
                 },
             }
         )

--- a/surfsense_backend/app/schemas/stripe.py
+++ b/surfsense_backend/app/schemas/stripe.py
@@ -56,6 +56,26 @@ class StripeWebhookResponse(BaseModel):
     received: bool = True
 
 
+class FinalizeCheckoutResponse(BaseModel):
+    """Response from /stripe/finalize-checkout.
+
+    Returned by the success page so the UI can show the post-purchase
+    balance immediately, even when the Stripe webhook hasn't been
+    delivered yet. ``status`` mirrors the underlying purchase row
+    (``pending`` / ``completed`` / ``failed``); the FE polls this
+    endpoint until it sees ``completed`` or a final ``failed``.
+    """
+
+    purchase_type: str  # "page_packs" | "premium_tokens"
+    status: str  # PagePurchaseStatus / PremiumTokenPurchaseStatus value
+    pages_limit: int | None = None
+    pages_used: int | None = None
+    pages_granted: int | None = None
+    premium_credit_micros_limit: int | None = None
+    premium_credit_micros_used: int | None = None
+    premium_credit_micros_granted: int | None = None
+
+
 class CreateTokenCheckoutSessionRequest(BaseModel):
     """Request body for creating a premium token purchase checkout session."""
 

--- a/surfsense_web/app/dashboard/[search_space_id]/purchase-success/page.tsx
+++ b/surfsense_web/app/dashboard/[search_space_id]/purchase-success/page.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { CheckCircle2 } from "lucide-react";
+import { AlertCircle, CheckCircle2, Loader2 } from "lucide-react";
 import Link from "next/link";
-import { useParams } from "next/navigation";
+import { useParams, useSearchParams } from "next/navigation";
+import { useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
 	Card,
@@ -12,23 +13,133 @@ import {
 	CardHeader,
 	CardTitle,
 } from "@/components/ui/card";
+import type { FinalizeCheckoutResponse } from "@/contracts/types/stripe.types";
+import { stripeApiService } from "@/lib/apis/stripe-api.service";
+
+type FinalizeState =
+	| { kind: "loading" }
+	| { kind: "completed"; data: FinalizeCheckoutResponse }
+	| { kind: "pending"; data: FinalizeCheckoutResponse }
+	| { kind: "still_pending"; data: FinalizeCheckoutResponse }
+	| { kind: "failed"; data: FinalizeCheckoutResponse }
+	| { kind: "error"; message: string }
+	| { kind: "no_session" };
+
+const POLL_INTERVAL_MS = 2000;
+const MAX_POLL_ATTEMPTS = 15; // ~30s total before falling back to the still_pending state
 
 export default function PurchaseSuccessPage() {
 	const params = useParams();
+	const searchParams = useSearchParams();
 	const searchSpaceId = String(params.search_space_id ?? "");
+	const sessionId = searchParams.get("session_id");
+
+	const [state, setState] = useState<FinalizeState>(
+		sessionId ? { kind: "loading" } : { kind: "no_session" }
+	);
+	// Tracks active polling so component unmount cancels it
+	const cancelledRef = useRef(false);
+
+	useEffect(() => {
+		if (!sessionId) return;
+
+		cancelledRef.current = false;
+
+		const poll = async (attempt: number): Promise<void> => {
+			if (cancelledRef.current) return;
+			try {
+				const data = await stripeApiService.finalizeCheckout(sessionId);
+				if (cancelledRef.current) return;
+
+				if (data.status === "completed") {
+					setState({ kind: "completed", data });
+					return;
+				}
+				if (data.status === "failed") {
+					setState({ kind: "failed", data });
+					return;
+				}
+
+				// Status is "pending" - either the user paid via async
+				// payment method (Klarna, ACH) or webhook + finalize both
+				// raced and lost. Keep polling up to MAX_POLL_ATTEMPTS,
+				// then fall back to a friendlier message that explains
+				// fulfilment may complete asynchronously.
+				if (attempt < MAX_POLL_ATTEMPTS) {
+					setState({ kind: "pending", data });
+					setTimeout(() => poll(attempt + 1), POLL_INTERVAL_MS);
+				} else {
+					setState({ kind: "still_pending", data });
+				}
+			} catch (err) {
+				if (cancelledRef.current) return;
+				const message = err instanceof Error ? err.message : "Unable to finalize checkout.";
+				setState({ kind: "error", message });
+			}
+		};
+
+		void poll(1);
+
+		return () => {
+			cancelledRef.current = true;
+		};
+	}, [sessionId]);
 
 	return (
 		<div className="flex min-h-[calc(100vh-64px)] items-center justify-center px-4 py-8">
 			<Card className="w-full max-w-lg">
 				<CardHeader className="text-center">
-					<CheckCircle2 className="mx-auto h-10 w-10 text-emerald-500" />
-					<CardTitle className="text-2xl">Purchase complete</CardTitle>
-					<CardDescription>Your purchase is being applied to your account now.</CardDescription>
+					{state.kind === "loading" || state.kind === "pending" ? (
+						<Loader2 className="mx-auto h-10 w-10 animate-spin text-primary" />
+					) : state.kind === "completed" ? (
+						<CheckCircle2 className="mx-auto h-10 w-10 text-emerald-500" />
+					) : (
+						<AlertCircle className="mx-auto h-10 w-10 text-amber-500" />
+					)}
+					<CardTitle className="text-2xl">
+						{state.kind === "loading" && "Confirming payment…"}
+						{state.kind === "pending" && "Processing your payment…"}
+						{state.kind === "still_pending" && "Payment still processing"}
+						{state.kind === "completed" && "Purchase complete"}
+						{state.kind === "failed" && "Purchase failed"}
+						{state.kind === "error" && "Couldn't confirm payment"}
+						{state.kind === "no_session" && "Purchase complete"}
+					</CardTitle>
+					<CardDescription>
+						{state.kind === "loading" && "We're verifying your payment with Stripe."}
+						{state.kind === "pending" &&
+							"Your bank is taking a moment to confirm. This usually takes 5–30 seconds."}
+						{state.kind === "still_pending" &&
+							"Your payment is still being processed by your bank. We'll apply your purchase as soon as it clears — usually within a few minutes. You can safely close this page."}
+						{state.kind === "completed" &&
+							(state.data.purchase_type === "page_packs"
+								? `Added ${formatNumber(state.data.pages_granted ?? 0)} pages to your account.`
+								: `Added ${formatCredit(state.data.premium_credit_micros_granted ?? 0)} of premium credit to your account.`)}
+						{state.kind === "failed" &&
+							"Stripe reported the checkout as failed or expired. Your card was not charged."}
+						{state.kind === "error" &&
+							"Don't worry — if your card was charged, your purchase will still apply within a minute or two."}
+						{state.kind === "no_session" &&
+							"Your purchase is being applied to your account."}
+					</CardDescription>
 				</CardHeader>
 				<CardContent className="space-y-3 text-center">
-					<p className="text-sm text-muted-foreground">
-						Your usage meters should refresh automatically in a moment.
-					</p>
+					{state.kind === "completed" && state.data.purchase_type === "page_packs" && (
+						<p className="text-sm text-muted-foreground">
+							New balance: {formatNumber(state.data.pages_limit ?? 0)} total pages
+							{typeof state.data.pages_used === "number"
+								? ` (${formatNumber((state.data.pages_limit ?? 0) - state.data.pages_used)} remaining)`
+								: ""}
+						</p>
+					)}
+					{state.kind === "completed" && state.data.purchase_type === "premium_tokens" && (
+						<p className="text-sm text-muted-foreground">
+							New premium credit balance: {formatCredit(state.data.premium_credit_micros_limit ?? 0)}
+						</p>
+					)}
+					{state.kind === "error" && (
+						<p className="text-sm text-muted-foreground">{state.message}</p>
+					)}
 				</CardContent>
 				<CardFooter className="flex flex-col gap-2">
 					<Button asChild className="w-full">
@@ -41,4 +152,17 @@ export default function PurchaseSuccessPage() {
 			</Card>
 		</div>
 	);
+}
+
+function formatNumber(n: number): string {
+	return new Intl.NumberFormat("en-US").format(n);
+}
+
+function formatCredit(micros: number): string {
+	const dollars = micros / 1_000_000;
+	return new Intl.NumberFormat("en-US", {
+		style: "currency",
+		currency: "USD",
+		maximumFractionDigits: 2,
+	}).format(dollars);
 }

--- a/surfsense_web/contracts/types/stripe.types.ts
+++ b/surfsense_web/contracts/types/stripe.types.ts
@@ -73,6 +73,19 @@ export const getTokenPurchasesResponse = z.object({
 	purchases: z.array(tokenPurchase),
 });
 
+// Response from /stripe/finalize-checkout. Either page or token fields
+// are populated depending on purchase_type.
+export const finalizeCheckoutResponse = z.object({
+	purchase_type: z.enum(["page_packs", "premium_tokens"]),
+	status: pagePurchaseStatusEnum,
+	pages_limit: z.number().nullable().optional(),
+	pages_used: z.number().nullable().optional(),
+	pages_granted: z.number().nullable().optional(),
+	premium_credit_micros_limit: z.number().nullable().optional(),
+	premium_credit_micros_used: z.number().nullable().optional(),
+	premium_credit_micros_granted: z.number().nullable().optional(),
+});
+
 export type PagePurchaseStatus = z.infer<typeof pagePurchaseStatusEnum>;
 export type CreateCheckoutSessionRequest = z.infer<typeof createCheckoutSessionRequest>;
 export type CreateCheckoutSessionResponse = z.infer<typeof createCheckoutSessionResponse>;
@@ -85,3 +98,4 @@ export type TokenStripeStatusResponse = z.infer<typeof tokenStripeStatusResponse
 export type TokenPurchaseStatus = z.infer<typeof tokenPurchaseStatusEnum>;
 export type TokenPurchase = z.infer<typeof tokenPurchase>;
 export type GetTokenPurchasesResponse = z.infer<typeof getTokenPurchasesResponse>;
+export type FinalizeCheckoutResponse = z.infer<typeof finalizeCheckoutResponse>;

--- a/surfsense_web/lib/apis/stripe-api.service.ts
+++ b/surfsense_web/lib/apis/stripe-api.service.ts
@@ -5,6 +5,8 @@ import {
 	type CreateTokenCheckoutSessionResponse,
 	createCheckoutSessionResponse,
 	createTokenCheckoutSessionResponse,
+	type FinalizeCheckoutResponse,
+	finalizeCheckoutResponse,
 	type GetPagePurchasesResponse,
 	type GetTokenPurchasesResponse,
 	getPagePurchasesResponse,
@@ -53,6 +55,20 @@ class StripeApiService {
 
 	getTokenPurchases = async (): Promise<GetTokenPurchasesResponse> => {
 		return baseApiService.get("/api/v1/stripe/token-purchases", getTokenPurchasesResponse);
+	};
+
+	/**
+	 * Synchronously fulfil a checkout session from the success page.
+	 *
+	 * Solves the race where the user lands on /purchase-success before
+	 * Stripe's checkout.session.completed webhook arrives. Idempotent —
+	 * safe to call concurrently with the webhook.
+	 */
+	finalizeCheckout = async (sessionId: string): Promise<FinalizeCheckoutResponse> => {
+		return baseApiService.get(
+			`/api/v1/stripe/finalize-checkout?session_id=${encodeURIComponent(sessionId)}`,
+			finalizeCheckoutResponse
+		);
 	};
 }
 


### PR DESCRIPTION
<!--- Summarize your pull request in a few sentences -->

## Description
<!--- Clearly describe what has changed in this pull request -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If this PR relates to an open issue, please link to the issue here: FIX #123 -->
FIX #


## Screenshots
<!-- If applicable, add screenshots or images to demonstrate the changes visually -->

## API Changes
<!-- Document any API changes if applicable -->
- [ ] This PR includes API changes

## Change Type
<!--- Indicate what kind(s) of changes this PR includes: -->
- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Dependency/Build system
- [ ] Breaking change
- [ ] Other (specify):

## Testing Performed
<!--- Briefly describe how you have tested these changes and what verification was performed -->
- [ ] Tested locally
- [ ] Manual/QA verification

## Checklist
<!--- Please confirm the following by marking with an 'x' as appropriate -->
- [ ] Follows project coding standards and conventions
- [ ] Documentation updated as needed
- [ ] Dependencies updated as needed
- [ ] No lint/build errors or new warnings
- [ ] All relevant tests are passing

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a race condition in the Stripe checkout flow where users would land on the purchase-success page before the `checkout.session.completed` webhook was delivered. The solution introduces a new `/stripe/finalize-checkout` endpoint that allows the frontend to synchronously fulfill purchases by retrieving the session from Stripe's API on page load. The backend now appends `session_id={{CHECKOUT_SESSION_ID}}` to success URLs so the frontend can call this endpoint immediately. The implementation includes idempotency guarantees, authorization checks (verifying `client_reference_id` matches the authenticated user), and proper handling of concurrent webhook and finalize-checkout calls. The frontend now polls the finalize endpoint until the purchase is completed or displays appropriate fallback messages for async payment methods. Additionally, the code standardizes purchase type metadata from `premium_credit` to `premium_tokens` while maintaining backward compatibility for in-flight sessions.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_backend/app/schemas/stripe.py` |
| 2 | `surfsense_web/contracts/types/stripe.types.ts` |
| 3 | `surfsense_backend/app/routes/stripe_routes.py` |
| 4 | `surfsense_web/lib/apis/stripe-api.service.ts` |
| 5 | `surfsense_web/app/dashboard/[search_space_id]/purchase-success/page.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Purchase success page now polls for real-time checkout completion status with improved error handling and feedback.
  * Displays updated balance information immediately after successful purchase.
  * Enhanced consistency in purchase type processing across checkout flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->