### PR TITLE
refactor(env): replace inline process.env reads with BACKEND_URL in lib/

### DIFF
--- a/surfsense_web/lib/apis/base-api.service.ts
+++ b/surfsense_web/lib/apis/base-api.service.ts
@@ -9,7 +9,7 @@ import {
 	NetworkError,
 	NotFoundError,
 } from "../error";
-
+import { BACKEND_URL } from "@/lib/env-config";
 enum ResponseType {
 	JSON = "json",
 	TEXT = "text",
@@ -390,4 +390,4 @@ class BaseApiService {
 	}
 }
 
-export const baseApiService = new BaseApiService(process.env.NEXT_PUBLIC_FASTAPI_BACKEND_URL || "");
+export const baseApiService = new BaseApiService(BACKEND_URL);

--- a/surfsense_web/lib/auth-utils.ts
+++ b/surfsense_web/lib/auth-utils.ts
@@ -1,7 +1,7 @@
 /**
  * Authentication utilities for handling token expiration and redirects
  */
-
+import { BACKEND_URL } from "@/lib/env-config";
 const REDIRECT_PATH_KEY = "surfsense_redirect_path";
 const BEARER_TOKEN_KEY = "surfsense_bearer_token";
 const REFRESH_TOKEN_KEY = "surfsense_refresh_token";
@@ -194,8 +194,7 @@ export async function logout(): Promise<boolean> {
 	// Call backend to revoke the refresh token
 	if (refreshToken) {
 		try {
-			const backendUrl = process.env.NEXT_PUBLIC_FASTAPI_BACKEND_URL || "http://localhost:8000";
-			const response = await fetch(`${backendUrl}/auth/jwt/revoke`, {
+			const response = await fetch(`${BACKEND_URL}/auth/jwt/revoke`, {
 				method: "POST",
 				headers: {
 					"Content-Type": "application/json",
@@ -273,8 +272,7 @@ export async function refreshAccessToken(): Promise<string | null> {
 	isRefreshing = true;
 	refreshPromise = (async () => {
 		try {
-			const backendUrl = process.env.NEXT_PUBLIC_FASTAPI_BACKEND_URL || "http://localhost:8000";
-			const response = await fetch(`${backendUrl}/auth/jwt/refresh`, {
+			const response = await fetch(`${BACKEND_URL}/auth/jwt/refresh`, {
 				method: "POST",
 				headers: {
 					"Content-Type": "application/json",

--- a/surfsense_web/lib/chat/thread-persistence.ts
+++ b/surfsense_web/lib/chat/thread-persistence.ts
@@ -4,7 +4,7 @@
  */
 
 import { baseApiService } from "@/lib/apis/base-api.service";
-
+import { BACKEND_URL } from "@/lib/env-config";
 // =============================================================================
 // Types matching backend schemas
 // =============================================================================
@@ -228,6 +228,5 @@ export interface RegenerateParams {
  * Get the URL for the regenerate endpoint (for streaming fetch)
  */
 export function getRegenerateUrl(threadId: number): string {
-	const backendUrl = process.env.NEXT_PUBLIC_FASTAPI_BACKEND_URL || "http://localhost:8000";
-	return `${backendUrl}/api/v1/threads/${threadId}/regenerate`;
+	return `${BACKEND_URL}/api/v1/threads/${threadId}/regenerate`;
 }


### PR DESCRIPTION
<!--- Summarize your pull request in a few sentences -->

## Description
Replaced inline `process.env.NEXT_PUBLIC_FASTAPI_BACKEND_URL` reads in `lib/` files with `BACKEND_URL` imported from `@/lib/env-config`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If this PR relates to an open issue, please link to the issue here: FIX #123 -->
FIX #1374 


## Screenshots
<!-- If applicable, add screenshots or images to demonstrate the changes visually -->

## API Changes
<!-- Document any API changes if applicable -->
- [ ] This PR includes API changes

## Change Type
<!--- Indicate what kind(s) of changes this PR includes: -->
- [x] Refactoring

## Testing Performed
<!--- Briefly describe how you have tested these changes and what verification was performed -->
- [ ] Tested locally
- [ ] Manual/QA verification

## Checklist
<!--- Please confirm the following by marking with an 'x' as appropriate -->
- [x] Follows project coding standards and conventions
- [ ] Documentation updated as needed
- [ ] Dependencies updated as needed
- [ ] No lint/build errors or new warnings
- [ ] All relevant tests are passing

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR refactors the `lib/` directory to eliminate inline `process.env.NEXT_PUBLIC_FASTAPI_BACKEND_URL` reads by replacing them with a centralized `BACKEND_URL` constant imported from `@/lib/env-config`. The changes affect three files: the base API service initialization, authentication utilities (logout and token refresh functions), and thread persistence URL generation. This improves code maintainability by centralizing environment variable access and removes hardcoded fallback URLs.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/lib/apis/base-api.service.ts` |
| 2 | `surfsense_web/lib/auth-utils.ts` |
| 3 | `surfsense_web/lib/chat/thread-persistence.ts` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->