### PR TITLE
refactor(web): extract formatThreadTimestamp helper for chat sidebars

### DIFF
--- a/surfsense_web/components/layout/ui/sidebar/AllPrivateChatsSidebar.tsx
+++ b/surfsense_web/components/layout/ui/sidebar/AllPrivateChatsSidebar.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { format } from "date-fns";
 import {
 	ArchiveIcon,
 	ChevronLeft,
@@ -47,6 +46,7 @@ import {
 	searchThreads,
 	updateThread,
 } from "@/lib/chat/thread-persistence";
+import { formatThreadTimestamp } from "@/lib/format-date";
 import { cn } from "@/lib/utils";
 import { SidebarSlideOutPanel } from "./SidebarSlideOutPanel";
 
@@ -392,8 +392,7 @@ export function AllPrivateChatsSidebar({
 											</TooltipTrigger>
 											<TooltipContent side="bottom" align="start">
 												<p>
-													{t("updated") || "Updated"}:{" "}
-													{format(new Date(thread.updatedAt), "MMM d, yyyy 'at' h:mm a")}
+													{t("updated") || "Updated"}: {formatThreadTimestamp(thread.updatedAt)}
 												</p>
 											</TooltipContent>
 										</Tooltip>

--- a/surfsense_web/components/layout/ui/sidebar/AllSharedChatsSidebar.tsx
+++ b/surfsense_web/components/layout/ui/sidebar/AllSharedChatsSidebar.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { format } from "date-fns";
 import {
 	ArchiveIcon,
 	ChevronLeft,
@@ -47,6 +46,7 @@ import {
 	searchThreads,
 	updateThread,
 } from "@/lib/chat/thread-persistence";
+import { formatThreadTimestamp } from "@/lib/format-date";
 import { cn } from "@/lib/utils";
 import { SidebarSlideOutPanel } from "./SidebarSlideOutPanel";
 
@@ -392,8 +392,7 @@ export function AllSharedChatsSidebar({
 											</TooltipTrigger>
 											<TooltipContent side="bottom" align="start">
 												<p>
-													{t("updated") || "Updated"}:{" "}
-													{format(new Date(thread.updatedAt), "MMM d, yyyy 'at' h:mm a")}
+													{t("updated") || "Updated"}: {formatThreadTimestamp(thread.updatedAt)}
 												</p>
 											</TooltipContent>
 										</Tooltip>

--- a/surfsense_web/lib/format-date.ts
+++ b/surfsense_web/lib/format-date.ts
@@ -22,3 +22,11 @@ export function formatRelativeDate(dateString: string): string {
 	if (daysAgo < 7) return `${daysAgo}d ago`;
 	return format(date, "MMM d, yyyy");
 }
+
+/**
+ * Format a thread's last-updated timestamp for the chats sidebars.
+ * Example: "Mar 23, 2026 at 4:30 PM"
+ */
+export function formatThreadTimestamp(dateString: string): string {
+	return format(new Date(dateString), "MMM d, yyyy 'at' h:mm a");
+}


### PR DESCRIPTION
## Summary

Closes #1376.

`AllPrivateChatsSidebar.tsx` and `AllSharedChatsSidebar.tsx` had byte-identical
inline `date-fns` calls for the thread "updated at" tooltip:

```tsx
{format(new Date(thread.updatedAt), "MMM d, yyyy 'at' h:mm a")}
```

Extract the shared format string into a `formatThreadTimestamp` helper in
`surfsense_web/lib/format-date.ts`, sibling of the existing
`formatRelativeDate`. Future date-format or i18n changes now have one place
to edit instead of two files in lockstep.

## Implementation (matches the issue's "What to do" steps verbatim)

| File | Change |
| --- | --- |
| `surfsense_web/lib/format-date.ts` | New `formatThreadTimestamp(dateString: string): string` |
| `surfsense_web/components/layout/ui/sidebar/AllPrivateChatsSidebar.tsx` | Use the helper; drop the now-unused `format` import (only used in this one line in this file) |
| `surfsense_web/components/layout/ui/sidebar/AllSharedChatsSidebar.tsx` | Same as above |

```ts
/**
 * Format a thread's last-updated timestamp for the chats sidebars.
 * Example: "Mar 23, 2026 at 4:30 PM"
 */
export function formatThreadTimestamp(dateString: string): string {
	return format(new Date(dateString), "MMM d, yyyy 'at' h:mm a");
}
```

## Acceptance criteria from #1376

- [x] `formatThreadTimestamp` exported from `lib/format-date.ts`
- [x] Both sidebars use the helper
- [x] Sidebars render identical timestamp strings as before (same format
      string, same `new Date()` construction; output is byte-equivalent)

## Verification

```
biome check components/layout/ui/sidebar/AllPrivateChatsSidebar.tsx \
            components/layout/ui/sidebar/AllSharedChatsSidebar.tsx \
            lib/format-date.ts
# Pre-existing import-ordering warnings only (also present on origin/main);
# no new diagnostics from this change.

biome format --write <those files>
# Reformatted the tooltip JSX from:
#   {t("updated") || "Updated"}:{" "}
#   {format(new Date(thread.updatedAt), "MMM d, yyyy 'at' h:mm a")}
# to:
#   {t("updated") || "Updated"}: {formatThreadTimestamp(thread.updatedAt)}
# (Same string output; biome collapses now-shorter line.)

npx tsc --noEmit
# No new errors in the touched files.
```

## Diff size

3 files changed, 12 insertions(+), 6 deletions(-).

## Notes

- I deliberately ran `biome format --write` rather than `biome check
  --write` on the sidebar files, so only formatting (not import
  reordering) was applied. The remaining import-ordering warnings the
  biome `check` surface are pre-existing (verified by stashing my
  change and re-running biome on origin/main) -- happy to take them
  in a separate "biome organizeImports cleanup" PR if you'd like.
- One micro-shift: `{t("updated") || "Updated"}:{" "}` + the now-shorter
  call now fits on a single line, so biome collapsed those two JSX
  lines into one. That's a render-equivalent change (same characters
  emitted, same `:` separator, same space between).


<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR extracts a duplicated date formatting call from two chat sidebar components into a shared `formatThreadTimestamp` helper function in `lib/format-date.ts`. Both `AllPrivateChatsSidebar.tsx` and `AllSharedChatsSidebar.tsx` had identical inline `date-fns` format calls for displaying thread update timestamps. The new helper consolidates this formatting logic into a single, reusable location, making future date format or internationalization changes easier to maintain.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/lib/format-date.ts` |
| 2 | `surfsense_web/components/layout/ui/sidebar/AllPrivateChatsSidebar.tsx` |
| 3 | `surfsense_web/components/layout/ui/sidebar/AllSharedChatsSidebar.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated timestamp formatting across chat sidebars. The "Updated" timestamps in both private and shared conversation lists now use unified date and time formatting through a centralized helper utility, ensuring consistent temporal information display throughout your chat experience and improving overall application consistency and maintainability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MODSetter/SurfSense/pull/1378)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->