### PR TITLE
docs(editor): align PlateEditor onSave JSDoc with Mod+Shift+S chord

### DIFF
--- a/surfsense_web/components/editor/plate-editor.tsx
+++ b/surfsense_web/components/editor/plate-editor.tsx
@@ -42,7 +42,7 @@ export interface PlateEditorProps {
 	editorVariant?: "default" | "demo" | "fullWidth" | "none";
 	/** Additional className for the container */
 	className?: string;
-	/** Save callback. When provided, ⌘+S / Ctrl+S shortcut is registered and save button appears. */
+	/** Save callback. When provided, ⌘+Shift+S / Ctrl+Shift+S shortcut is registered (avoiding the browser's ⌘+S / Ctrl+S "Save Page As" conflict) and a save button appears in the toolbar. */
 	onSave?: () => void;
 	/** Whether there are unsaved changes */
 	hasUnsavedChanges?: boolean;


### PR DESCRIPTION
<!-- Summarize your pull request in a few sentences -->
Aligns the `PlateEditor` `onSave` JSDoc with the registered keyboard chord. The doc said `⌘+S / Ctrl+S` but the `SaveShortcutPlugin` registers `Mod+Shift+S`. The Shift requirement is intentional (it avoids the browser's "Save Page As" conflict), so the right fix is to update the doc comment, not the chord — same conclusion the issue reaches.

## Description
Changes the JSDoc on `PlateEditorProps.onSave` in `surfsense_web/components/editor/plate-editor.tsx` from "`⌘+S / Ctrl+S` shortcut is registered" to "`⌘+Shift+S / Ctrl+Shift+S` shortcut is registered (avoiding the browser's `⌘+S / Ctrl+S` 'Save Page As' conflict) and a save button appears in the toolbar." The actual chord at line 135 (`keys: [[Key.Mod, Key.Shift, "s"]]`) is unchanged.

## Motivation and Context
<!-- If this PR relates to an open issue, please link to the issue here: FIX #123 -->
FIX #1373

Misleading doc comments on a public component prop are the kind of interface drift that nudges future contributors toward "fixing" the wrong side. Keeping JSDoc honest is cheap and prevents a regression where someone removes `Key.Shift` to match the doc.

## Screenshots
<!-- Doc comment only; no UI change. -->
None applicable — single-line JSDoc edit, no rendered output.

## API Changes
- [ ] This PR includes API changes

## Change Type
- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [x] Documentation
- [ ] Dependency/Build system
- [ ] Breaking change
- [ ] Other (specify):

## Testing Performed
- [x] Tested locally
- [x] Manual/QA verification

Verified by grepping the file: the JSDoc now matches the `Key.Mod, Key.Shift, "s"` chord array in `SaveShortcutPlugin`.

## Checklist
- [x] Follows project coding standards and conventions
- [x] Documentation updated as needed
- [x] Dependencies updated as needed
- [x] No lint/build errors or new warnings
- [x] All relevant tests are passing

AI disclosure: authored with Claude as a coding assistant; I reviewed the change before pushing.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR corrects the JSDoc comment for the `PlateEditor` component's `onSave` prop to accurately reflect the keyboard shortcut that is actually registered. The documentation previously stated `⌘+S / Ctrl+S`, but the implementation uses `⌘+Shift+S / Ctrl+Shift+S` to avoid conflicts with the browser's native "Save Page As" functionality. The updated comment now matches the actual `Mod+Shift+S` chord implementation and explains the rationale for including the Shift key.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/components/editor/plate-editor.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the editor's save keyboard shortcut uses `⌘+Shift+S` (Mac) or `Ctrl+Shift+S` (Windows/Linux) to avoid browser conflicts, and a save button is available in the toolbar.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MODSetter/SurfSense/pull/1386)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->