### PR TITLE
refactor: migrate PromptConfigManager save to updateSearchSpaceMutationAtom

### DIFF
--- a/surfsense_web/components/settings/prompt-config-manager.tsx
+++ b/surfsense_web/components/settings/prompt-config-manager.tsx
@@ -1,19 +1,19 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
+import { useAtomValue } from "jotai";
 import { AlertTriangle, Info } from "lucide-react";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
+import { updateSearchSpaceMutationAtom } from "@/atoms/search-spaces/search-space-mutation.atoms";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Textarea } from "@/components/ui/textarea";
 import { searchSpacesApiService } from "@/lib/apis/search-spaces-api.service";
-import { authenticatedFetch } from "@/lib/auth-utils";
 import { cacheKeys } from "@/lib/query-client/cache-keys";
 import { Spinner } from "../ui/spinner";
-import { BACKEND_URL } from "@/lib/env-config";
 
 interface PromptConfigManagerProps {
 	searchSpaceId: number;
@@ -23,15 +23,17 @@ export function PromptConfigManager({ searchSpaceId }: PromptConfigManagerProps)
 	const {
 		data: searchSpace,
 		isLoading: loading,
-		refetch: fetchSearchSpace,
 	} = useQuery({
 		queryKey: cacheKeys.searchSpaces.detail(searchSpaceId.toString()),
 		queryFn: () => searchSpacesApiService.getSearchSpace({ id: searchSpaceId }),
 		enabled: !!searchSpaceId,
 	});
 
+	const { mutateAsync: updateSearchSpace, isPending: isSaving } = useAtomValue(
+		updateSearchSpaceMutationAtom
+	);
+
 	const [customInstructions, setCustomInstructions] = useState("");
-	const [saving, setSaving] = useState(false);
 	const hasSearchSpace = !!searchSpace;
 	const searchSpaceInstructions = searchSpace?.qna_custom_instructions;
 
@@ -48,34 +50,16 @@ export function PromptConfigManager({ searchSpaceId }: PromptConfigManagerProps)
 
 	const handleSave = async () => {
 		try {
-			setSaving(true);
-
-			const payload = {
-				qna_custom_instructions: customInstructions.trim() || "",
-			};
-
-			const response = await authenticatedFetch(
-				`${BACKEND_URL}/api/v1/searchspaces/${searchSpaceId}`,
-				{
-					method: "PUT",
-					headers: { "Content-Type": "application/json" },
-					body: JSON.stringify(payload),
-				}
-			);
-
-			if (!response.ok) {
-				const errorData = await response.json().catch(() => ({}));
-				throw new Error(errorData.detail || "Failed to save system instructions");
-			}
-
+			await updateSearchSpace({
+				id: searchSpaceId,
+				data: { qna_custom_instructions: customInstructions.trim() || "" },
+			});
 			toast.success("System instructions saved successfully");
-
-			await fetchSearchSpace();
 		} catch (error: unknown) {
+			const message =
+				error instanceof Error ? error.message : "Failed to save system instructions";
 			console.error("Error saving system instructions:", error);
-			toast.error(error instanceof Error ? error.message : "Failed to save system instructions");
-		} finally {
-			setSaving(false);
+			toast.error(message);
 		}
 	};
 
@@ -184,11 +168,11 @@ export function PromptConfigManager({ searchSpaceId }: PromptConfigManagerProps)
 					<Button
 						type="submit"
 						variant="outline"
-						disabled={!hasChanges || saving}
+						disabled={!hasChanges || isSaving}
 						className="gap-2 bg-white text-black hover:bg-accent hover:text-accent-foreground dark:bg-white dark:text-black"
 					>
-						{saving ? <Spinner size="sm" /> : null}
-						{saving ? "Saving" : "Save Instructions"}
+						{isSaving ? <Spinner size="sm" /> : null}
+						{isSaving ? "Saving" : "Save Instructions"}
 					</Button>
 				</div>
 			</form>


### PR DESCRIPTION
Migrate `PromptConfigManager` save handler from a raw `authenticatedFetch` call to the shared `updateSearchSpaceMutationAtom`, making all three settings managers consistent.

## Description

Replaces the raw `authenticatedFetch` PUT call in `PromptConfigManager.handleSave` with `updateSearchSpaceMutationAtom`. Removes the local `saving` state (replaced by `isPending` from the mutation), drops the manual `fetchSearchSpace()` refetch (the atom's `onSuccess` already invalidates the cache), and removes now-unused imports (`authenticatedFetch`, `BACKEND_URL`).

## Motivation and Context

`general-settings-manager` and `team-memory-manager` both route their save through `updateSearchSpaceMutationAtom`, which provides Zod validation, typed error handling via `baseApiService`, and centralized cache invalidation. `PromptConfigManager` was bypassing all of that with a raw fetch, causing inconsistent error handling and cache behavior across the three managers.

FIX [#1361](https://github.com/MODSetter/SurfSense/issues/1361)

## Screenshots

N/A — pure refactor, no visual change.

## API Changes

- [ ] This PR includes API changes

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [x] Refactoring
- [ ] Documentation
- [ ] Dependency/Build system
- [ ] Breaking change
- [ ] Other (specify):

## Testing Performed

- [x] Tested locally
- [ ] Manual/QA verification

Open Settings → Prompt Config, edit the instructions and click Save — success toast appears and the textarea reflects the saved value. TypeScript reports zero errors on the changed file (`npx tsc --noEmit --skipLibCheck`).

## Checklist

- [x] Follows project coding standards and conventions
- [x] Documentation updated as needed
- [x] Dependencies updated as needed
- [x] No lint/build errors or new warnings
- [ ] All relevant tests are passing

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR refactors the `PromptConfigManager` to use the shared `updateSearchSpaceMutationAtom` instead of raw `authenticatedFetch` calls for saving prompt configurations. This change aligns the component with the existing patterns used in `general-settings-manager` and `team-memory-manager`, providing consistent error handling, Zod validation, and automatic cache invalidation across all three settings managers. The local `saving` state is replaced with `isPending` from the mutation hook, and manual cache refetching is removed since the mutation atom handles cache invalidation automatically.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/components/settings/prompt-config-manager.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->