### PR TITLE
fix(citation-panel): reset expanded state when chunkId changes

### DIFF
--- a/surfsense_web/components/citation-panel/citation-panel.tsx
+++ b/surfsense_web/components/citation-panel/citation-panel.tsx
@@ -32,7 +32,7 @@ export const CitationPanelContent: FC<CitationPanelContentProps> = ({ chunkId, o
 
 	useEffect(() => {
 		setExpanded(false);
-	}, []);
+	}, [chunkId]);
 
 	const chunkWindow = expanded ? EXPANDED_CHUNK_WINDOW : DEFAULT_CHUNK_WINDOW;
 


### PR DESCRIPTION
## Summary

Adds `chunkId` to the dependency array of the mount-time reset effect in `CitationPanelContent` so that `expanded` resets each time the user opens a different citation.

Fixes #1367

## Description

`CitationPanelContent` keeps `expanded` in local state and resets it on mount with `useEffect(..., [])`. `RightPanel.tsx:251` renders this component without a `key`, so React reuses the same instance when `chunkId` changes; the mount-only effect never re-runs and a previously expanded panel stays expanded for the new citation, fetching the 50-chunk window unrequested. Adding `chunkId` to the deps makes the reset fire on every citation change.

## Motivation and Context

Reported in #1367. Steps from the issue body:

1. Click citation `[1]` - panel opens with default 5-chunk window.
2. Click "More context" - `expanded` becomes true, fetches 50-chunk window.
3. Click citation `[2]` in the chat.
4. Before: panel shows 50-chunk window for citation 2. After: panel shows default 5-chunk window for citation 2.

Fixes #1367

## Screenshots

Not applicable - behavioral fix on `useEffect` deps. Verification is the four-step repro above.

## API Changes

- [ ] This PR includes API changes

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Dependency/Build system
- [ ] Breaking change
- [ ] Other (specify):

## Testing Performed

- [x] Manual/QA verification

Repro before: citation A opened, expanded to 50-chunk window, click citation B - panel for B is still expanded. After: same flow resets to the default 5-chunk window when B opens.

## Checklist

- [x] Follows project coding standards and conventions
- [x] Documentation updated as needed
- [x] Dependencies updated as needed
- [x] No lint/build errors or new warnings
- [x] All relevant tests are passing

Note on Biome: `useExhaustiveDependencies` warns on `chunkId` here because it isn't read inside the effect callback - it's intentionally a re-execution trigger, per the issue body. The rule is `warn` in `biome.json` and the Code Quality workflow skips `biome-check-web`, so this isn't a CI blocker; happy to add a `// biome-ignore` comment if you'd prefer.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a bug where the citation panel's expanded state was persisting across different citations. When a user expanded citation A to show the 50-chunk window and then clicked citation B, the panel for citation B would incorrectly remain expanded. The fix adds `chunkId` to the `useEffect` dependency array so that the `expanded` state properly resets to the default 5-chunk window whenever the user opens a different citation.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/components/citation-panel/citation-panel.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->