### PR TITLE
feat(chunker): add table-aware chunk_text_hybrid to prevent mid-row table splits

### DIFF
--- a/surfsense_backend/app/indexing_pipeline/document_chunker.py
+++ b/surfsense_backend/app/indexing_pipeline/document_chunker.py
@@ -1,4 +1,14 @@
+import re
+
 from app.config import config
+
+# Regex that matches a Markdown table block (header + separator + one or more rows)
+# A table block starts with a | at the beginning of a line and ends when a
+# non-table line (or end of string) is encountered.
+_TABLE_BLOCK_RE = re.compile(
+    r"(?:(?:^|\n)(?=[ \t]*\|)(?:[ \t]*\|[^\n]*\n)+)",
+    re.MULTILINE,
+)
 
 
 def chunk_text(text: str, use_code_chunker: bool = False) -> list[str]:
@@ -7,3 +17,43 @@ def chunk_text(text: str, use_code_chunker: bool = False) -> list[str]:
         config.code_chunker_instance if use_code_chunker else config.chunker_instance
     )
     return [c.text for c in chunker.chunk(text)]
+
+
+def chunk_text_hybrid(text: str) -> list[str]:
+    """Table-aware chunker that prevents Markdown tables from being split mid-row.
+
+    Algorithm:
+    1. Scan the document for Markdown table blocks.
+    2. Each table block is emitted as a single, unmodified chunk so that its
+       header, separator row, and data rows always stay together.
+    3. The non-table prose segments between (and around) tables are passed through
+       the normal ``chunk_text`` chunker and their sub-chunks are interleaved in
+       document order.
+
+    This ensures that table data is never sliced in the middle by the token-based
+    chunker, which would otherwise produce garbled rows that are useless for RAG.
+
+    Fixes #1334.
+    """
+    chunks: list[str] = []
+    cursor = 0
+
+    for match in _TABLE_BLOCK_RE.finditer(text):
+        # Prose before this table
+        prose = text[cursor : match.start()].strip()
+        if prose:
+            chunks.extend(chunk_text(prose))
+
+        # The table itself is kept as one indivisible chunk
+        table_block = match.group(0).strip()
+        if table_block:
+            chunks.append(table_block)
+
+        cursor = match.end()
+
+    # Remaining prose after the last table (or entire text if no tables)
+    trailing = text[cursor:].strip()
+    if trailing:
+        chunks.extend(chunk_text(trailing))
+
+    return chunks

--- a/surfsense_backend/app/indexing_pipeline/indexing_pipeline_service.py
+++ b/surfsense_backend/app/indexing_pipeline/indexing_pipeline_service.py
@@ -19,7 +19,7 @@ from app.db import (
     DocumentType,
 )
 from app.indexing_pipeline.connector_document import ConnectorDocument
-from app.indexing_pipeline.document_chunker import chunk_text
+from app.indexing_pipeline.document_chunker import chunk_text, chunk_text_hybrid
 from app.indexing_pipeline.document_embedder import embed_texts
 from app.indexing_pipeline.document_hashing import (
     compute_content_hash,
@@ -387,11 +387,19 @@ class IndexingPipelineService:
             )
 
             t_step = time.perf_counter()
-            chunk_texts = await asyncio.to_thread(
-                chunk_text,
-                connector_doc.source_markdown,
-                use_code_chunker=connector_doc.should_use_code_chunker,
-            )
+            if connector_doc.should_use_code_chunker:
+                chunk_texts = await asyncio.to_thread(
+                    chunk_text,
+                    connector_doc.source_markdown,
+                    use_code_chunker=True,
+                )
+            else:
+                # Use the table-aware hybrid chunker so Markdown tables are not
+                # split mid-row (see issue #1334).
+                chunk_texts = await asyncio.to_thread(
+                    chunk_text_hybrid,
+                    connector_doc.source_markdown,
+                )
 
             texts_to_embed = [content, *chunk_texts]
             embeddings = await asyncio.to_thread(embed_texts, texts_to_embed)


### PR DESCRIPTION
…able splits

Document_chunker currently splits Markdown tables mid-row when the table is larger than a single chunk window, producing garbled rows that are useless for RAG retrieval (issue #1334).

Changes:
- document_chunker.py: add chunk_text_hybrid() that detects Markdown table blocks with a regex, emits each table as an indivisible single chunk, and feeds the surrounding prose through the normal chunk_text() chunker.
- indexing_pipeline_service.py: route normal (non-code) documents through chunk_text_hybrid instead of chunk_text so tables are protected by default.

Fixes #1334

## Description

<!--- Summarize your pull request in a few sentences -->

This PR adds a `chunk_text_hybrid()` function to the document chunker and wires it into the indexing pipeline so that Markdown tables are never split mid-row during document ingestion.

## Description

The original `chunk_text()` function treats the entire document as a flat character stream, so Markdown tables often get cut in the middle when the table is wider than a single chunk window. This produces garbled, incomplete rows that are useless for RAG retrieval.

**Changes:**

### `surfsense_backend/app/indexing_pipeline/document_chunker.py`

- Added `_TABLE_BLOCK_RE` regex to detect Markdown table blocks (header + separator + rows)
- Added `chunk_text_hybrid(text)`:
  1. Finds all Markdown table blocks in the document
  2. Emits each table as a single, indivisible chunk
  3. Passes non-table prose segments through the existing `chunk_text()` chunker
  4. Returns chunks in document order

### `surfsense_backend/app/indexing_pipeline/indexing_pipeline_service.py`

- Updated the chunking call site to use `chunk_text_hybrid` for normal (non-code) documents
- Code documents still use `chunk_text(use_code_chunker=True)` as before

## Screenshots

| Before | After |
|--------|-------|
| Table rows split across chunks | Each table is one indivisible chunk |

## Checklist

- [x] I have read the contributing guidelines
- [x] This change does not require a documentation update
- [x] Backwards-compatible — `chunk_text()` is unchanged; `chunk_text_hybrid()` is additive
- [x] No external dependencies added

Fixes #1334

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR introduces a table-aware text chunking mechanism to prevent Markdown tables from being split mid-row during document ingestion. A new `chunk_text_hybrid()` function detects Markdown table blocks using regex, emits each complete table as an indivisible chunk, and processes surrounding prose text through the existing chunker. The indexing pipeline now routes non-code documents through this hybrid chunker by default, ensuring table data remains intact for RAG retrieval while preserving the original chunking behavior for code documents.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_backend/app/indexing_pipeline/document_chunker.py` |
| 2 | `surfsense_backend/app/indexing_pipeline/indexing_pipeline_service.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->