### PR TITLE
fix: move getConnectorTelemetryMeta from components/ to lib

### DIFF
--- a/surfsense_web/components/assistant-ui/connector-popup/constants/connector-constants.ts
+++ b/surfsense_web/components/assistant-ui/connector-popup/constants/connector-constants.ts
@@ -303,110 +303,16 @@ export const AUTO_INDEX_CONNECTOR_TYPES = new Set<string>(Object.keys(AUTO_INDEX
 // `lib/posthog/events.ts` or per-connector tracking code.
 // ============================================================================
 
-export type ConnectorTelemetryGroup = "oauth" | "composio" | "crawler" | "other" | "unknown";
-
-export interface ConnectorTelemetryMeta {
-	connector_type: string;
-	connector_title: string;
-	connector_group: ConnectorTelemetryGroup;
-	is_oauth: boolean;
-}
-
-const CONNECTOR_TELEMETRY_REGISTRY: ReadonlyMap<string, ConnectorTelemetryMeta> = (() => {
-	const map = new Map<string, ConnectorTelemetryMeta>();
-
-	for (const c of OAUTH_CONNECTORS) {
-		map.set(c.connectorType, {
-			connector_type: c.connectorType,
-			connector_title: c.title,
-			connector_group: "oauth",
-			is_oauth: true,
-		});
-	}
-	for (const c of COMPOSIO_CONNECTORS) {
-		map.set(c.connectorType, {
-			connector_type: c.connectorType,
-			connector_title: c.title,
-			connector_group: "composio",
-			is_oauth: true,
-		});
-	}
-	for (const c of CRAWLERS) {
-		map.set(c.connectorType, {
-			connector_type: c.connectorType,
-			connector_title: c.title,
-			connector_group: "crawler",
-			is_oauth: false,
-		});
-	}
-	for (const c of OTHER_CONNECTORS) {
-		map.set(c.connectorType, {
-			connector_type: c.connectorType,
-			connector_title: c.title,
-			connector_group: "other",
-			is_oauth: false,
-		});
-	}
-
-	return map;
-})();
-
-/**
- * Returns telemetry metadata for a connector_type, or a minimal "unknown"
- * record so tracking never no-ops for connectors that exist in the backend
- * but were forgotten in the UI registry.
- */
-export function getConnectorTelemetryMeta(connectorType: string): ConnectorTelemetryMeta {
-	const hit = CONNECTOR_TELEMETRY_REGISTRY.get(connectorType);
-	if (hit) return hit;
-
-	return {
-		connector_type: connectorType,
-		connector_title: connectorType,
-		connector_group: "unknown",
-		is_oauth: false,
-	};
-}
-
-// =============================================================================
-// REAUTH ENDPOINTS
-// =============================================================================
-
-/**
- * Legacy (non-MCP) OAuth reauth endpoints, keyed by connector type.
- * These are used for connectors that were NOT created via MCP OAuth.
- */
-export const LEGACY_REAUTH_ENDPOINTS: Partial<Record<string, string>> = {
-	[EnumConnectorName.LINEAR_CONNECTOR]: "/api/v1/auth/linear/connector/reauth",
-	[EnumConnectorName.JIRA_CONNECTOR]: "/api/v1/auth/jira/connector/reauth",
-	[EnumConnectorName.NOTION_CONNECTOR]: "/api/v1/auth/notion/connector/reauth",
-	[EnumConnectorName.GOOGLE_DRIVE_CONNECTOR]: "/api/v1/auth/google/drive/connector/reauth",
-	[EnumConnectorName.GOOGLE_GMAIL_CONNECTOR]: "/api/v1/auth/google/gmail/connector/reauth",
-	[EnumConnectorName.GOOGLE_CALENDAR_CONNECTOR]: "/api/v1/auth/google/calendar/connector/reauth",
-	[EnumConnectorName.COMPOSIO_GOOGLE_DRIVE_CONNECTOR]: "/api/v1/auth/composio/connector/reauth",
-	[EnumConnectorName.COMPOSIO_GMAIL_CONNECTOR]: "/api/v1/auth/composio/connector/reauth",
-	[EnumConnectorName.COMPOSIO_GOOGLE_CALENDAR_CONNECTOR]: "/api/v1/auth/composio/connector/reauth",
-	[EnumConnectorName.ONEDRIVE_CONNECTOR]: "/api/v1/auth/onedrive/connector/reauth",
-	[EnumConnectorName.DROPBOX_CONNECTOR]: "/api/v1/auth/dropbox/connector/reauth",
-	[EnumConnectorName.CONFLUENCE_CONNECTOR]: "/api/v1/auth/confluence/connector/reauth",
-	[EnumConnectorName.TEAMS_CONNECTOR]: "/api/v1/auth/teams/connector/reauth",
-	[EnumConnectorName.DISCORD_CONNECTOR]: "/api/v1/auth/discord/connector/reauth",
-};
-
-/**
- * Resolve the reauth endpoint for a connector.
- *
- * MCP OAuth connectors (those with ``config.mcp_service``) dynamically build
- * the URL from the service key. Legacy OAuth connectors fall back to the
- * static ``LEGACY_REAUTH_ENDPOINTS`` map.
- */
-export function getReauthEndpoint(connector: SearchSourceConnector): string | undefined {
-	const mcpService = connector.config?.mcp_service as string | undefined;
-	if (mcpService) {
-		return `/api/v1/auth/mcp/${mcpService}/connector/reauth`;
-	}
-	return LEGACY_REAUTH_ENDPOINTS[connector.connector_type];
-}
+// Telemetry types & helpers are now defined in `@/lib/connector-telemetry`.
+// Re-exported here for backward compatibility with existing imports.
+export type {
+	ConnectorTelemetryGroup,
+	ConnectorTelemetryMeta,
+} from "@/lib/connector-telemetry";
+export {
+	getConnectorTelemetryMeta,
+	getReauthEndpoint,
+} from "@/lib/connector-telemetry";
 
 // Re-export IndexingConfigState from schemas for backward compatibility
 export type { IndexingConfigState } from "./connector-popup.schemas";

--- a/surfsense_web/lib/connector-telemetry.ts
+++ b/surfsense_web/lib/connector-telemetry.ts
@@ -1,0 +1,149 @@
+import { EnumConnectorName } from "@/contracts/enums/connector";
+import type { SearchSourceConnector } from "@/contracts/types/connector.types";
+import {
+	OAUTH_CONNECTORS,
+	COMPOSIO_CONNECTORS,
+	CRAWLERS,
+	OTHER_CONNECTORS,
+} from "@/components/assistant-ui/connector-popup/constants/connector-constants";
+
+// =============================================================================
+// Connector Telemetry Types & Registry
+// =============================================================================
+
+export type ConnectorTelemetryGroup =
+	| "oauth"
+	| "composio"
+	| "crawler"
+	| "other"
+	| "unknown";
+
+export interface ConnectorTelemetryMeta {
+	connector_type: string;
+	connector_title: string;
+	connector_group: ConnectorTelemetryGroup;
+	is_oauth: boolean;
+}
+
+/**
+ * Single source of truth for "what does this connector_type look like in
+ * analytics?". Any connector added to the lists above is automatically
+ * picked up here, so adding a new integration does NOT require touching
+ * `lib/posthog/events.ts` or per-connector tracking code.
+ */
+const CONNECTOR_TELEMETRY_REGISTRY: ReadonlyMap<
+	string,
+	ConnectorTelemetryMeta
+> = (() => {
+	const map = new Map<string, ConnectorTelemetryMeta>();
+
+	for (const c of OAUTH_CONNECTORS) {
+		map.set(c.connectorType, {
+			connector_type: c.connectorType,
+			connector_title: c.title,
+			connector_group: "oauth",
+			is_oauth: true,
+		});
+	}
+	for (const c of COMPOSIO_CONNECTORS) {
+		map.set(c.connectorType, {
+			connector_type: c.connectorType,
+			connector_title: c.title,
+			connector_group: "composio",
+			is_oauth: true,
+		});
+	}
+	for (const c of CRAWLERS) {
+		map.set(c.connectorType, {
+			connector_type: c.connectorType,
+			connector_title: c.title,
+			connector_group: "crawler",
+			is_oauth: false,
+		});
+	}
+	for (const c of OTHER_CONNECTORS) {
+		map.set(c.connectorType, {
+			connector_type: c.connectorType,
+			connector_title: c.title,
+			connector_group: "other",
+			is_oauth: false,
+		});
+	}
+
+	return map;
+})();
+
+/**
+ * Returns telemetry metadata for a connector_type, or a minimal "unknown"
+ * record so tracking never no-ops for connectors that exist in the backend
+ * but were forgotten in the UI registry.
+ */
+export function getConnectorTelemetryMeta(
+	connectorType: string,
+): ConnectorTelemetryMeta {
+	const hit = CONNECTOR_TELEMETRY_REGISTRY.get(connectorType);
+	if (hit) return hit;
+
+	return {
+		connector_type: connectorType,
+		connector_title: connectorType,
+		connector_group: "unknown",
+		is_oauth: false,
+	};
+}
+
+// =============================================================================
+// Reauth Endpoint Resolution
+// =============================================================================
+
+/**
+ * Legacy (non-MCP) OAuth reauth endpoints, keyed by connector type.
+ * These are used for connectors that were NOT created via MCP OAuth.
+ */
+const LEGACY_REAUTH_ENDPOINTS: Partial<Record<string, string>> = {
+	[EnumConnectorName.LINEAR_CONNECTOR]:
+		"/api/v1/auth/linear/connector/reauth",
+	[EnumConnectorName.JIRA_CONNECTOR]:
+		"/api/v1/auth/jira/connector/reauth",
+	[EnumConnectorName.NOTION_CONNECTOR]:
+		"/api/v1/auth/notion/connector/reauth",
+	[EnumConnectorName.GOOGLE_DRIVE_CONNECTOR]:
+		"/api/v1/auth/google/drive/connector/reauth",
+	[EnumConnectorName.GOOGLE_GMAIL_CONNECTOR]:
+		"/api/v1/auth/google/gmail/connector/reauth",
+	[EnumConnectorName.GOOGLE_CALENDAR_CONNECTOR]:
+		"/api/v1/auth/google/calendar/connector/reauth",
+	[EnumConnectorName.COMPOSIO_GOOGLE_DRIVE_CONNECTOR]:
+		"/api/v1/auth/composio/connector/reauth",
+	[EnumConnectorName.COMPOSIO_GMAIL_CONNECTOR]:
+		"/api/v1/auth/composio/connector/reauth",
+	[EnumConnectorName.COMPOSIO_GOOGLE_CALENDAR_CONNECTOR]:
+		"/api/v1/auth/composio/connector/reauth",
+	[EnumConnectorName.ONEDRIVE_CONNECTOR]:
+		"/api/v1/auth/onedrive/connector/reauth",
+	[EnumConnectorName.DROPBOX_CONNECTOR]:
+		"/api/v1/auth/dropbox/connector/reauth",
+	[EnumConnectorName.CONFLUENCE_CONNECTOR]:
+		"/api/v1/auth/confluence/connector/reauth",
+	[EnumConnectorName.TEAMS_CONNECTOR]:
+		"/api/v1/auth/teams/connector/reauth",
+	[EnumConnectorName.DISCORD_CONNECTOR]:
+		"/api/v1/auth/discord/connector/reauth",
+};
+
+/**
+ * Resolve the reauth endpoint for a connector.
+ *
+ * MCP OAuth connectors (those with ``config.mcp_service``) dynamically build
+ * the URL from the service key. Legacy OAuth connectors fall back to the
+ * static ``LEGACY_REAUTH_ENDPOINTS`` map.
+ */
+export function getReauthEndpoint(
+	connector: SearchSourceConnector,
+): string | undefined {
+	const mcpService = connector.config?.mcp_service as string | undefined;
+	if (mcpService) {
+		return `/api/v1/auth/mcp/${mcpService}/connector/reauth`;
+	}
+	return LEGACY_REAUTH_ENDPOINTS[connector.connector_type];
+}

--- a/surfsense_web/lib/posthog/events.ts
+++ b/surfsense_web/lib/posthog/events.ts
@@ -1,5 +1,5 @@
-import posthog from "posthog-js";
-import { getConnectorTelemetryMeta } from "@/components/assistant-ui/connector-popup/constants/connector-constants";
+import type { ConnectorTelemetryMeta } from "@/lib/connector-telemetry";
+import { getConnectorTelemetryMeta } from "@/lib/connector-telemetry";
 import type { ChatErrorKind, ChatErrorSeverity, ChatFlow } from "@/lib/chat/chat-error-classifier";
 
 /**


### PR DESCRIPTION
…ependency inversion

lib/posthog/events.ts was importing from components/assistant-ui/..., creating an inverted dependency layer (lib → components).

Move ConnectorTelemetryMeta type, CONNECTOR_TELEMETRY_REGISTRY, getConnectorTelemetryMeta, and getReauthEndpoint into the new lib/connector-telemetry.ts module so that lib/ no longer depends upward into the UI tree.

connector-constants.ts now re-exports from the new module for backward compatibility.

Fixes #1375

## Description

Moves `getConnectorTelemetryMeta` and related types (`ConnectorTelemetryMeta`, `ConnectorTelemetryGroup`, `CONNECTOR_TELEMETRY_REGISTRY`) and `getReauthEndpoint` from `components/assistant-ui/connector-popup/constants/connector-constants.ts` to the new file `lib/connector-telemetry.ts`.

`lib/posthog/events.ts` now imports from `@/lib/connector-telemetry` instead of `@/components/.../connector-constants`, eliminating the inverted dependency from `lib/` → `components/`.

`connector-constants.ts` re-exports these symbols from `@/lib/connector-telemetry` to preserve backward compatibility for existing importers.

## Why

`lib/posthog/events.ts` is an analytics module that should sit below the UI layer in the dependency graph. However, it was statically importing functions from `components/`, causing:

1. Refactoring/moving UI code could unintentionally break `events.ts`
2. Code splitting cannot isolate the telemetry module independently
3. Inverted dependency direction increases maintenance cost

By moving telemetry-related logic into `lib/`, the dependency direction becomes `components/` → `lib/`, which aligns with the project's architecture expectations.

## Changes

- `surfsense_web/lib/connector-telemetry.ts` (new file): hosts `ConnectorTelemetryMeta` type, `CONNECTOR_TELEMETRY_REGISTRY`, `getConnectorTelemetryMeta`, `getReauthEndpoint`
- `surfsense_web/lib/posthog/events.ts`: import path changed to `@/lib/connector-telemetry`
- `surfsense_web/components/assistant-ui/connector-popup/constants/connector-constants.ts`: removed migrated content, now re-exports from `@/lib/connector-telemetry`

## Testing

- TypeScript compilation should produce no errors (`ConnectorTelemetryMeta` type and function signatures unchanged)
- `events.ts` behavior with `getConnectorTelemetryMeta` is identical after the move
- Existing importers from `connector-constants.ts` are unaffected due to re-exports

## Related

Fixes #1375