### PR TITLE
feat(shared): extract formatThreadTimestamp helper for chats sidebars…

### DIFF
--- a/surfsense_web/components/layout/ui/sidebar/AllPrivateChatsSidebar.tsx
+++ b/surfsense_web/components/layout/ui/sidebar/AllPrivateChatsSidebar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { format } from "date-fns";
+import { formatThreadTimestamp } from "@/lib/format-date";
 import { useSetAtom } from "jotai";
 import {
 	ArchiveIcon,
@@ -390,7 +390,7 @@ export function AllPrivateChatsSidebarContent({
 											<TooltipContent side="bottom" align="start">
 												<p>
 													{t("updated") || "Updated"}:{" "}
-													{format(new Date(thread.updatedAt), "MMM d, yyyy 'at' h:mm a")}
+													{formatThreadTimestamp(thread.updatedAt)}
 												</p>
 											</TooltipContent>
 										</Tooltip>

--- a/surfsense_web/components/layout/ui/sidebar/AllSharedChatsSidebar.tsx
+++ b/surfsense_web/components/layout/ui/sidebar/AllSharedChatsSidebar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { format } from "date-fns";
+import { formatThreadTimestamp } from "@/lib/format-date";
 import { useSetAtom } from "jotai";
 import {
 	ArchiveIcon,
@@ -389,7 +389,7 @@ export function AllSharedChatsSidebarContent({
 											<TooltipContent side="bottom" align="start">
 												<p>
 													{t("updated") || "Updated"}:{" "}
-													{format(new Date(thread.updatedAt), "MMM d, yyyy 'at' h:mm a")}
+													{formatThreadTimestamp(thread.updatedAt)}
 												</p>
 											</TooltipContent>
 										</Tooltip>

--- a/surfsense_web/lib/format-date.ts
+++ b/surfsense_web/lib/format-date.ts
@@ -22,3 +22,11 @@ export function formatRelativeDate(dateString: string): string {
 	if (daysAgo < 7) return `${daysAgo}d ago`;
 	return format(date, "MMM d, yyyy");
 }
+
+/**
+ * Format a thread's last-updated timestamp for the chats sidebars.
+ * Example: "Mar 23, 2026 at 4:30 PM"
+ */
+export function formatThreadTimestamp(dateString: string): string {
+	return format(new Date(dateString), "MMM d, yyyy 'at' h:mm a");
+}


### PR DESCRIPTION
… (fixes #1376)

- Add formatThreadTimestamp() to surfsense_web/lib/format-date.ts
- Use shared helper in AllPrivateChatsSidebar and AllSharedChatsSidebar
- Remove unused date-fns format import from both sidebar files
- Centralises timestamp formatting policy for future i18n/relative-time changes

## Description

Two sidebar files (`AllPrivateChatsSidebar.tsx` and `AllSharedChatsSidebar.tsx`) render thread "updated at" timestamps with identical inline `date-fns` `format()` calls.

This creates two problems:
1. **Duplication**: Same formatting logic exists in two places
2. **Inconsistency**: The rest of the app uses `formatRelativeDate()` from `lib/format-date.ts`, meaning "how we display a recent timestamp" has two policies

This PR extracts a shared `formatThreadTimestamp()` helper in `surfsense_web/lib/format-date.ts` and replaces both inline calls.

### Motivation and Context

FIX #1376

If we ever want to switch threads to relative time, or i18n-localize the format, the two sidebars must currently be edited in lockstep. This refactoring centralizes the formatting policy so future changes only need to be made in one place.

### Change Type

- [x] Refactoring

### Testing Performed

- [x] Tested locally
- [ ] Manual/QA verification

### Checklist

- [x] Follows project coding standards and conventions
- [x] No lint/build errors or new warnings

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR extracts duplicate thread timestamp formatting logic from two chat sidebar components (`AllPrivateChatsSidebar` and `AllSharedChatsSidebar`) into a shared `formatThreadTimestamp()` helper function in `lib/format-date.ts`. This refactoring eliminates code duplication and centralizes the formatting policy, making it easier to implement future changes like internationalization or switching to relative time formatting.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/lib/format-date.ts` |
| 2 | `surfsense_web/components/layout/ui/sidebar/AllPrivateChatsSidebar.tsx` |
| 3 | `surfsense_web/components/layout/ui/sidebar/AllSharedChatsSidebar.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated duplicate timestamp formatting logic previously used across multiple chat sidebar components into a centralized, reusable utility function. This ensures consistent date-time display formatting throughout the application (format: Month Day, Year at Hour:Minute AM/PM), eliminates code redundancy, and improves overall code maintainability. No visible changes to user-facing features.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MODSetter/SurfSense/pull/1395)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->