### PR TITLE
refactor(env): replace inline process.env reads with BACKEND_URL in c…

### DIFF
--- a/surfsense_web/components/assistant-ui/connector-popup/connect-forms/components/obsidian-connect-form.tsx
+++ b/surfsense_web/components/assistant-ui/connector-popup/connect-forms/components/obsidian-connect-form.tsx
@@ -9,11 +9,11 @@ import { useApiKey } from "@/hooks/use-api-key";
 import { copyToClipboard as copyToClipboardUtil } from "@/lib/utils";
 import { getConnectorBenefits } from "../connector-benefits";
 import type { ConnectFormProps } from "../index";
+import { BACKEND_URL } from "@/lib/env-config";
 
 const PLUGIN_RELEASES_URL =
 	"https://github.com/MODSetter/SurfSense/releases?q=obsidian&expanded=true";
 
-const BACKEND_URL = process.env.NEXT_PUBLIC_FASTAPI_BACKEND_URL ?? "https://surfsense.com";
 
 /**
  * Obsidian connect form for the plugin-only architecture.

--- a/surfsense_web/components/assistant-ui/connector-popup/connector-configs/components/circleback-config.tsx
+++ b/surfsense_web/components/assistant-ui/connector-popup/connector-configs/components/circleback-config.tsx
@@ -10,7 +10,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { authenticatedFetch } from "@/lib/auth-utils";
 import type { ConnectorConfigProps } from "../index";
-
+import { BACKEND_URL } from "@/lib/env-config";
 export interface CirclebackConfigProps extends ConnectorConfigProps {
 	onNameChange?: (name: string) => void;
 }
@@ -42,7 +42,7 @@ export const CirclebackConfig: FC<CirclebackConfigProps> = ({ connector, onNameC
 		const doFetch = async () => {
 			if (!connector.search_space_id) return;
 
-			const baseUrl = process.env.NEXT_PUBLIC_FASTAPI_BACKEND_URL;
+			const baseUrl = BACKEND_URL;
 			if (!baseUrl) {
 				console.error("NEXT_PUBLIC_FASTAPI_BACKEND_URL is not configured");
 				setIsLoading(false);

--- a/surfsense_web/components/assistant-ui/connector-popup/connector-configs/views/connector-edit-view.tsx
+++ b/surfsense_web/components/assistant-ui/connector-popup/connector-configs/views/connector-edit-view.tsx
@@ -20,7 +20,7 @@ import { getReauthEndpoint, LIVE_CONNECTOR_TYPES } from "../../constants/connect
 import { getConnectorDisplayName } from "../../tabs/all-connectors-tab";
 import { MCPServiceConfig } from "../components/mcp-service-config";
 import { getConnectorConfigComponent } from "../index";
-
+import { BACKEND_URL } from "@/lib/env-config";
 const VISION_LLM_CONNECTOR_TYPES = new Set<SearchSourceConnector["connector_type"]>([
 	EnumConnectorName.GOOGLE_DRIVE_CONNECTOR,
 	EnumConnectorName.COMPOSIO_GOOGLE_DRIVE_CONNECTOR,
@@ -93,7 +93,7 @@ export const ConnectorEditView: FC<ConnectorEditViewProps> = ({
 		if (!spaceId || !reauthEndpoint) return;
 		setReauthing(true);
 		try {
-			const backendUrl = process.env.NEXT_PUBLIC_FASTAPI_BACKEND_URL || "http://localhost:8000";
+			const backendUrl = BACKEND_URL;
 			const url = new URL(`${backendUrl}${reauthEndpoint}`);
 			url.searchParams.set("connector_id", String(connector.id));
 			url.searchParams.set("space_id", String(spaceId));

--- a/surfsense_web/components/assistant-ui/connector-popup/hooks/use-connector-dialog.ts
+++ b/surfsense_web/components/assistant-ui/connector-popup/hooks/use-connector-dialog.ts
@@ -43,7 +43,7 @@ import {
 	parseOAuthAuthResponse,
 	validateIndexingConfigState,
 } from "../constants/connector-popup.schemas";
-
+import { BACKEND_URL } from "@/lib/env-config";
 const OAUTH_RESULT_COOKIE = "connector_oauth_result";
 
 function readOAuthResultCookie(): string | null {
@@ -364,7 +364,7 @@ export const useConnectorDialog = () => {
 			try {
 				// Check if authEndpoint already has query parameters
 				const separator = connector.authEndpoint.includes("?") ? "&" : "?";
-				const url = `${process.env.NEXT_PUBLIC_FASTAPI_BACKEND_URL}${connector.authEndpoint}${separator}space_id=${searchSpaceId}`;
+				const url = `${BACKEND_URL}${connector.authEndpoint}${separator}space_id=${searchSpaceId}`;
 
 				const response = await authenticatedFetch(url, { method: "GET" });
 

--- a/surfsense_web/components/assistant-ui/connector-popup/views/connector-accounts-list-view.tsx
+++ b/surfsense_web/components/assistant-ui/connector-popup/views/connector-accounts-list-view.tsx
@@ -16,7 +16,7 @@ import { cn } from "@/lib/utils";
 import { getReauthEndpoint, LIVE_CONNECTOR_TYPES } from "../constants/connector-constants";
 import { useConnectorStatus } from "../hooks/use-connector-status";
 import { getConnectorDisplayName } from "../tabs/all-connectors-tab";
-
+import { BACKEND_URL } from "@/lib/env-config";
 interface ConnectorAccountsListViewProps {
 	connectorType: string;
 	connectorTitle: string;
@@ -55,7 +55,7 @@ export const ConnectorAccountsListView: FC<ConnectorAccountsListViewProps> = ({
 			if (!searchSpaceId || !endpoint) return;
 			setReauthingId(connector.id);
 			try {
-				const backendUrl = process.env.NEXT_PUBLIC_FASTAPI_BACKEND_URL || "http://localhost:8000";
+				const backendUrl = BACKEND_URL;
 				const url = new URL(`${backendUrl}${endpoint}`);
 				url.searchParams.set("connector_id", String(connector.id));
 				url.searchParams.set("space_id", String(searchSpaceId));

--- a/surfsense_web/hooks/use-search-source-connectors.ts
+++ b/surfsense_web/hooks/use-search-source-connectors.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { authenticatedFetch } from "@/lib/auth-utils";
-
+import { BACKEND_URL } from "@/lib/env-config";
 export interface SearchSourceConnector {
 	id: number;
 	name: string;
@@ -108,7 +108,7 @@ export const useSearchSourceConnectors = (lazy: boolean = false, searchSpaceId?:
 
 				// Build URL with optional search_space_id query parameter
 				const url = new URL(
-					`${process.env.NEXT_PUBLIC_FASTAPI_BACKEND_URL}/api/v1/search-source-connectors`
+					`${BACKEND_URL}/api/v1/search-source-connectors`
 				);
 				if (spaceId !== undefined) {
 					url.searchParams.append("search_space_id", spaceId.toString());
@@ -170,7 +170,7 @@ export const useSearchSourceConnectors = (lazy: boolean = false, searchSpaceId?:
 		try {
 			// Add search_space_id as a query parameter
 			const url = new URL(
-				`${process.env.NEXT_PUBLIC_FASTAPI_BACKEND_URL}/api/v1/search-source-connectors`
+				`${BACKEND_URL}/api/v1/search-source-connectors`
 			);
 			url.searchParams.append("search_space_id", spaceId.toString());
 
@@ -208,7 +208,7 @@ export const useSearchSourceConnectors = (lazy: boolean = false, searchSpaceId?:
 	) => {
 		try {
 			const response = await authenticatedFetch(
-				`${process.env.NEXT_PUBLIC_FASTAPI_BACKEND_URL}/api/v1/search-source-connectors/${connectorId}`,
+				`${BACKEND_URL}/api/v1/search-source-connectors/${connectorId}`,
 				{
 					method: "PUT",
 					headers: { "Content-Type": "application/json" },
@@ -239,7 +239,7 @@ export const useSearchSourceConnectors = (lazy: boolean = false, searchSpaceId?:
 	const deleteConnector = async (connectorId: number) => {
 		try {
 			const response = await authenticatedFetch(
-				`${process.env.NEXT_PUBLIC_FASTAPI_BACKEND_URL}/api/v1/search-source-connectors/${connectorId}`,
+				`${BACKEND_URL}/api/v1/search-source-connectors/${connectorId}`,
 				{
 					method: "DELETE",
 					headers: { "Content-Type": "application/json" },
@@ -284,7 +284,7 @@ export const useSearchSourceConnectors = (lazy: boolean = false, searchSpaceId?:
 
 			const response = await authenticatedFetch(
 				`${
-					process.env.NEXT_PUBLIC_FASTAPI_BACKEND_URL
+					BACKEND_URL
 				}/api/v1/search-source-connectors/${connectorId}/index?${params.toString()}`,
 				{
 					method: "POST",


### PR DESCRIPTION
<!--- Summarize your pull request in a few sentences -->

## Description
<!--- Clearly describe what has changed in this pull request -->
refactor(env): replace inline process.env reads with BACKEND_URL in connector forms and hooks
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If this PR relates to an open issue, please link to the issue here: FIX #123 -->
FIX #1374 


## Screenshots
<!-- If applicable, add screenshots or images to demonstrate the changes visually -->

## API Changes
<!-- Document any API changes if applicable -->
- [ ] This PR includes API changes

## Change Type
<!--- Indicate what kind(s) of changes this PR includes: -->
- [x] Refactoring

## Testing Performed
<!--- Briefly describe how you have tested these changes and what verification was performed -->
- [ ] Tested locally
- [ ] Manual/QA verification

## Checklist
<!--- Please confirm the following by marking with an 'x' as appropriate -->
- [x] Follows project coding standards and conventions
- [ ] Documentation updated as needed
- [ ] Dependencies updated as needed
- [ ] No lint/build errors or new warnings
- [ ] All relevant tests are passing

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR refactors environment variable access by replacing inline `process.env.NEXT_PUBLIC_FASTAPI_BACKEND_URL` reads with a centralized `BACKEND_URL` constant imported from `@/lib/env-config`. The changes affect connector forms, configuration components, and hooks throughout the application, improving maintainability by consolidating environment variable access into a single location.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/components/assistant-ui/connector-popup/connect-forms/components/obsidian-connect-form.tsx` |
| 2 | `surfsense_web/components/assistant-ui/connector-popup/connector-configs/components/circleback-config.tsx` |
| 3 | `surfsense_web/components/assistant-ui/connector-popup/connector-configs/views/connector-edit-view.tsx` |
| 4 | `surfsense_web/components/assistant-ui/connector-popup/views/connector-accounts-list-view.tsx` |
| 5 | `surfsense_web/components/assistant-ui/connector-popup/hooks/use-connector-dialog.ts` |
| 6 | `surfsense_web/hooks/use-search-source-connectors.ts` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated backend URL configuration across connector and API integration components for improved maintainability and consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MODSetter/SurfSense/pull/1410?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->