### PR TITLE
refactor(web): shrink LayoutShell.documentsPanel interface (fixes #1360)

### DIFF
--- a/surfsense_web/components/layout/providers/LayoutDataProvider.tsx
+++ b/surfsense_web/components/layout/providers/LayoutDataProvider.tsx
@@ -127,7 +127,6 @@ export function LayoutDataProvider({ searchSpaceId, children }: LayoutDataProvid
 
 	// Documents sidebar state (shared atom so Composer can toggle it)
 	const [isDocumentsSidebarOpen, setIsDocumentsSidebarOpen] = useAtom(documentsSidebarOpenAtom);
-	const [isDocumentsDocked, setIsDocumentsDocked] = useState(true);
 	const setIsRightPanelCollapsed = useSetAtom(rightPanelCollapsedAtom);
 
 	// Open documents sidebar by default on desktop (docked mode)
@@ -748,8 +747,6 @@ export function LayoutDataProvider({ searchSpaceId, children }: LayoutDataProvid
 				documentsPanel={{
 					open: isDocumentsSidebarOpen,
 					onOpenChange: setIsDocumentsSidebarOpen,
-					isDocked: isDocumentsDocked,
-					onDockedChange: setIsDocumentsDocked,
 				}}
 				onTabSwitch={handleTabSwitch}
 			>

--- a/surfsense_web/components/layout/ui/shell/LayoutShell.tsx
+++ b/surfsense_web/components/layout/ui/shell/LayoutShell.tsx
@@ -157,8 +157,6 @@ interface LayoutShellProps {
 	documentsPanel?: {
 		open: boolean;
 		onOpenChange: (open: boolean) => void;
-		isDocked?: boolean;
-		onDockedChange?: (docked: boolean) => void;
 	};
 	onTabSwitch?: (tab: Tab) => void;
 }


### PR DESCRIPTION
<!--- Summarize your pull request in a few sentences -->
Removes the dead `isDocked` / `onDockedChange` plumbing from `LayoutShell.documentsPanel` — these fields were declared and populated by `LayoutDataProvider` but never forwarded by the shell to any consumer, so the interface advertised a capability it never delivered.

## Description
- **`components/layout/ui/shell/LayoutShell.tsx`** — Trims the `documentsPanel` prop type to the two fields the shell actually plumbs through (`open`, `onOpenChange`). `RightPanel` already declares its own interface restricted to those two fields, and `DocumentsSidebar` keeps the docking props on its own optional interface for the few callers that wire them directly.
- **`components/layout/providers/LayoutDataProvider.tsx`** — Drops the `isDocumentsDocked` / `setIsDocumentsDocked` `useState` pair and the matching `isDocked` / `onDockedChange` entries in the `documentsPanel` prop, since the shell never read them downstream. `FreeLayoutDataProvider` was already passing the minimal pair, so it needs no change.
- **`components/layout/ui/sidebar/DocumentsSidebar.tsx`** — Left untouched per the issue notes. Its docking props remain optional so any direct caller that does want to drive docking can still do so without the shell as a middleman.

## Motivation and Context
The previous interface advertised four fields, but `LayoutShell` only ever forwarded two. New contributors reading the type would expect the shell to drive a docking flow that it doesn't, and the data provider was carrying a `useState` that nothing else in the tree consumed. Tightening the contract makes the shell's actual capability self-documenting and removes a dead plumbing path.

FIX #1360

## Screenshots
N/A — type / dead-code cleanup, no UI change.

## API Changes
- [ ] This PR includes API changes

## Change Type
- [x] Refactoring

## Testing Performed
- `pnpm exec biome check ./components/layout/ui/shell/LayoutShell.tsx ./components/layout/providers/LayoutDataProvider.tsx` passes.
- `pnpm exec tsc --noEmit` introduces no new type errors in the touched files. Verified there are no other callers of `LayoutShell` passing `isDocked` / `onDockedChange` (`grep -r` across `surfsense_web/` returned only the two files above plus `DocumentsSidebar`'s own internal prop definitions, which are untouched).
- Runtime behaviour is unchanged: `LayoutShell` never read the removed fields, so removing them in the data provider has no downstream effect.

- [x] Tested locally
- [x] Manual/QA verification

## Checklist
- [x] Follows project coding standards and conventions
- [x] Documentation updated as needed
- [x] Dependencies updated as needed
- [x] No lint/build errors or new warnings
- [x] All relevant tests are passing

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR cleans up dead code by removing unused docking-related props (`isDocked` and `onDockedChange`) from the `LayoutShell.documentsPanel` interface. The shell component never forwarded these fields to any consumers, so the interface was advertising a capability it didn't actually deliver. The changes remove the unused state management from `LayoutDataProvider` and tighten the interface definition in `LayoutShell` to only include the two props that are actually used (`open` and `onOpenChange`).

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/components/layout/ui/shell/LayoutShell.tsx` |
| 2 | `surfsense_web/components/layout/providers/LayoutDataProvider.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->