### PR TITLE
feat(chat): add RemoveAdsBanner component to FreeChatPage

### DIFF
--- a/surfsense_web/components/free-chat/free-chat-page.tsx
+++ b/surfsense_web/components/free-chat/free-chat-page.tsx
@@ -37,6 +37,7 @@ import { BACKEND_URL } from "@/lib/env-config";
 import { trackAnonymousChatMessageSent } from "@/lib/posthog/events";
 import { FreeModelSelector } from "./free-model-selector";
 import { FreeThread } from "./free-thread";
+import { RemoveAdsBanner } from "./remove-ads-banner";
 
 // Render all tool calls via ToolFallback; backend keeps persisted
 // payloads bounded by summarising / truncating outputs.
@@ -135,7 +136,7 @@ export function FreeChatPage() {
 		pendingRetryRef.current = null;
 	}, [resetKey, modelSlug, tokenUsageStore]);
 
-	const cancelRun = useCallback(() => {
+	const cancelRun = useCallback(async () => {
 		if (abortControllerRef.current) {
 			abortControllerRef.current.abort();
 			abortControllerRef.current = null;
@@ -486,6 +487,8 @@ export function FreeChatPage() {
 					<div className="flex h-14 shrink-0 items-center justify-between border-b border-border/40 px-4">
 						<FreeModelSelector />
 					</div>
+
+					<RemoveAdsBanner />
 
 					{captchaRequired && TURNSTILE_SITE_KEY && (
 						<div className="flex justify-center border-b bg-muted/30 px-4 py-4">

--- a/surfsense_web/components/free-chat/remove-ads-banner.tsx
+++ b/surfsense_web/components/free-chat/remove-ads-banner.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { Sparkles, X } from "lucide-react";
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+const ADSENSE_CLIENT_ID = process.env.NEXT_PUBLIC_GOOGLE_ADSENSE_CLIENT_ID;
+
+// Versioned key so the copy can change later without resurfacing for users who
+// already dismissed an older variant (bump the version to re-show).
+const DISMISS_KEY = "surfsense:remove-ads-banner-dismissed:v1";
+
+/**
+ * Dismissible promo shown on the free /free/[model_slug] chat pages, nudging
+ * anonymous users to sign up to remove ads. Dismissal is persisted in
+ * localStorage so it stays hidden across reloads and navigations. The free
+ * chat keeps working whether or not the banner is dismissed.
+ *
+ * Renders nothing when AdSense is not configured (dev/preview), since there are
+ * no ads to remove in that case.
+ */
+export function RemoveAdsBanner({ className }: { className?: string }) {
+	// Default hidden so dismissed users never see a flash before the stored
+	// value is read on the client (avoids a hydration/flicker mismatch).
+	const [dismissed, setDismissed] = useState(true);
+
+	useEffect(() => {
+		try {
+			setDismissed(localStorage.getItem(DISMISS_KEY) === "1");
+		} catch {
+			// localStorage can throw in private browsing / when disabled.
+			setDismissed(false);
+		}
+	}, []);
+
+	const handleDismiss = () => {
+		setDismissed(true);
+		try {
+			localStorage.setItem(DISMISS_KEY, "1");
+		} catch {
+			// Ignore: dismissal just won't persist across reloads.
+		}
+	};
+
+	if (!ADSENSE_CLIENT_ID || dismissed) return null;
+
+	return (
+		<div className={cn("shrink-0 border-b bg-muted/30 px-4 py-3", className)}>
+			<Alert className="relative mx-auto w-full max-w-2xl pr-10">
+				<Sparkles />
+				<AlertTitle>Go ad-free with a free account</AlertTitle>
+				<AlertDescription>
+					<p>
+						Create a free SurfSense account to remove ads, unlock $5 of premium credit, and save
+						your chat history. You can keep chatting for free either way.
+					</p>
+					<Button asChild size="sm" className="mt-1">
+						<Link href="/login">Create Free Account</Link>
+					</Button>
+				</AlertDescription>
+				<Button
+					type="button"
+					variant="ghost"
+					size="icon"
+					onClick={handleDismiss}
+					aria-label="Dismiss"
+					className="absolute top-2 right-2 size-6"
+				>
+					<X />
+				</Button>
+			</Alert>
+		</div>
+	);
+}


### PR DESCRIPTION
- Integrated the RemoveAdsBanner component into the FreeChatPage to enhance user experience by providing ad-free interaction.

<!--- Summarize your pull request in a few sentences -->

## Description
<!--- Clearly describe what has changed in this pull request -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If this PR relates to an open issue, please link to the issue here: FIX #123 -->
FIX #


## Screenshots
<!-- If applicable, add screenshots or images to demonstrate the changes visually -->

## API Changes
<!-- Document any API changes if applicable -->
- [ ] This PR includes API changes

## Change Type
<!--- Indicate what kind(s) of changes this PR includes: -->
- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Dependency/Build system
- [ ] Breaking change
- [ ] Other (specify):

## Testing Performed
<!--- Briefly describe how you have tested these changes and what verification was performed -->
- [ ] Tested locally
- [ ] Manual/QA verification

## Checklist
<!--- Please confirm the following by marking with an 'x' as appropriate -->
- [ ] Follows project coding standards and conventions
- [ ] Documentation updated as needed
- [ ] Dependencies updated as needed
- [ ] No lint/build errors or new warnings
- [ ] All relevant tests are passing

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds a new dismissible banner component (`RemoveAdsBanner`) to the free chat page that encourages anonymous users to create an account to remove ads and unlock premium credit. The banner only appears when AdSense is configured, can be dismissed by users (with the preference persisted in localStorage), and is integrated into the `FreeChatPage` component above the captcha section.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/components/free-chat/remove-ads-banner.tsx` |
| 2 | `surfsense_web/components/free-chat/free-chat-page.tsx` |
</details>

<details>
<summary>⚠️ Inconsistent Changes Detected</summary>

| File Path | Warning |
|-----------|---------|
| `surfsense_web/components/free-chat/free-chat-page.tsx` | The cancelRun callback signature was changed from a regular function to an async function, but this change appears unrelated to adding the RemoveAdsBanner component |
</details>

[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a "Remove Ads" promotional banner on the free chat page highlighting ad-free premium options. Users can dismiss the banner with a single click, and their preference is saved locally to eliminate repeated prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->