### PR TITLE
fix(auth): centralize redirect path storage

### DIFF
--- a/surfsense_web/app/(home)/login/page.tsx
+++ b/surfsense_web/app/(home)/login/page.tsx
@@ -8,6 +8,7 @@ import { toast } from "sonner";
 import { Logo } from "@/components/Logo";
 import { useGlobalLoadingEffect } from "@/hooks/use-global-loading";
 import { getAuthErrorDetails, shouldRetry } from "@/lib/auth-errors";
+import { setRedirectPath } from "@/lib/auth-utils";
 import { AUTH_TYPE } from "@/lib/env-config";
 import { AmbientBackground } from "./AmbientBackground";
 import { GoogleLoginButton } from "./GoogleLoginButton";
@@ -33,7 +34,7 @@ function LoginContent() {
 		// Save returnUrl to localStorage so it persists through OAuth flows (e.g., Google)
 		// This is read by TokenHandler after successful authentication
 		if (returnUrl) {
-			localStorage.setItem("surfsense_redirect_path", decodeURIComponent(returnUrl));
+			setRedirectPath(decodeURIComponent(returnUrl));
 		}
 
 		// Show registration success message

--- a/surfsense_web/app/invite/[invite_code]/page.tsx
+++ b/surfsense_web/app/invite/[invite_code]/page.tsx
@@ -31,7 +31,7 @@ import {
 import { Spinner } from "@/components/ui/spinner";
 import type { AcceptInviteResponse } from "@/contracts/types/invites.types";
 import { invitesApiService } from "@/lib/apis/invites-api.service";
-import { getBearerToken } from "@/lib/auth-utils";
+import { getBearerToken, setRedirectPath } from "@/lib/auth-utils";
 import {
 	trackSearchSpaceInviteAccepted,
 	trackSearchSpaceInviteDeclined,
@@ -125,7 +125,7 @@ export default function InviteAcceptPage() {
 		// Store the invite code to redirect back after login
 		localStorage.setItem("pending_invite_code", inviteCode);
 		// Save the current invite page URL so we can return after authentication
-		localStorage.setItem("surfsense_redirect_path", `/invite/${inviteCode}`);
+		setRedirectPath(`/invite/${inviteCode}`);
 		// Redirect to login (we manually set the path above since invite pages need special handling)
 		window.location.href = "/login";
 	};

--- a/surfsense_web/lib/auth-utils.ts
+++ b/surfsense_web/lib/auth-utils.ts
@@ -60,10 +60,18 @@ export function handleUnauthorized(): void {
 		const currentPath = pathname + window.location.search + window.location.hash;
 		const excludedPaths = ["/auth", "/auth/callback", "/"];
 		if (!excludedPaths.includes(pathname)) {
-			localStorage.setItem(REDIRECT_PATH_KEY, currentPath);
+			setRedirectPath(currentPath);
 		}
 		window.location.href = getLoginPath();
 	}
+}
+
+/**
+ * Stores the path to redirect to after successful authentication.
+ */
+export function setRedirectPath(path: string): void {
+	if (typeof window === "undefined") return;
+	localStorage.setItem(REDIRECT_PATH_KEY, path);
 }
 
 /**
@@ -230,7 +238,7 @@ export function redirectToLogin(): void {
 	// Don't save auth-related paths or home page
 	const excludedPaths = ["/auth", "/auth/callback", "/", "/login", "/register", "/desktop/login"];
 	if (!excludedPaths.includes(window.location.pathname)) {
-		localStorage.setItem(REDIRECT_PATH_KEY, currentPath);
+		setRedirectPath(currentPath);
 	}
 
 	window.location.href = getLoginPath();


### PR DESCRIPTION
## Summary
- export setRedirectPath() from uth-utils
- route redirect-path writes in login, invite, handleUnauthorized(), and edirectToLogin() through that helper
- leave the surfsense_redirect_path storage key private to uth-utils

Fixes #1364.

## Validation
- pnpm exec biome format --write lib/auth-utils.ts app/(home)/login/page.tsx app/invite/[invite_code]/page.tsx
- pnpm exec biome check lib/auth-utils.ts app/(home)/login/page.tsx app/invite/[invite_code]/page.tsx --max-diagnostics 500 passes with existing warnings in login/invite files
- g -n 'surfsense_redirect_path' surfsense_web only reports lib/auth-utils.ts
- git diff --check
- pnpm exec tsc --noEmit --pretty false currently fails on existing repo-wide TypeScript errors unrelated to these files, including MDX component prop types, assistant-ui connector types, missing @playwright/test types, missing ElectronAPI, and locale/schema type mismatches.

## Not run
- Manual Google OAuth return-url flow; this environment does not have project credentials.
- Manual invite login return flow; this environment does not have a valid invite/backend session.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR centralizes redirect path storage logic by extracting direct `localStorage.setItem` calls into a new `setRedirectPath()` helper function exported from `auth-utils`. The change ensures that all redirect path writes throughout the authentication flow (login, invite acceptance, unauthorized handling, and redirect to login) use a single, consistent method, keeping the `surfsense_redirect_path` storage key private to the auth utilities module.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/lib/auth-utils.ts` |
| 2 | `surfsense_web/app/(home)/login/page.tsx` |
| 3 | `surfsense_web/app/invite/[invite_code]/page.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->