### PR TITLE
docs(editor): align PlateEditor onSave JSDoc with Mod+Shift+S chord

### DIFF
--- a/surfsense_web/components/editor/plate-editor.tsx
+++ b/surfsense_web/components/editor/plate-editor.tsx
@@ -42,7 +42,7 @@ export interface PlateEditorProps {
 	editorVariant?: "default" | "demo" | "fullWidth" | "none";
 	/** Additional className for the container */
 	className?: string;
-	/** Save callback. When provided, ⌘+S / Ctrl+S shortcut is registered and save button appears. */
+	/** Save callback. When provided, ⌘+Shift+S / Ctrl+Shift+S shortcut is registered (avoiding the browser's ⌘+S / Ctrl+S "Save Page As" conflict) and a save button appears in the toolbar. */
 	onSave?: () => void;
 	/** Whether there are unsaved changes */
 	hasUnsavedChanges?: boolean;


### PR DESCRIPTION
Re-raised against `dev` per @MODSetter on #1386.

The `PlateEditor.onSave` JSDoc claims `⌘+S / Ctrl+S`, but the actual registered chord is `⌘+Shift+S / Ctrl+Shift+S` (the unmodified chord conflicts with the browser's Save Page As).

This is a 1-line docstring fix that keeps the type contract honest for downstream consumers.

Closes #1373 (if still relevant).

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR corrects the JSDoc documentation for the `PlateEditor.onSave` prop to accurately reflect the keyboard shortcut registered in the implementation. The documentation previously stated `⌘+S / Ctrl+S`, but the actual chord is `⌘+Shift+S / Ctrl+Shift+S` to avoid conflicts with the browser's native "Save Page As" shortcut. The docstring also adds clarity about the save button appearing in the toolbar.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/components/editor/plate-editor.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->