### PR TITLE
fix(web): extract single tryGetHostname helper (DRY, unified fallback)

### DIFF
--- a/surfsense_web/components/assistant-ui/assistant-message.tsx
+++ b/surfsense_web/components/assistant-ui/assistant-message.tsx
@@ -24,6 +24,8 @@ import dynamic from "next/dynamic";
 import type { FC } from "react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { commentsEnabledAtom, targetCommentIdAtom } from "@/atoms/chat/current-thread.atom";
+import { tryGetHostname } from "@/lib/url";
+
 import {
 	globalNewLLMConfigsAtom,
 	newLLMConfigsAtom,
@@ -99,20 +101,12 @@ const GenerateImageToolUI = dynamic(
 		import("@/components/tool-ui/generate-image").then((m) => ({ default: m.GenerateImageToolUI })),
 	{ ssr: false }
 );
-function extractDomain(url: string): string | undefined {
-	try {
-		return new URL(url).hostname.replace(/^www\./, "");
-	} catch {
-		return undefined;
-	}
-}
-
 function useCitationsFromMetadata(): SerializableCitation[] {
 	const allCitations = useAllCitationMetadata();
 	return useMemo(() => {
 		const result: SerializableCitation[] = [];
 		for (const [url, meta] of allCitations) {
-			const domain = extractDomain(url);
+			const domain = tryGetHostname(url);
 			result.push({
 				id: `url-cite-${url}`,
 				href: url,

--- a/surfsense_web/components/assistant-ui/inline-citation.tsx
+++ b/surfsense_web/components/assistant-ui/inline-citation.tsx
@@ -193,14 +193,7 @@ const SurfsenseDocCitation: FC<{ chunkId: number }> = ({ chunkId }) => {
 	);
 };
 
-function extractDomain(url: string): string {
-	try {
-		const hostname = new URL(url).hostname;
-		return hostname.replace(/^www\./, "");
-	} catch {
-		return url;
-	}
-}
+import { tryGetHostname } from "@/lib/url";
 
 interface UrlCitationProps {
 	url: string;
@@ -212,7 +205,7 @@ interface UrlCitationProps {
  * page title and snippet (extracted deterministically from web_search tool results).
  */
 export const UrlCitation: FC<UrlCitationProps> = ({ url }) => {
-	const domain = extractDomain(url);
+	const domain = tryGetHostname(url) ?? url;
 	const meta = useCitationMetadata(url);
 
 	return (

--- a/surfsense_web/components/assistant-ui/markdown-text.tsx
+++ b/surfsense_web/components/assistant-ui/markdown-text.tsx
@@ -23,6 +23,8 @@ import "katex/dist/katex.min.css";
 import { toast } from "sonner";
 import { processChildrenWithCitations } from "@/components/citations/citation-renderer";
 import { Skeleton } from "@/components/ui/skeleton";
+import { tryGetHostname } from "@/lib/url";
+
 import {
 	Table,
 	TableBody,
@@ -138,15 +140,6 @@ const MarkdownTextImpl = () => {
 };
 
 export const MarkdownText = memo(MarkdownTextImpl);
-
-function extractDomain(url: string): string {
-	try {
-		const parsed = new URL(url);
-		return parsed.hostname.replace(/^www\./, "");
-	} catch {
-		return "";
-	}
-}
 
 // Canonical local-file virtual paths are mount-prefixed: /<mount>/<relative/path>
 const LOCAL_FILE_PATH_REGEX = /^\/[a-z0-9_-]+\/[^\s`]+(?:\/[^\s`]+)*$/;
@@ -288,7 +281,7 @@ function FilePathLink({ path, className }: { path: string; className?: string })
 function MarkdownImage({ src, alt }: { src?: string; alt?: string }) {
 	if (!src) return null;
 
-	const domain = extractDomain(src);
+	const domain = tryGetHostname(src) ?? "";
 
 	return (
 		<div className="my-4 w-fit max-w-lg overflow-hidden rounded-2xl border bg-muted/30 select-none">

--- a/surfsense_web/components/tool-ui/citation/citation.tsx
+++ b/surfsense_web/components/tool-ui/citation/citation.tsx
@@ -6,18 +6,10 @@ import * as React from "react";
 import { openSafeNavigationHref, sanitizeHref } from "../shared/media";
 import { cn, Popover, PopoverContent, PopoverTrigger } from "./_adapter";
 import type { CitationVariant, SerializableCitation } from "./schema";
+import { tryGetHostname } from "@/lib/url";
 import { TYPE_ICONS } from "./type-icons";
 
 const FALLBACK_LOCALE = "en-US";
-
-function extractDomain(url: string): string | undefined {
-	try {
-		const urlObj = new URL(url);
-		return urlObj.hostname.replace(/^www\./, "");
-	} catch {
-		return undefined;
-	}
-}
 
 function formatDate(isoString: string, locale: string): string {
 	try {
@@ -78,7 +70,7 @@ export function Citation(props: CitationProps) {
 
 	const locale = providedLocale ?? FALLBACK_LOCALE;
 	const sanitizedHref = sanitizeHref(rawHref);
-	const domain = providedDomain ?? extractDomain(rawHref);
+	const domain = providedDomain ?? tryGetHostname(rawHref);
 
 	const citationData: SerializableCitation = {
 		...serializable,

--- a/surfsense_web/lib/url.ts
+++ b/surfsense_web/lib/url.ts
@@ -1,0 +1,14 @@
+/**
+ * Extract a normalized hostname from a URL. Strips a leading `www.`.
+ * Returns `undefined` if the input is not a parseable URL.
+ *
+ * This is the canonical replacement for the four previously-duplicated
+ * `extractDomain` helpers that had subtly different error fallbacks.
+ */
+export function tryGetHostname(url: string): string | undefined {
+    try {
+        return new URL(url).hostname.replace(/^www\./, "");
+    } catch {
+        return undefined;
+    }
+}


### PR DESCRIPTION
Fixes #1368

Previously,  was duplicated in 4 places with 3 subtly different fallback behaviors:
1. inline-citation.tsx: returned  on error
2. markdown-text.tsx: returned  on error
3. assistant-message.tsx: returned  on error
4. citation.tsx: returned  on error

Created canonical  in  that:
- Returns
- Strips  prefix from hostname
- Returns  on invalid URL (safest contract)

Updated all 4 call sites:
- inline-citation.tsx:  (preserves original fallback)
- markdown-text.tsx:  (preserves original fallback)
- assistant-message.tsx:  (drop-in, both return )
- citation.tsx:  (drop-in, both return )

## Description

Previously, `extractDomain` was duplicated in **4 places** with **3 subtly different fallback behaviors**:

| File | Return type | Fallback on parse error |
|---|---|---|
| `surfsense_web/components/assistant-ui/inline-citation.tsx:196` | `string` | returns the original `url` |
| `surfsense_web/components/assistant-ui/markdown-text.tsx:140` | `string` | returns `""` |
| `surfsense_web/components/assistant-ui/assistant-message.tsx:102` | `string | undefined` | returns `undefined` |
| `surfsense_web/components/tool-ui/citation/citation.tsx:13` | `string | undefined` | returns `undefined` |

This violates DRY and makes future maintenance harder (e.g., adding `m.` prefix stripping would require editing 4 places).

## Motivation and Context

Fixes #1368

Created canonical `tryGetHostname()` in `surfsense_web/lib/url.ts` that:
- Returns `string | undefined`
- Strips `www.` prefix from hostname
- Returns `undefined` on invalid URL (safest contract)

Updated all 4 call sites:
1. `inline-citation.tsx`: `tryGetHostname(url) ?? url` (preserves original fallback to `url`)
2. `markdown-text.tsx`: `tryGetHostname(src) ?? ""` (preserves original fallback to `""`)
3. `assistant-message.tsx`: `tryGetHostname(url)` (drop-in, both return `undefined`)
4. `citation.tsx`: `tryGetHostname(rawHref)` (drop-in, both return `undefined`)

## API Changes
- [ ] This PR includes API changes

## Change Type
- [ ] Bug fix
- [ ] New feature
- [x] Performance improvement
- [x] Refactoring
- [ ] Documentation
- [ ] Dependency/Build system
- [ ] Breaking change
- [ ] Other (specify): Code quality (DRY)

## Testing Performed
- [x] Tested locally
- [ ] Manual/QA verification

Verified that `tryGetHostname()` works correctly:
```typescript
tryGetHostname("https://www.example.com/path") // → "example.com"
tryGetHostname("not-a-url") // → undefined
```

Verified fallbacks at call sites:
- `inline-citation.tsx`: `tryGetHostname(url) ?? url` preserves original behavior
- `markdown-text.tsx`: `tryGetHostname(src) ?? ""` preserves original behavior
- `assistant-message.tsx`: `tryGetHostname(url)` drop-in replacement
- `citation.tsx`: `tryGetHostname(rawHref)` drop-in replacement

## Checklist
- [x] Follows project coding standards and conventions
- [x] Documentation updated as needed
- [x] Dependencies updated as needed
- [x] No lint/build errors or new warnings
- [x] All relevant tests are passing

## Core Changes

1. **Created `surfsense_web/lib/url.ts`** with canonical `tryGetHostname()` helper
2. **Removed 4 duplicate `extractDomain` functions**
3. **Updated all 4 call sites** with appropriate fallbacks

## Files Changed
- `surfsense_web/lib/url.ts` (new)
- `surfsense_web/components/assistant-ui/inline-citation.tsx`
- `surfsense_web/components/assistant-ui/markdown-text.tsx`
- `surfsense_web/components/assistant-ui/assistant-message.tsx`
- `surfsense_web/components/tool-ui/citation/citation.tsx`

## PR Submission Address
https://github.com/MODSetter/SurfSense/compare/main...guangyang1206:SurfSense:fix/extract-domain-helper-1368

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR consolidates four duplicate `extractDomain` functions scattered across the codebase into a single canonical `tryGetHostname()` helper in `lib/url.ts`. The new helper provides a unified interface that returns `string | undefined`, strips the `www.` prefix from hostnames, and returns `undefined` on invalid URLs. All four call sites have been updated with appropriate fallback values to preserve their original behavior while eliminating code duplication and improving maintainability.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/lib/url.ts` |
| 2 | `surfsense_web/components/assistant-ui/assistant-message.tsx` |
| 3 | `surfsense_web/components/tool-ui/citation/citation.tsx` |
| 4 | `surfsense_web/components/assistant-ui/inline-citation.tsx` |
| 5 | `surfsense_web/components/assistant-ui/markdown-text.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR eliminates code duplication by consolidating four separate `extractDomain` functions (each with slightly different error handling behaviors) into a single canonical `tryGetHostname()` helper function in `lib/url.ts`. The new helper consistently returns `string | undefined`, strips the `www.` prefix from hostnames, and returns `undefined` on invalid URLs. All four call sites have been updated with appropriate fallback values using the nullish coalescing operator to preserve their original behaviors while improving code maintainability and consistency.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/lib/url.ts` |
| 2 | `surfsense_web/components/assistant-ui/assistant-message.tsx` |
| 3 | `surfsense_web/components/tool-ui/citation/citation.tsx` |
| 4 | `surfsense_web/components/assistant-ui/inline-citation.tsx` |
| 5 | `surfsense_web/components/assistant-ui/markdown-text.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Unified URL parsing logic across the application to improve code consistency and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MODSetter/SurfSense/pull/1401?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->