### PR TITLE
fix(web): remove orphaned hasPermission inline body in roles-manager

### DIFF
--- a/surfsense_web/components/settings/roles-manager.tsx
+++ b/surfsense_web/components/settings/roles-manager.tsx
@@ -26,7 +26,7 @@ import {
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
-import { myAccessAtom, canPerform } from "@/atoms/members/members-query.atoms";
+import { canPerform, myAccessAtom } from "@/atoms/members/members-query.atoms";
 import { permissionsAtom } from "@/atoms/permissions/permissions-query.atoms";
 import {
 	createRoleMutationAtom,
@@ -258,13 +258,6 @@ export function RolesManager({ searchSpaceId }: { searchSpaceId: number }) {
 
 	const hasPermission = useCallback(
 		(permission: string) => canPerform(access, permission),
-		[access]
-	);
-		(permission: string) => {
-			if (!access) return false;
-			if (access.is_owner) return true;
-			return access.permissions?.includes(permission) ?? false;
-		},
 		[access]
 	);
 


### PR DESCRIPTION
<!--- Summarize your pull request in a few sentences -->
Removes orphaned arrow-function code left behind in `roles-manager.tsx` after PR #1428 (for issue #1366) extracted `hasPermission` into the shared `canPerform` helper. The leftover lines produce a parse error that breaks `pnpm build` and currently fails the E2E job on every PR targeting `dev`.

## Description
`components/settings/roles-manager.tsx` ends up with two function bodies stacked on top of each other after the merge — the new `useCallback(canPerform(...))` block closes correctly, then a second arrow function, its dependency array, and a trailing `)` follow with no enclosing call. This patch deletes those orphan lines.

Before:

```tsx
const hasPermission = useCallback(
    (permission: string) => canPerform(access, permission),
    [access]
);
    (permission: string) => {
        if (!access) return false;
        if (access.is_owner) return true;
        return access.permissions?.includes(permission) ?? false;
    },
    [access]
);
```

After:

```tsx
const hasPermission = useCallback(
    (permission: string) => canPerform(access, permission),
    [access]
);
```

The remaining `useCallback` already supplies the same predicate the duplicated body computed (`canPerform` was extracted from that exact body in #1428), so behavior is unchanged.

## Motivation and Context
Currently any PR opened against `dev` fails the `Journey` E2E job because Playwright's `webServer` runs `pnpm build && pnpm start` in CI — and `pnpm build` exits 1 with `Expression expected` on `roles-manager.tsx:269`. Confirmed locally on a clean `dev` checkout. After this patch `pnpm build` completes successfully.

Sister file `app/dashboard/[search_space_id]/team/team-content.tsx` (the other file #1428 touched) was migrated cleanly and is not affected.

## Screenshots
N/A — bug fix, no UI change.

## API Changes
- [ ] This PR includes API changes

## Change Type
- [x] Bug fix

## Testing Performed
- Reproduced the failure on a clean `dev` checkout: `pnpm build` exits 1 with `Expression expected` at `roles-manager.tsx:269`.
- After the patch: `pnpm build` completes successfully, `pnpm exec biome check ./components/settings/roles-manager.tsx` passes.
- No behavior to QA — the deleted lines were never reachable code.

- [x] Tested locally
- [x] Manual/QA verification

## Checklist
- [x] Follows project coding standards and conventions
- [x] Documentation updated as needed
- [x] Dependencies updated as needed
- [x] No lint/build errors or new warnings
- [x] All relevant tests are passing

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a build-breaking syntax error in `roles-manager.tsx` by removing orphaned code leftover from a previous refactoring. After PR #1428 extracted the `hasPermission` logic into a shared `canPerform` helper, duplicate function body lines were inadvertently left behind, causing parse errors that broke `pnpm build` and failed E2E tests. The fix also reorders the import statement for consistency.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/components/settings/roles-manager.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->