### PR TITLE
fix(web): invalidate all log cache keys on log mutations

### DIFF
--- a/surfsense_web/atoms/logs/log-mutation.atoms.ts
+++ b/surfsense_web/atoms/logs/log-mutation.atoms.ts
@@ -19,10 +19,8 @@ export const createLogMutationAtom = atomWithMutation((get) => {
 		enabled: !!searchSpaceId,
 		mutationFn: async (request: CreateLogRequest) => logsApiService.createLog(request),
 		onSuccess: () => {
-			queryClient.invalidateQueries({ queryKey: cacheKeys.logs.list(searchSpaceId ?? undefined) });
-			queryClient.invalidateQueries({
-				queryKey: cacheKeys.logs.summary(searchSpaceId ?? undefined),
-			});
+			// Invalidate all log-related queries (list, summary, detail, withQueryParams)
+			queryClient.invalidateQueries({ queryKey: ["logs"] });
 		},
 	};
 });
@@ -38,11 +36,7 @@ export const updateLogMutationAtom = atomWithMutation((get) => {
 		mutationFn: async ({ logId, data }: { logId: number; data: UpdateLogRequest }) =>
 			logsApiService.updateLog(logId, data),
 		onSuccess: (_data, variables) => {
-			queryClient.invalidateQueries({ queryKey: cacheKeys.logs.detail(variables.logId) });
-			queryClient.invalidateQueries({ queryKey: cacheKeys.logs.list(searchSpaceId ?? undefined) });
-			queryClient.invalidateQueries({
-				queryKey: cacheKeys.logs.summary(searchSpaceId ?? undefined),
-			});
+			queryClient.invalidateQueries({ queryKey: ["logs"] });
 		},
 	};
 });
@@ -57,12 +51,7 @@ export const deleteLogMutationAtom = atomWithMutation((get) => {
 		enabled: !!searchSpaceId,
 		mutationFn: async (request: DeleteLogRequest) => logsApiService.deleteLog(request),
 		onSuccess: (_data, request) => {
-			queryClient.invalidateQueries({ queryKey: cacheKeys.logs.list(searchSpaceId ?? undefined) });
-			queryClient.invalidateQueries({
-				queryKey: cacheKeys.logs.summary(searchSpaceId ?? undefined),
-			});
-			if (request?.id)
-				queryClient.invalidateQueries({ queryKey: cacheKeys.logs.detail(request.id) });
+			queryClient.invalidateQueries({ queryKey: ["logs"] });
 		},
 	};
 });


### PR DESCRIPTION
Fixes #1369

Log create/update/delete mutations were invalidating cacheKeys.logs.list(...) and cacheKeys.logs.summary(...), but useLogs subscribes to cacheKeys.logs.withQueryParams(...) — a different query key. This caused UI staleness after mutations until the 3-minute staleTime elapsed.

Switch all three mutation atoms (createLogMutationAtom, updateLogMutationAtom, deleteLogMutationAtom) to invalidate the ["logs"] prefix, which covers list, summary, detail, and withQueryParams.

See: https://github.com/MODSetter/SurfSense/issues/1369

Fixes #1369 — log create/update/delete mutations did not invalidate the
query keys that `useLogs` actually subscribes to, causing UI staleness.

## Description

**Problem** (Fixes #1369):

`useLogs` subscribes to:
```ts
cacheKeys.logs.withQueryParams({ search_space_id, ...filters })
// produces ["logs", "with-query-params", ...]
```

But the three log mutation atoms were only invalidating:
```ts
queryClient.invalidateQueries({ queryKey: cacheKeys.logs.list(...) });
// ["logs", "list", id]
queryClient.invalidateQueries({ queryKey: cacheKeys.logs.summary(...) });
// ["logs", "summary", id]
```

`["logs", "list", id]` and `["logs", "with-query-params", ...]` are
sibling branches under `["logs"]` — TanStack Query does NOT cascade
from sibling to sibling. Result: after creating/updating/deleting a log,
the UI stayed stale until the 3-minute `staleTime` elapsed.

**Fix**:

Replace the narrow invalidations with a prefix-level invalidation:
```ts
queryClient.invalidateQueries({ queryKey: ["logs"] });
```

This covers `list`, `summary`, `detail`, and `withQueryParams` in one
shot. Log mutations are rare enough that the extra refetch cost is
acceptable.

Applied to all three mutation atoms:
- `createLogMutationAtom`
- `updateLogMutationAtom`
- `deleteLogMutationAtom`

## Motivation and Context

- Restores the invariant "mutate → relevant queries refetch" that
  contributors expect.
- Aligns the cache-keys module with consumer reality.
- Removes a class of "why is the UI stale?" support questions.

## Screenshots

N/A (behavior fix — verify by creating/deleting a log and observing
immediate UI refresh)

## API Changes

- [ ] This PR includes API changes

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Dependency/Build system
- [ ] Breaking change
- [ ] Other (specify):

## Testing Performed

- [x] Tested locally (create/delete log → list refreshes immediately)
- [ ] Manual/QA verification

## Checklist

- [x] Follows project coding standards and conventions
- [ ] Documentation updated as needed
- [x] No lint/build errors or new warnings
- [ ] All relevant tests are passing

---

**Branch**: `fix/log-mutations-invalidate-all-keys-1369`
**Commit**: `fix(web): invalidate all log cache keys on log mutations`

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a cache invalidation bug where log create, update, and delete mutations were only invalidating specific query keys (`list` and `summary`) but not the `withQueryParams` key that the `useLogs` hook actually subscribes to. This caused the UI to remain stale after mutations until the 3-minute `staleTime` elapsed. The fix replaces narrow invalidations with a broad prefix-level invalidation of `["logs"]`, ensuring all log-related queries (list, summary, detail, and withQueryParams) are refreshed immediately after any mutation.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/atoms/logs/log-mutation.atoms.ts` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->