### PR TITLE
fix: use shared useIsMobile (768px) in SidebarSlideOutPanel (#1359)

### DIFF
--- a/surfsense_web/components/layout/ui/sidebar/SidebarSlideOutPanel.tsx
+++ b/surfsense_web/components/layout/ui/sidebar/SidebarSlideOutPanel.tsx
@@ -2,7 +2,7 @@
 
 import { AnimatePresence, motion } from "motion/react";
 import { useCallback, useEffect } from "react";
-import { useMediaQuery } from "@/hooks/use-media-query";
+import { useIsMobile } from "@/hooks/use-mobile";
 import { SLIDEOUT_PANEL_OPENED_EVENT } from "@/lib/layout-events";
 
 interface SidebarSlideOutPanelProps {
@@ -28,7 +28,7 @@ export function SidebarSlideOutPanel({
 	width = 360,
 	children,
 }: SidebarSlideOutPanelProps) {
-	const isMobile = !useMediaQuery("(min-width: 640px)");
+	const isMobile = useIsMobile();
 
 	useEffect(() => {
 		if (open) {


### PR DESCRIPTION
## Description

Replaces the ad-hoc `useMediaQuery("(min-width: 640px)")` check in `SidebarSlideOutPanel` with the project-wide `useIsMobile()` hook (768px). The slide-out's mobile/desktop layout choice now aligns with the rest of the dashboard at every viewport size.

## Motivation and Context

The slide-out was breaking at viewports between 640-767px: the rest of the layout had collapsed to mobile (sidebar hidden) but the slide-out still rendered the desktop side-attached overlay, positioned against a sidebar that was no longer there. The fix matches the canonical adapter so the slide-out and the surrounding layout always agree on "is mobile".

FIX #1359

## Change Type

- [x] Bug fix

## Testing Performed

- [x] Tested locally
- Resized the dev browser across the 640/768 boundary and confirmed the slide-out now renders as a full-width mobile overlay below 768px (matching the rest of the layout) and as a side-attached overlay at 768px and above.
- No other call site touched; `useIsMobile`'s 768px threshold is unchanged.

## Checklist

- [x] Follows project coding standards and conventions
- [x] No lint/build errors or new warnings (diff is a 2-line hook swap; existing `useIsMobile` is the documented project-wide adapter)

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a layout bug in the sidebar slide-out panel by replacing an ad-hoc media query check (640px) with the project-wide `useIsMobile()` hook (768px). This ensures the slide-out panel's mobile/desktop rendering behavior is consistent with the rest of the dashboard, eliminating a broken state that occurred between 640-767px viewports where the panel would try to attach to a sidebar that was already hidden.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/components/layout/ui/sidebar/SidebarSlideOutPanel.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->