### PR TITLE
refactor(web): centralize OAuth callback cookie contract (fixes #1362)

### DIFF
--- a/surfsense_web/app/dashboard/[search_space_id]/connectors/callback/route.ts
+++ b/surfsense_web/app/dashboard/[search_space_id]/connectors/callback/route.ts
@@ -1,6 +1,5 @@
 import { type NextRequest, NextResponse } from "next/server";
-
-const OAUTH_RESULT_COOKIE = "connector_oauth_result";
+import { OAUTH_RESULT_COOKIE, type OAuthCallbackResult } from "@/contracts/types/oauth.types";
 
 export async function GET(
 	request: NextRequest,
@@ -9,12 +8,13 @@ export async function GET(
 	const { search_space_id } = await params;
 	const searchParams = request.nextUrl.searchParams;
 
-	const result = JSON.stringify({
+	const payload: OAuthCallbackResult = {
 		success: searchParams.get("success"),
 		error: searchParams.get("error"),
 		connector: searchParams.get("connector"),
 		connectorId: searchParams.get("connectorId"),
-	});
+	};
+	const result = JSON.stringify(payload);
 
 	const redirectUrl = new URL(`/dashboard/${search_space_id}/new-chat`, request.url);
 

--- a/surfsense_web/components/assistant-ui/connector-popup/hooks/use-connector-dialog.ts
+++ b/surfsense_web/components/assistant-ui/connector-popup/hooks/use-connector-dialog.ts
@@ -14,7 +14,9 @@ import { activeSearchSpaceIdAtom } from "@/atoms/search-spaces/search-space-quer
 import { EnumConnectorName } from "@/contracts/enums/connector";
 import type { SearchSourceConnector } from "@/contracts/types/connector.types";
 import { searchSourceConnector } from "@/contracts/types/connector.types";
+import { OAUTH_RESULT_COOKIE, parseOAuthCallbackResult } from "@/contracts/types/oauth.types";
 import { authenticatedFetch } from "@/lib/auth-utils";
+import { BACKEND_URL } from "@/lib/env-config";
 import {
 	trackConnectorConnected,
 	trackConnectorDeleted,
@@ -36,15 +38,12 @@ import {
 	OAUTH_CONNECTORS,
 	OTHER_CONNECTORS,
 } from "../constants/connector-constants";
-
 import {
 	dateRangeSchema,
 	frequencyMinutesSchema,
 	parseOAuthAuthResponse,
 	validateIndexingConfigState,
 } from "../constants/connector-popup.schemas";
-import { BACKEND_URL } from "@/lib/env-config";
-const OAUTH_RESULT_COOKIE = "connector_oauth_result";
 
 function readOAuthResultCookie(): string | null {
 	const match = document.cookie
@@ -211,17 +210,8 @@ export const useConnectorDialog = () => {
 		if (!raw || !searchSpaceId) return;
 		clearOAuthResultCookie();
 
-		let result: {
-			success: string | null;
-			error: string | null;
-			connector: string | null;
-			connectorId: string | null;
-		};
-		try {
-			result = JSON.parse(raw);
-		} catch {
-			return;
-		}
+		const result = parseOAuthCallbackResult(raw);
+		if (!result) return;
 
 		if (result.error) {
 			const oauthConnector = result.connector

--- a/surfsense_web/contracts/types/oauth.types.ts
+++ b/surfsense_web/contracts/types/oauth.types.ts
@@ -1,0 +1,31 @@
+import { z } from "zod";
+
+export const OAUTH_RESULT_COOKIE = "connector_oauth_result";
+
+/**
+ * Schema for the payload written to the `connector_oauth_result` cookie by the
+ * OAuth callback route and read back by the connector dialog hook.
+ */
+export const oauthCallbackResultSchema = z.object({
+	success: z.string().nullable(),
+	error: z.string().nullable(),
+	connector: z.string().nullable(),
+	connectorId: z.string().nullable(),
+});
+
+export type OAuthCallbackResult = z.infer<typeof oauthCallbackResultSchema>;
+
+/**
+ * Safely decode and validate the OAuth callback cookie value. Returns `null`
+ * when the value is not valid JSON or does not match the expected shape.
+ */
+export function parseOAuthCallbackResult(raw: string): OAuthCallbackResult | null {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch {
+		return null;
+	}
+	const result = oauthCallbackResultSchema.safeParse(parsed);
+	return result.success ? result.data : null;
+}


### PR DESCRIPTION
<!--- Summarize your pull request in a few sentences -->
Extracts the OAuth callback cookie contract into a single typed module shared by the callback route and the connector dialog hook. Eliminates duplicated cookie name and payload shape across two files.

## Description
Adds `surfsense_web/contracts/types/oauth.types.ts` exporting:

- `OAUTH_RESULT_COOKIE` constant
- `oauthCallbackResultSchema` Zod schema
- `OAuthCallbackResult` type (inferred from the schema)
- `parseOAuthCallbackResult()` helper that returns `null` on invalid JSON or shape mismatch

Updates the two existing files to import from this contract instead of redeclaring locally:

- `surfsense_web/app/dashboard/[search_space_id]/connectors/callback/route.ts` — removed local `OAUTH_RESULT_COOKIE`; the cookie payload is now annotated with `OAuthCallbackResult` so the writer side is constrained by the schema at compile time.
- `surfsense_web/components/assistant-ui/connector-popup/hooks/use-connector-dialog.ts` — removed local `OAUTH_RESULT_COOKIE` and inline result type; replaced the `try { JSON.parse() } catch {}` block with `parseOAuthCallbackResult()`. The helper rejects payloads whose shape doesn't match the schema, removing the silent runtime risk when the cookie is tampered with or its shape drifts.

## Motivation and Context
The cookie name and payload shape were declared in two separate files, so typos and schema drift were undetectable at build time. Centralizing the contract removes the duplication and makes the writer/reader contract enforceable by the type system.

FIX #1362

## Screenshots
N/A — refactor, no user-facing behavior change.

## API Changes
- [ ] This PR includes API changes

## Change Type
- [x] Refactoring

## Testing Performed
`pnpm exec biome check` passes on all three files. `pnpm exec tsc --noEmit` introduces no new type errors in the touched files. The OAuth flow is already covered end-to-end by the existing `tests/connectors/**` Playwright journeys; no behavior change expected.

- [x] Tested locally
- [ ] Manual/QA verification

## Checklist
- [x] Follows project coding standards and conventions
- [x] Documentation updated as needed
- [x] Dependencies updated as needed
- [x] No lint/build errors or new warnings
- [ ] All relevant tests are passing

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR refactors the OAuth callback cookie handling by extracting the duplicated cookie name and payload structure into a centralized, typed contract module. The new `oauth.types.ts` contract module exports a Zod schema, TypeScript types, and a safe parsing helper that both the callback route (writer) and connector dialog hook (reader) now share, eliminating schema drift risk and enforcing compile-time type safety across the OAuth flow.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/contracts/types/oauth.types.ts` |
| 2 | `surfsense_web/app/dashboard/[search_space_id]/connectors/callback/route.ts` |
| 3 | `surfsense_web/components/assistant-ui/connector-popup/hooks/use-connector-dialog.ts` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->