### PR TITLE
feat(a11y): add aria-label to clickable media cards

### DIFF
--- a/surfsense_web/components/homepage/use-cases-grid.tsx
+++ b/surfsense_web/components/homepage/use-cases-grid.tsx
@@ -68,6 +68,7 @@ function UseCaseCard({
 				<div
 					role="button"
 					tabIndex={0}
+					aria-label={`Expand ${title}`}
 					className="cursor-pointer overflow-hidden bg-neutral-50 p-2 dark:bg-neutral-950"
 					onClick={open}
 					onKeyDown={(e) => {

--- a/surfsense_web/components/ui/hero-carousel.tsx
+++ b/surfsense_web/components/ui/hero-carousel.tsx
@@ -118,6 +118,7 @@ function HeroCarouselCard({
 				<div
 					role="button"
 					tabIndex={0}
+					aria-label={`Expand ${title}`}
 					className="cursor-pointer bg-neutral-50 p-2 sm:p-3 dark:bg-neutral-950"
 					onClick={open}
 					onKeyDown={(e) => {


### PR DESCRIPTION
## Summary
Adds the missing `aria-label` to the two clickable media cards on the homepage so screen readers announce what each card does. The cards already had `role="button"`, `tabIndex={0}`, and `onKeyDown` from earlier work; this completes the four-attribute set called out in #913.

## Why this matters
@MODSetter filed #913 on 2026-03-24 listing four required attributes for keyboard accessibility on `surfsense_web/components/ui/hero-carousel.tsx:107` and `surfsense_web/components/homepage/use-cases-grid.tsx:66-74`. Re-reading both files at HEAD: `role`, `tabIndex`, and `onKeyDown` are all present (`hero-carousel.tsx:118-129` and `use-cases-grid.tsx:67-79`). Only the `aria-label` was outstanding. The two-line addition uses the exact pattern from the issue's example: `aria-label={`Expand ${title}`}`. Without an accessible name, screen readers fall back to the inner image alt-text or the video element, which doesn't convey the affordance.

## Testing
- Visually inspected both clickable divs at HEAD before editing
- Verified `title` prop is in scope at both edit sites (the `HeroCarouselCard` props at `hero-carousel.tsx:68` and `UseCaseCard` at `use-cases-grid.tsx:51`)
- Diff is +2 lines

Fixes #913

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds `aria-label` attributes to two clickable media cards on the homepage to improve screen reader accessibility. The cards already had `role="button"`, `tabIndex`, and `onKeyDown` handlers; this completes the set of required attributes for proper keyboard accessibility by providing an accessible name that announces the expand action to screen reader users.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/components/homepage/use-cases-grid.tsx` |
| 2 | `surfsense_web/components/ui/hero-carousel.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->