### PR TITLE
fix(auth): remove redundant token storage write

### DIFF
--- a/surfsense_web/app/auth/callback/page.tsx
+++ b/surfsense_web/app/auth/callback/page.tsx
@@ -8,11 +8,7 @@ export default function AuthCallbackPage() {
 	// TokenHandler uses useGlobalLoadingEffect to show the loading screen
 	return (
 		<Suspense fallback={null}>
-			<TokenHandler
-				redirectPath="/dashboard"
-				tokenParamName="token"
-				storageKey="surfsense_bearer_token"
-			/>
+			<TokenHandler redirectPath="/dashboard" tokenParamName="token" />
 		</Suspense>
 	);
 }

--- a/surfsense_web/components/TokenHandler.tsx
+++ b/surfsense_web/components/TokenHandler.tsx
@@ -9,7 +9,6 @@ import { trackLoginSuccess } from "@/lib/posthog/events";
 interface TokenHandlerProps {
 	redirectPath?: string; // Default path to redirect after storing token (if no saved path)
 	tokenParamName?: string; // Name of the URL parameter containing the token
-	storageKey?: string; // Key to use when storing in localStorage (kept for backwards compatibility)
 }
 
 /**
@@ -19,12 +18,10 @@ interface TokenHandlerProps {
  *
  * @param redirectPath - Default path to redirect after storing token (default: '/dashboard')
  * @param tokenParamName - Name of the URL parameter containing the token (default: 'token')
- * @param storageKey - Key to use when storing in localStorage (default: 'surfsense_bearer_token')
  */
 const TokenHandler = ({
 	redirectPath = "/dashboard",
 	tokenParamName = "token",
-	storageKey = "surfsense_bearer_token",
 }: TokenHandlerProps) => {
 	// Always show loading for this component - spinner animation won't reset
 	useGlobalLoadingEffect(true);
@@ -45,7 +42,6 @@ const TokenHandler = ({
 					}
 					sessionStorage.removeItem("login_success_tracked");
 
-					localStorage.setItem(storageKey, token);
 					setBearerToken(token);
 
 					if (refreshToken) {
@@ -78,7 +74,7 @@ const TokenHandler = ({
 		};
 
 		run();
-	}, [tokenParamName, storageKey, redirectPath]);
+	}, [tokenParamName, redirectPath]);
 
 	// Return null - the global provider handles the loading UI
 	return null;


### PR DESCRIPTION
## Summary
- remove the redundant raw localStorage write from TokenHandler
- rely on setBearerToken(token) so browser storage and Electron sync stay on the same path
- remove the now-unused storageKey prop from the auth callback usage

Fixes #1365.

## Validation
- pnpm install --frozen-lockfile
- pnpm exec biome check components/TokenHandler.tsx app/auth/callback/page.tsx --max-diagnostics 500
- git diff --check
- pnpm exec tsc --noEmit --pretty false currently fails on existing repo-wide TypeScript errors unrelated to these files, including MDX component prop types in blog/changelog pages, dashboard layout implicit-any values, assistant-ui connector types, missing @playwright/test types, and the missing ElectronAPI global type.

## Not run
- Manual OAuth callback flow; this environment does not have project credentials.
- Desktop Electron token propagation; validated by keeping the existing setBearerToken path intact.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR removes a redundant direct `localStorage.setItem()` call from the `TokenHandler` component, consolidating token storage to rely solely on the existing `setBearerToken()` function. This ensures browser storage and Electron sync remain on the same code path. The now-unused `storageKey` prop is also removed from both the component interface and its usage in the auth callback page.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/components/TokenHandler.tsx` |
| 2 | `surfsense_web/app/auth/callback/page.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->