### PR TITLE
feat(editor): route large documents to Monaco viewer

### DIFF
--- a/surfsense_backend/app/routes/editor_routes.py
+++ b/surfsense_backend/app/routes/editor_routes.py
@@ -38,6 +38,8 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
+EDITOR_PLATE_MAX_BYTES = 2 * 1024 * 1024
+
 
 @router.get("/search-spaces/{search_space_id}/documents/{document_id}/editor-content")
 async def get_editor_content(
@@ -84,6 +86,7 @@ async def get_editor_content(
 
     def _build_response(md: str) -> dict:
         size_bytes = len(md.encode("utf-8"))
+        viewer_mode = "monaco" if size_bytes > EDITOR_PLATE_MAX_BYTES else "plate"
         truncated = False
         output_md = md
         if max_length is not None and size_bytes > max_length:
@@ -97,6 +100,7 @@ async def get_editor_content(
             "content_size_bytes": size_bytes,
             "chunk_count": chunk_count,
             "truncated": truncated,
+            "viewer_mode": viewer_mode,
             "updated_at": document.updated_at.isoformat()
             if document.updated_at
             else None,

--- a/surfsense_backend/app/routes/editor_routes.py
+++ b/surfsense_backend/app/routes/editor_routes.py
@@ -41,21 +41,10 @@ router = APIRouter()
 EDITOR_PLATE_MAX_BYTES = 5 * 1024 * 1024
 
 
-def _truncate_utf8(text: str, max_bytes: int) -> str:
-    encoded = text.encode("utf-8")
-    if len(encoded) <= max_bytes:
-        return text
-    return encoded[:max_bytes].decode("utf-8", errors="ignore")
-
-
 @router.get("/search-spaces/{search_space_id}/documents/{document_id}/editor-content")
 async def get_editor_content(
     search_space_id: int,
     document_id: int,
-    max_length: int | None = Query(
-        None,
-        description="Truncate source_markdown to this many UTF-8 bytes. Defaults to the Plate editor byte limit.",
-    ),
     session: AsyncSession = Depends(get_async_session),
     user: User = Depends(current_active_user),
 ):
@@ -95,20 +84,13 @@ async def get_editor_content(
     def _build_response(md: str) -> dict:
         size_bytes = len(md.encode("utf-8"))
         viewer_mode = "monaco" if size_bytes > EDITOR_PLATE_MAX_BYTES else "plate"
-        content_limit = max_length if max_length is not None else EDITOR_PLATE_MAX_BYTES
-        truncated = False
-        output_md = md
-        if size_bytes > content_limit:
-            output_md = _truncate_utf8(md, content_limit)
-            truncated = True
         return {
             "document_id": document.id,
             "title": document.title,
             "document_type": document.document_type.value,
-            "source_markdown": output_md,
+            "source_markdown": md,
             "content_size_bytes": size_bytes,
             "chunk_count": chunk_count,
-            "truncated": truncated,
             "viewer_mode": viewer_mode,
             "editor_plate_max_bytes": EDITOR_PLATE_MAX_BYTES,
             "updated_at": document.updated_at.isoformat()

--- a/surfsense_backend/app/routes/editor_routes.py
+++ b/surfsense_backend/app/routes/editor_routes.py
@@ -38,7 +38,14 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
-EDITOR_PLATE_MAX_BYTES = 2 * 1024 * 1024
+EDITOR_PLATE_MAX_BYTES = 5 * 1024 * 1024
+
+
+def _truncate_utf8(text: str, max_bytes: int) -> str:
+    encoded = text.encode("utf-8")
+    if len(encoded) <= max_bytes:
+        return text
+    return encoded[:max_bytes].decode("utf-8", errors="ignore")
 
 
 @router.get("/search-spaces/{search_space_id}/documents/{document_id}/editor-content")
@@ -46,7 +53,8 @@ async def get_editor_content(
     search_space_id: int,
     document_id: int,
     max_length: int | None = Query(
-        None, description="Truncate source_markdown to this many characters"
+        None,
+        description="Truncate source_markdown to this many UTF-8 bytes. Defaults to the Plate editor byte limit.",
     ),
     session: AsyncSession = Depends(get_async_session),
     user: User = Depends(current_active_user),
@@ -87,10 +95,11 @@ async def get_editor_content(
     def _build_response(md: str) -> dict:
         size_bytes = len(md.encode("utf-8"))
         viewer_mode = "monaco" if size_bytes > EDITOR_PLATE_MAX_BYTES else "plate"
+        content_limit = max_length if max_length is not None else EDITOR_PLATE_MAX_BYTES
         truncated = False
         output_md = md
-        if max_length is not None and size_bytes > max_length:
-            output_md = md[:max_length]
+        if size_bytes > content_limit:
+            output_md = _truncate_utf8(md, content_limit)
             truncated = True
         return {
             "document_id": document.id,
@@ -101,6 +110,7 @@ async def get_editor_content(
             "chunk_count": chunk_count,
             "truncated": truncated,
             "viewer_mode": viewer_mode,
+            "editor_plate_max_bytes": EDITOR_PLATE_MAX_BYTES,
             "updated_at": document.updated_at.isoformat()
             if document.updated_at
             else None,

--- a/surfsense_web/components/editor-panel/editor-panel.tsx
+++ b/surfsense_web/components/editor-panel/editor-panel.tsx
@@ -51,10 +51,12 @@ interface EditorContent {
 	content_size_bytes?: number;
 	chunk_count?: number;
 	truncated?: boolean;
+	viewer_mode?: ViewerMode;
 }
 
 const EDITABLE_DOCUMENT_TYPES = new Set(["FILE", "NOTE"]);
 type EditorRenderMode = "rich_markdown" | "source_code";
+type ViewerMode = "plate" | "monaco";
 
 type AgentFilesystemMount = {
 	mount: string;
@@ -168,6 +170,9 @@ export function EditorPanelContent({
 	);
 
 	const isLargeDocument = (editorDoc?.content_size_bytes ?? 0) > LARGE_DOCUMENT_THRESHOLD;
+	const viewerMode: ViewerMode = isMemoryMode
+		? "plate"
+		: (editorDoc?.viewer_mode ?? (isLargeDocument ? "monaco" : "plate"));
 
 	useEffect(() => {
 		const controller = new AbortController();
@@ -432,12 +437,10 @@ export function EditorPanelContent({
 		? (isMemoryMode ||
 				editorRenderMode === "source_code" ||
 				EDITABLE_DOCUMENT_TYPES.has(editorDoc.document_type ?? "")) &&
-			!isLargeDocument
+			viewerMode === "plate"
 		: false;
-	// Render through PlateEditor for editable doc types (FILE/NOTE).
-	// Everything else (large docs, non-editable types) falls back to the
-	// lightweight `MarkdownViewer` — Plate is heavy on multi-MB docs and
-	// non-editable types don't benefit from its editing UX.
+	// Render through PlateEditor only when the backend says the rich editor is safe.
+	// Monaco mode is a raw markdown safety path for large documents.
 	const renderInPlateEditor = isEditableType;
 	const hasUnsavedChanges = editedMarkdown !== null;
 	const showDesktopHeader = !!onClose;
@@ -492,14 +495,14 @@ export function EditorPanelContent({
 		}
 	}, [documentId, editorDoc?.title, searchSpaceId]);
 
-	const largeDocAlert = isLargeDocument && !isLocalFileMode && editorDoc && (
-		<Alert className="mb-4">
+	const largeDocAlert = viewerMode === "monaco" && !isLocalFileMode && editorDoc && (
+		<Alert className="m-4 shrink-0">
 			<FileText className="size-4" />
 			<AlertDescription className="flex items-center justify-between gap-4">
 				<span>
 					This document is too large for the editor (
 					{Math.round((editorDoc.content_size_bytes ?? 0) / 1024 / 1024)}MB,{" "}
-					{editorDoc.chunk_count ?? 0} chunks). Showing a preview below.
+					{editorDoc.chunk_count ?? 0} chunks). Showing raw markdown below.
 				</span>
 				<Button
 					variant="outline"
@@ -753,12 +756,19 @@ export function EditorPanelContent({
 							}}
 						/>
 					</div>
-				) : isLargeDocument && !isLocalFileMode ? (
-					// Large doc — fast Streamdown preview + download CTA.
-					// Plate is heavy on multi-MB docs.
-					<div className="h-full overflow-y-auto px-5 py-4">
+				) : viewerMode === "monaco" && !isLocalFileMode ? (
+					// Large doc — raw markdown in Monaco. Rich renderers are intentionally skipped.
+					<div className="flex h-full min-h-0 flex-col">
 						{largeDocAlert}
-						<MarkdownViewer content={editorDoc.source_markdown} enableCitations />
+						<div className="min-h-0 flex-1 overflow-hidden">
+							<SourceCodeEditor
+								path={`${editorDoc.title || "document"}.md`}
+								language="markdown"
+								value={editorDoc.source_markdown}
+								readOnly
+								onChange={() => {}}
+							/>
+						</div>
 					</div>
 				) : renderInPlateEditor ? (
 					// Editable doc (FILE/NOTE) — Plate editing UX.

--- a/surfsense_web/components/editor-panel/editor-panel.tsx
+++ b/surfsense_web/components/editor-panel/editor-panel.tsx
@@ -12,7 +12,7 @@ import {
 	XIcon,
 } from "lucide-react";
 import dynamic from "next/dynamic";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { closeEditorPanelAtom, editorPanelAtom } from "@/atoms/editor/editor-panel.atom";
 import { DownloadOriginalButton } from "@/components/documents/download-original-button";
@@ -52,6 +52,7 @@ interface EditorContent {
 	chunk_count?: number;
 	truncated?: boolean;
 	viewer_mode?: ViewerMode;
+	editor_plate_max_bytes?: number;
 }
 
 const EDITABLE_DOCUMENT_TYPES = new Set(["FILE", "NOTE"]);
@@ -114,6 +115,20 @@ function EditorPanelSkeleton() {
 	);
 }
 
+function getUtf8ByteSize(value: string): number {
+	return new TextEncoder().encode(value).byteLength;
+}
+
+function formatBytes(bytes: number): string {
+	if (bytes >= 1024 * 1024) {
+		return `${(bytes / 1024 / 1024).toFixed(1)}MB`;
+	}
+	if (bytes >= 1024) {
+		return `${Math.round(bytes / 1024)}KB`;
+	}
+	return `${bytes}B`;
+}
+
 export function EditorPanelContent({
 	kind = "document",
 	documentId,
@@ -169,7 +184,8 @@ export function EditorPanelContent({
 		[electronAPI, searchSpaceId]
 	);
 
-	const isLargeDocument = (editorDoc?.content_size_bytes ?? 0) > LARGE_DOCUMENT_THRESHOLD;
+	const plateMaxBytes = editorDoc?.editor_plate_max_bytes ?? LARGE_DOCUMENT_THRESHOLD;
+	const isLargeDocument = (editorDoc?.content_size_bytes ?? 0) > plateMaxBytes;
 	const viewerMode: ViewerMode = isMemoryMode
 		? "plate"
 		: (editorDoc?.viewer_mode ?? (isLargeDocument ? "monaco" : "plate"));
@@ -248,8 +264,6 @@ export function EditorPanelContent({
 				const url = new URL(
 					`${BACKEND_URL}/api/v1/search-spaces/${searchSpaceId}/documents/${documentId}/editor-content`
 				);
-				url.searchParams.set("max_length", String(LARGE_DOCUMENT_THRESHOLD));
-
 				const response = await authenticatedFetch(url.toString(), { method: "GET" });
 
 				if (controller.signal.aborted) return;
@@ -407,7 +421,12 @@ export function EditorPanelContent({
 				setEditorDoc((prev) => (prev ? { ...prev, source_markdown: markdownRef.current } : prev));
 				setEditedMarkdown(null);
 				if (!options?.silent) {
-					toast.success("Document saved! Reindexing in background...");
+					const savedSizeBytes = getUtf8ByteSize(markdownRef.current);
+					if (savedSizeBytes > plateMaxBytes) {
+						toast.success("Document saved. It will reopen in raw markdown mode.");
+					} else {
+						toast.success("Document saved! Reindexing in background...");
+					}
 				}
 				return true;
 			} catch (err) {
@@ -428,6 +447,7 @@ export function EditorPanelContent({
 			localFilePath,
 			memoryLimits,
 			memoryScope,
+			plateMaxBytes,
 			resolveLocalVirtualPath,
 			searchSpaceId,
 		]
@@ -447,6 +467,11 @@ export function EditorPanelContent({
 	const showEditingActions = isEditableType && isEditing;
 	const localFileLanguage = inferMonacoLanguageFromPath(localFilePath);
 	const activeMarkdown = editedMarkdown ?? editorDoc?.source_markdown ?? "";
+	const activeMarkdownSizeBytes = useMemo(() => getUtf8ByteSize(activeMarkdown), [activeMarkdown]);
+	const isNearPlateLimit = activeMarkdownSizeBytes >= plateMaxBytes * 0.9;
+	const isOverPlateLimit = activeMarkdownSizeBytes > plateMaxBytes;
+	const showPlateSizeWarning =
+		showEditingActions && !isMemoryMode && !isLocalFileMode && isNearPlateLimit;
 	const memoryLimitState = isMemoryMode
 		? getMemoryLimitState(activeMarkdown.length, memoryLimits)
 		: null;
@@ -773,6 +798,16 @@ export function EditorPanelContent({
 				) : renderInPlateEditor ? (
 					// Editable doc (FILE/NOTE) — Plate editing UX.
 					<div className="flex h-full min-h-0 flex-col">
+						{showPlateSizeWarning && (
+							<Alert className="m-4 mb-0 shrink-0">
+								<FileText className="size-4" />
+								<AlertDescription>
+									{isOverPlateLimit
+										? `This document is ${formatBytes(activeMarkdownSizeBytes)}, above the rich editor limit of ${formatBytes(plateMaxBytes)}. You can save, but it will reopen in raw markdown mode.`
+										: `This document is approaching the rich editor limit (${formatBytes(activeMarkdownSizeBytes)} of ${formatBytes(plateMaxBytes)}).`}
+								</AlertDescription>
+							</Alert>
+						)}
 						<div className="flex-1 min-h-0 overflow-hidden">
 							<PlateEditor
 								key={`${

--- a/surfsense_web/components/editor-panel/editor-panel.tsx
+++ b/surfsense_web/components/editor-panel/editor-panel.tsx
@@ -50,7 +50,6 @@ interface EditorContent {
 	source_markdown: string;
 	content_size_bytes?: number;
 	chunk_count?: number;
-	truncated?: boolean;
 	viewer_mode?: ViewerMode;
 	editor_plate_max_bytes?: number;
 }

--- a/surfsense_web/components/layout/ui/tabs/DocumentTabContent.tsx
+++ b/surfsense_web/components/layout/ui/tabs/DocumentTabContent.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { PlateEditor } from "@/components/editor/plate-editor";
+import { SourceCodeEditor } from "@/components/editor/source-code-editor";
 import { MarkdownViewer } from "@/components/markdown-viewer";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
@@ -22,6 +23,7 @@ interface DocumentContent {
 	content_size_bytes?: number;
 	chunk_count?: number;
 	truncated?: boolean;
+	viewer_mode?: ViewerMode;
 }
 
 function DocumentSkeleton() {
@@ -51,6 +53,7 @@ interface DocumentTabContentProps {
 }
 
 const EDITABLE_DOCUMENT_TYPES = new Set(["FILE", "NOTE"]);
+type ViewerMode = "plate" | "monaco";
 
 export function DocumentTabContent({ documentId, searchSpaceId, title }: DocumentTabContentProps) {
 	const [doc, setDoc] = useState<DocumentContent | null>(null);
@@ -66,6 +69,7 @@ export function DocumentTabContent({ documentId, searchSpaceId, title }: Documen
 	const router = useRouter();
 
 	const isLargeDocument = (doc?.content_size_bytes ?? 0) > LARGE_DOCUMENT_THRESHOLD;
+	const viewerMode: ViewerMode = doc?.viewer_mode ?? (isLargeDocument ? "monaco" : "plate");
 
 	useEffect(() => {
 		const controller = new AbortController();
@@ -204,9 +208,9 @@ export function DocumentTabContent({ documentId, searchSpaceId, title }: Documen
 		);
 	}
 
-	const isEditable = EDITABLE_DOCUMENT_TYPES.has(doc.document_type ?? "") && !isLargeDocument;
+	const isEditable = viewerMode === "plate" && EDITABLE_DOCUMENT_TYPES.has(doc.document_type ?? "");
 
-	if (isEditing && !isLargeDocument) {
+	if (isEditing && viewerMode === "plate") {
 		return (
 			<div className="flex flex-col h-full overflow-hidden">
 				<div className="flex items-center justify-between px-6 py-3 border-b shrink-0">
@@ -265,64 +269,74 @@ export function DocumentTabContent({ documentId, searchSpaceId, title }: Documen
 					</Button>
 				)}
 			</div>
-			<div className="flex-1 overflow-auto">
-				<div className="max-w-4xl mx-auto px-6 py-6">
-					{isLargeDocument ? (
-						<>
-							<Alert className="mb-4">
-								<FileText className="size-4" />
-								<AlertDescription className="flex items-center justify-between gap-4">
-									<span>
-										This document is too large for the editor (
-										{Math.round((doc.content_size_bytes ?? 0) / 1024 / 1024)}MB,{" "}
-										{doc.chunk_count ?? 0} chunks). Showing a preview below.
+			<div className="flex-1 min-h-0 overflow-hidden">
+				{viewerMode === "monaco" ? (
+					<div className="flex h-full min-h-0 flex-col">
+						<Alert className="m-4 shrink-0">
+							<FileText className="size-4" />
+							<AlertDescription className="flex items-center justify-between gap-4">
+								<span>
+									This document is too large for the editor (
+									{Math.round((doc.content_size_bytes ?? 0) / 1024 / 1024)}MB,{" "}
+									{doc.chunk_count ?? 0} chunks). Showing raw markdown below.
+								</span>
+								<Button
+									variant="outline"
+									size="sm"
+									className="relative shrink-0"
+									disabled={downloading}
+									onClick={async () => {
+										setDownloading(true);
+										try {
+											const response = await authenticatedFetch(
+												`${BACKEND_URL}/api/v1/search-spaces/${searchSpaceId}/documents/${documentId}/download-markdown`,
+												{ method: "GET" }
+											);
+											if (!response.ok) throw new Error("Download failed");
+											const blob = await response.blob();
+											const url = URL.createObjectURL(blob);
+											const a = document.createElement("a");
+											a.href = url;
+											const disposition = response.headers.get("content-disposition");
+											const match = disposition?.match(/filename="(.+)"/);
+											a.download = match?.[1] ?? `${doc.title || "document"}.md`;
+											document.body.appendChild(a);
+											a.click();
+											a.remove();
+											URL.revokeObjectURL(url);
+											toast.success("Download started");
+										} catch {
+											toast.error("Failed to download document");
+										} finally {
+											setDownloading(false);
+										}
+									}}
+								>
+									<span className={`flex items-center gap-1.5 ${downloading ? "opacity-0" : ""}`}>
+										<Download className="size-3.5" />
+										Download .md
 									</span>
-									<Button
-										variant="outline"
-										size="sm"
-										className="relative shrink-0"
-										disabled={downloading}
-										onClick={async () => {
-											setDownloading(true);
-											try {
-												const response = await authenticatedFetch(
-													`${BACKEND_URL}/api/v1/search-spaces/${searchSpaceId}/documents/${documentId}/download-markdown`,
-													{ method: "GET" }
-												);
-												if (!response.ok) throw new Error("Download failed");
-												const blob = await response.blob();
-												const url = URL.createObjectURL(blob);
-												const a = document.createElement("a");
-												a.href = url;
-												const disposition = response.headers.get("content-disposition");
-												const match = disposition?.match(/filename="(.+)"/);
-												a.download = match?.[1] ?? `${doc.title || "document"}.md`;
-												document.body.appendChild(a);
-												a.click();
-												a.remove();
-												URL.revokeObjectURL(url);
-												toast.success("Download started");
-											} catch {
-												toast.error("Failed to download document");
-											} finally {
-												setDownloading(false);
-											}
-										}}
-									>
-										<span className={`flex items-center gap-1.5 ${downloading ? "opacity-0" : ""}`}>
-											<Download className="size-3.5" />
-											Download .md
-										</span>
-										{downloading && <Spinner size="sm" className="absolute" />}
-									</Button>
-								</AlertDescription>
-							</Alert>
+									{downloading && <Spinner size="sm" className="absolute" />}
+								</Button>
+							</AlertDescription>
+						</Alert>
+						<div className="min-h-0 flex-1 overflow-hidden">
+							<SourceCodeEditor
+								path={`${doc.title || "document"}.md`}
+								language="markdown"
+								value={doc.source_markdown}
+								readOnly
+								onChange={() => {}}
+							/>
+						</div>
+					</div>
+				) : (
+					<div className="h-full overflow-auto">
+						<div className="max-w-4xl mx-auto px-6 py-6">
 							<MarkdownViewer content={doc.source_markdown} enableCitations />
-						</>
-					) : (
-						<MarkdownViewer content={doc.source_markdown} enableCitations />
-					)}
-				</div>
+						</div>
+					</div>
+				)}
 			</div>
 		</div>
 	);

--- a/surfsense_web/components/layout/ui/tabs/DocumentTabContent.tsx
+++ b/surfsense_web/components/layout/ui/tabs/DocumentTabContent.tsx
@@ -22,7 +22,6 @@ interface DocumentContent {
 	source_markdown: string;
 	content_size_bytes?: number;
 	chunk_count?: number;
-	truncated?: boolean;
 	viewer_mode?: ViewerMode;
 	editor_plate_max_bytes?: number;
 }

--- a/surfsense_web/components/layout/ui/tabs/DocumentTabContent.tsx
+++ b/surfsense_web/components/layout/ui/tabs/DocumentTabContent.tsx
@@ -2,7 +2,7 @@
 
 import { Download, FileQuestionMark, FileText, Pencil, RefreshCw } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import { PlateEditor } from "@/components/editor/plate-editor";
 import { SourceCodeEditor } from "@/components/editor/source-code-editor";
@@ -24,6 +24,7 @@ interface DocumentContent {
 	chunk_count?: number;
 	truncated?: boolean;
 	viewer_mode?: ViewerMode;
+	editor_plate_max_bytes?: number;
 }
 
 function DocumentSkeleton() {
@@ -55,6 +56,20 @@ interface DocumentTabContentProps {
 const EDITABLE_DOCUMENT_TYPES = new Set(["FILE", "NOTE"]);
 type ViewerMode = "plate" | "monaco";
 
+function getUtf8ByteSize(value: string): number {
+	return new TextEncoder().encode(value).byteLength;
+}
+
+function formatBytes(bytes: number): string {
+	if (bytes >= 1024 * 1024) {
+		return `${(bytes / 1024 / 1024).toFixed(1)}MB`;
+	}
+	if (bytes >= 1024) {
+		return `${Math.round(bytes / 1024)}KB`;
+	}
+	return `${bytes}B`;
+}
+
 export function DocumentTabContent({ documentId, searchSpaceId, title }: DocumentTabContentProps) {
 	const [doc, setDoc] = useState<DocumentContent | null>(null);
 	const [isLoading, setIsLoading] = useState(true);
@@ -68,8 +83,13 @@ export function DocumentTabContent({ documentId, searchSpaceId, title }: Documen
 	const changeCountRef = useRef(0);
 	const router = useRouter();
 
-	const isLargeDocument = (doc?.content_size_bytes ?? 0) > LARGE_DOCUMENT_THRESHOLD;
+	const plateMaxBytes = doc?.editor_plate_max_bytes ?? LARGE_DOCUMENT_THRESHOLD;
+	const isLargeDocument = (doc?.content_size_bytes ?? 0) > plateMaxBytes;
 	const viewerMode: ViewerMode = doc?.viewer_mode ?? (isLargeDocument ? "monaco" : "plate");
+	const activeMarkdown = editedMarkdown ?? doc?.source_markdown ?? "";
+	const activeMarkdownSizeBytes = useMemo(() => getUtf8ByteSize(activeMarkdown), [activeMarkdown]);
+	const isNearPlateLimit = activeMarkdownSizeBytes >= plateMaxBytes * 0.9;
+	const isOverPlateLimit = activeMarkdownSizeBytes > plateMaxBytes;
 
 	useEffect(() => {
 		const controller = new AbortController();
@@ -92,8 +112,6 @@ export function DocumentTabContent({ documentId, searchSpaceId, title }: Documen
 				const url = new URL(
 					`${BACKEND_URL}/api/v1/search-spaces/${searchSpaceId}/documents/${documentId}/editor-content`
 				);
-				url.searchParams.set("max_length", String(LARGE_DOCUMENT_THRESHOLD));
-
 				const response = await authenticatedFetch(url.toString(), { method: "GET" });
 
 				if (controller.signal.aborted) return;
@@ -165,14 +183,19 @@ export function DocumentTabContent({ documentId, searchSpaceId, title }: Documen
 
 			setDoc((prev) => (prev ? { ...prev, source_markdown: markdownRef.current } : prev));
 			setEditedMarkdown(null);
-			toast.success("Document saved! Reindexing in background...");
+			const savedSizeBytes = getUtf8ByteSize(markdownRef.current);
+			if (savedSizeBytes > plateMaxBytes) {
+				toast.success("Document saved. It will reopen in raw markdown mode.");
+			} else {
+				toast.success("Document saved! Reindexing in background...");
+			}
 		} catch (err) {
 			console.error("Error saving document:", err);
 			toast.error(err instanceof Error ? err.message : "Failed to save document");
 		} finally {
 			setSaving(false);
 		}
-	}, [documentId, searchSpaceId]);
+	}, [documentId, plateMaxBytes, searchSpaceId]);
 
 	if (isLoading) return <DocumentSkeleton />;
 
@@ -232,20 +255,32 @@ export function DocumentTabContent({ documentId, searchSpaceId, title }: Documen
 						Done editing
 					</Button>
 				</div>
-				<div className="flex-1 overflow-hidden">
-					<PlateEditor
-						key={`edit-${documentId}`}
-						preset="full"
-						markdown={doc.source_markdown}
-						onMarkdownChange={handleMarkdownChange}
-						readOnly={false}
-						placeholder="Start writing..."
-						editorVariant="default"
-						onSave={handleSave}
-						hasUnsavedChanges={editedMarkdown !== null}
-						isSaving={saving}
-						defaultEditing={true}
-					/>
+				<div className="flex-1 min-h-0 overflow-hidden flex flex-col">
+					{isNearPlateLimit && (
+						<Alert className="m-4 mb-0 shrink-0">
+							<FileText className="size-4" />
+							<AlertDescription>
+								{isOverPlateLimit
+									? `This document is ${formatBytes(activeMarkdownSizeBytes)}, above the rich editor limit of ${formatBytes(plateMaxBytes)}. You can save, but it will reopen in raw markdown mode.`
+									: `This document is approaching the rich editor limit (${formatBytes(activeMarkdownSizeBytes)} of ${formatBytes(plateMaxBytes)}).`}
+							</AlertDescription>
+						</Alert>
+					)}
+					<div className="min-h-0 flex-1 overflow-hidden">
+						<PlateEditor
+							key={`edit-${documentId}`}
+							preset="full"
+							markdown={doc.source_markdown}
+							onMarkdownChange={handleMarkdownChange}
+							readOnly={false}
+							placeholder="Start writing..."
+							editorVariant="default"
+							onSave={handleSave}
+							hasUnsavedChanges={editedMarkdown !== null}
+							isSaving={saving}
+							defaultEditing={true}
+						/>
+					</div>
 				</div>
 			</div>
 		);

--- a/surfsense_web/tests/helpers/api/documents.ts
+++ b/surfsense_web/tests/helpers/api/documents.ts
@@ -45,6 +45,7 @@ export type EditorContent = {
 	chunk_count: number;
 	truncated: boolean;
 	viewer_mode?: "plate" | "monaco";
+	editor_plate_max_bytes?: number;
 };
 
 // Same endpoint the UI hits when a user opens a document in the dashboard.

--- a/surfsense_web/tests/helpers/api/documents.ts
+++ b/surfsense_web/tests/helpers/api/documents.ts
@@ -43,7 +43,6 @@ export type EditorContent = {
 	source_markdown: string;
 	content_size_bytes: number;
 	chunk_count: number;
-	truncated: boolean;
 	viewer_mode?: "plate" | "monaco";
 	editor_plate_max_bytes?: number;
 };

--- a/surfsense_web/tests/helpers/api/documents.ts
+++ b/surfsense_web/tests/helpers/api/documents.ts
@@ -44,6 +44,7 @@ export type EditorContent = {
 	content_size_bytes: number;
 	chunk_count: number;
 	truncated: boolean;
+	viewer_mode?: "plate" | "monaco";
 };
 
 // Same endpoint the UI hits when a user opens a document in the dashboard.


### PR DESCRIPTION
<!--- Summarize your pull request in a few sentences -->

## Description
<!--- Clearly describe what has changed in this pull request -->
- Add backend `viewer_mode` contract for editor content so large documents use `monaco` and smaller documents use `plate`.
- Increase the rich editor byte limit to 5MB and expose `editor_plate_max_bytes` to the frontend.
- Render large documents as read-only raw markdown in Monaco instead of mounting Plate.
- Add live Plate editing warnings when content approaches or exceeds the backend-provided rich editor limit.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If this PR relates to an open issue, please link to the issue here: FIX #123 -->
FIX #


## Screenshots
<!-- If applicable, add screenshots or images to demonstrate the changes visually -->

## API Changes
<!-- Document any API changes if applicable -->
- [ ] This PR includes API changes

## Change Type
<!--- Indicate what kind(s) of changes this PR includes: -->
- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Dependency/Build system
- [ ] Breaking change
- [ ] Other (specify):

## Testing Performed
<!--- Briefly describe how you have tested these changes and what verification was performed -->
- [ ] Tested locally
- [ ] Manual/QA verification

## Checklist
<!--- Please confirm the following by marking with an 'x' as appropriate -->
- [ ] Follows project coding standards and conventions
- [ ] Documentation updated as needed
- [ ] Dependencies updated as needed
- [ ] No lint/build errors or new warnings
- [ ] All relevant tests are passing

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR implements a dynamic viewer mode selection for documents based on size, routing large documents (>5MB) to a read-only Monaco editor while keeping smaller documents in the rich Plate editor. The backend now returns a `viewer_mode` field (`plate` or `monaco`) along with `editor_plate_max_bytes` to guide the frontend. The frontend adds live warnings when editing documents that approach or exceed the byte limit, and uses UTF-8 byte size calculations instead of character counts for accurate limit checks. Large documents are now displayed as raw markdown in Monaco instead of attempting to render them in the heavy Plate editor.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_backend/app/routes/editor_routes.py` |
| 2 | `surfsense_web/tests/helpers/api/documents.ts` |
| 3 | `surfsense_web/components/editor-panel/editor-panel.tsx` |
| 4 | `surfsense_web/components/layout/ui/tabs/DocumentTabContent.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->