### PR TITLE
feat: add fastCRW search connector

### DIFF
--- a/surfsense_backend/alembic/versions/160_add_crw_api_enum.py
+++ b/surfsense_backend/alembic/versions/160_add_crw_api_enum.py
@@ -1,0 +1,41 @@
+"""Add CRW_API connector enum value
+
+Revision ID: 160
+Revises: 159
+Create Date: 2026-06-13 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "160"
+down_revision: str | None = "159"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Safely add CRW_API to searchsourceconnectortype enum."""
+    op.execute(
+        """
+    DO $$
+    BEGIN
+        IF NOT EXISTS (
+            SELECT 1 FROM pg_type t
+            JOIN pg_enum e ON t.oid = e.enumtypid
+            WHERE t.typname = 'searchsourceconnectortype' AND e.enumlabel = 'CRW_API'
+        ) THEN
+            ALTER TYPE searchsourceconnectortype ADD VALUE 'CRW_API';
+        END IF;
+    END
+    $$;
+    """
+    )
+
+
+def downgrade() -> None:
+    """Downgrade not supported for enum edits."""
+    pass

--- a/surfsense_backend/app/agents/chat/multi_agent_chat/main_agent/runtime/connector_searchable_types.py
+++ b/surfsense_backend/app/agents/chat/multi_agent_chat/main_agent/runtime/connector_searchable_types.py
@@ -17,13 +17,14 @@ from typing import Any
 
 # Maps SearchSourceConnectorType enum values to the searchable document/connector types
 # used by pre-search middleware and web_search.
-# Live search connectors (TAVILY_API, LINKUP_API, BAIDU_SEARCH_API) are routed to
-# the web_search tool; all others are considered local/indexed data.
+# Live search connectors (TAVILY_API, LINKUP_API, BAIDU_SEARCH_API, CRW_API) are
+# routed to the web_search tool; all others are considered local/indexed data.
 _CONNECTOR_TYPE_TO_SEARCHABLE: dict[str, str] = {
     # Live search connectors (handled by web_search tool)
     "TAVILY_API": "TAVILY_API",
     "LINKUP_API": "LINKUP_API",
     "BAIDU_SEARCH_API": "BAIDU_SEARCH_API",
+    "CRW_API": "CRW_API",
     # Local/indexed connectors (handled by KB pre-search middleware)
     "SLACK_CONNECTOR": "SLACK_CONNECTOR",
     "TEAMS_CONNECTOR": "TEAMS_CONNECTOR",

--- a/surfsense_backend/app/agents/chat/multi_agent_chat/subagents/builtins/deliverables/tools/knowledge_base.py
+++ b/surfsense_backend/app/agents/chat/multi_agent_chat/subagents/builtins/deliverables/tools/knowledge_base.py
@@ -27,6 +27,7 @@ _LIVE_SEARCH_CONNECTORS: set[str] = {
     "TAVILY_API",
     "LINKUP_API",
     "BAIDU_SEARCH_API",
+    "CRW_API",
 }
 
 # Patterns that indicate the query has no meaningful search signal.
@@ -455,6 +456,7 @@ def format_documents_for_context(
         "TAVILY_API",
         "LINKUP_API",
         "BAIDU_SEARCH_API",
+        "CRW_API",
     }
 
     parts: list[str] = []

--- a/surfsense_backend/app/agents/chat/multi_agent_chat/subagents/builtins/research/tools/web_search.py
+++ b/surfsense_backend/app/agents/chat/multi_agent_chat/subagents/builtins/research/tools/web_search.py
@@ -16,18 +16,21 @@ _LIVE_SEARCH_CONNECTORS: set[str] = {
     "TAVILY_API",
     "LINKUP_API",
     "BAIDU_SEARCH_API",
+    "CRW_API",
 }
 
 _LIVE_CONNECTOR_SPECS: dict[str, tuple[str, bool, bool, dict[str, Any]]] = {
     "TAVILY_API": ("search_tavily", False, True, {}),
     "LINKUP_API": ("search_linkup", False, False, {"mode": "standard"}),
     "BAIDU_SEARCH_API": ("search_baidu", False, True, {}),
+    "CRW_API": ("search_crw", False, True, {}),
 }
 
 _CONNECTOR_LABELS: dict[str, str] = {
     "TAVILY_API": "Tavily",
     "LINKUP_API": "Linkup",
     "BAIDU_SEARCH_API": "Baidu",
+    "CRW_API": "fastCRW",
 }
 
 

--- a/surfsense_backend/app/agents/chat/multi_agent_chat/subagents/builtins/research/tools/web_search.py
+++ b/surfsense_backend/app/agents/chat/multi_agent_chat/subagents/builtins/research/tools/web_search.py
@@ -213,24 +213,16 @@ def create_web_search_tool(
                 continue
             all_documents.extend(result)
 
-        seen_urls: set[str] = set()
-        deduplicated: list[dict[str, Any]] = []
-        for doc in all_documents:
-            url = ((doc.get("document") or {}).get("metadata") or {}).get("url", "")
-            if url and url in seen_urls:
-                continue
-            if url:
-                seen_urls.add(url)
-            deduplicated.append(doc)
-
-        formatted = _format_web_results(deduplicated)
+        # Do not deduplicate by URL: each chunk is a distinct source entry that
+        # citation tracking relies on. Collapsing by URL would drop evidence
+        # returned by different live-search engines for the same page.
+        formatted = _format_web_results(all_documents)
 
         perf.info(
-            "[web_search] query=%r engines=%d results=%d deduped=%d chars=%d in %.3fs",
+            "[web_search] query=%r engines=%d results=%d chars=%d in %.3fs",
             query[:60],
             len(tasks),
             len(all_documents),
-            len(deduplicated),
             len(formatted),
             time.perf_counter() - t0,
         )

--- a/surfsense_backend/app/agents/chat/shared/tools/web_search.py
+++ b/surfsense_backend/app/agents/chat/shared/tools/web_search.py
@@ -22,18 +22,21 @@ _LIVE_SEARCH_CONNECTORS: set[str] = {
     "TAVILY_API",
     "LINKUP_API",
     "BAIDU_SEARCH_API",
+    "CRW_API",
 }
 
 _LIVE_CONNECTOR_SPECS: dict[str, tuple[str, bool, bool, dict[str, Any]]] = {
     "TAVILY_API": ("search_tavily", False, True, {}),
     "LINKUP_API": ("search_linkup", False, False, {"mode": "standard"}),
     "BAIDU_SEARCH_API": ("search_baidu", False, True, {}),
+    "CRW_API": ("search_crw", False, True, {}),
 }
 
 _CONNECTOR_LABELS: dict[str, str] = {
     "TAVILY_API": "Tavily",
     "LINKUP_API": "Linkup",
     "BAIDU_SEARCH_API": "Baidu",
+    "CRW_API": "fastCRW",
 }
 
 

--- a/surfsense_backend/app/agents/chat/shared/tools/web_search.py
+++ b/surfsense_backend/app/agents/chat/shared/tools/web_search.py
@@ -219,24 +219,16 @@ def create_web_search_tool(
                 continue
             all_documents.extend(result)
 
-        seen_urls: set[str] = set()
-        deduplicated: list[dict[str, Any]] = []
-        for doc in all_documents:
-            url = ((doc.get("document") or {}).get("metadata") or {}).get("url", "")
-            if url and url in seen_urls:
-                continue
-            if url:
-                seen_urls.add(url)
-            deduplicated.append(doc)
-
-        formatted = _format_web_results(deduplicated)
+        # Do not deduplicate by URL: each chunk is a distinct source entry that
+        # citation tracking relies on. Collapsing by URL would drop evidence
+        # returned by different live-search engines for the same page.
+        formatted = _format_web_results(all_documents)
 
         perf.info(
-            "[web_search] query=%r engines=%d results=%d deduped=%d chars=%d in %.3fs",
+            "[web_search] query=%r engines=%d results=%d chars=%d in %.3fs",
             query[:60],
             len(tasks),
             len(all_documents),
-            len(deduplicated),
             len(formatted),
             time.perf_counter() - t0,
         )

--- a/surfsense_backend/app/db.py
+++ b/surfsense_backend/app/db.py
@@ -85,6 +85,7 @@ class SearchSourceConnectorType(StrEnum):
     SEARXNG_API = "SEARXNG_API"
     LINKUP_API = "LINKUP_API"
     BAIDU_SEARCH_API = "BAIDU_SEARCH_API"  # Baidu AI Search API for Chinese web search
+    CRW_API = "CRW_API"  # fastCRW — Firecrawl-compatible web scraper; self-host or cloud
     SLACK_CONNECTOR = "SLACK_CONNECTOR"
     TEAMS_CONNECTOR = "TEAMS_CONNECTOR"
     ONEDRIVE_CONNECTOR = "ONEDRIVE_CONNECTOR"

--- a/surfsense_backend/app/services/ai_file_sort_service.py
+++ b/surfsense_backend/app/services/ai_file_sort_service.py
@@ -61,6 +61,7 @@ _CONNECTOR_TYPE_LABEL: dict[str, str] = {
     SearchSourceConnectorType.SEARXNG_API: "SearXNG Search",
     SearchSourceConnectorType.LINKUP_API: "Linkup Search",
     SearchSourceConnectorType.BAIDU_SEARCH_API: "Baidu Search",
+    SearchSourceConnectorType.CRW_API: "fastCRW Search",
     SearchSourceConnectorType.SLACK_CONNECTOR: "Slack",
     SearchSourceConnectorType.TEAMS_CONNECTOR: "Teams",
     SearchSourceConnectorType.ONEDRIVE_CONNECTOR: "OneDrive",

--- a/surfsense_backend/app/services/connector_service.py
+++ b/surfsense_backend/app/services/connector_service.py
@@ -948,6 +948,17 @@ class ConnectorService:
                 "sources": [],
             }, []
 
+        # Guard against unexpected JSON shapes: a non-object envelope would
+        # raise on .get(...) and fail the whole request instead of degrading.
+        if not isinstance(data, dict):
+            print("WARNING: fastCRW returned a non-object JSON envelope")
+            return {
+                "id": 13,
+                "name": "fastCRW Search",
+                "type": "CRW_API",
+                "sources": [],
+            }, []
+
         # Firecrawl-compatible envelope: failures set success=False and error.
         if data.get("success") is False:
             print(
@@ -963,6 +974,15 @@ class ConnectorService:
 
         crw_results = data.get("data", [])
 
+        if not isinstance(crw_results, list):
+            print("WARNING: fastCRW returned a non-list `data` payload")
+            return {
+                "id": 13,
+                "name": "fastCRW Search",
+                "type": "CRW_API",
+                "sources": [],
+            }, []
+
         if not crw_results:
             return {
                 "id": 13,
@@ -976,6 +996,8 @@ class ConnectorService:
 
         async with self.counter_lock:
             for result in crw_results:
+                if not isinstance(result, dict):
+                    continue
                 title = result.get("title", "fastCRW Result")
                 url = result.get("url", "")
                 # Prefer the full markdown when present, fall back to the snippet.

--- a/surfsense_backend/app/services/connector_service.py
+++ b/surfsense_backend/app/services/connector_service.py
@@ -835,6 +835,186 @@ class ConnectorService:
 
         return result_object, documents
 
+    async def search_crw(
+        self,
+        user_query: str,
+        search_space_id: int,
+        top_k: int = 20,
+    ) -> tuple:
+        """
+        Search using fastCRW and return both sources and documents.
+
+        fastCRW is a Firecrawl-compatible web scraper (single binary; self-host
+        or cloud). Results come from the ``POST /v1/search`` endpoint, which
+        returns a ``{success, data: [{title, url, description, markdown?}]}``
+        envelope.
+
+        Args:
+            user_query: User's search query
+            search_space_id: Search space ID
+            top_k: Maximum number of results to return
+
+        Returns:
+            tuple: (sources_info_dict, documents_list)
+        """
+        # Get CRW connector configuration
+        crw_connector = await self.get_connector_by_type(
+            SearchSourceConnectorType.CRW_API, search_space_id
+        )
+
+        if not crw_connector:
+            return {
+                "id": 13,
+                "name": "fastCRW Search",
+                "type": "CRW_API",
+                "sources": [],
+            }, []
+
+        config = crw_connector.config or {}
+        api_key = config.get("CRW_API_KEY")
+
+        # Default to the managed cloud; allow self-host override via CRW_BASE_URL.
+        base_url = (config.get("CRW_BASE_URL") or "https://fastcrw.com/api").rstrip("/")
+        search_endpoint = f"{base_url}/v1/search"
+
+        # Bearer auth (self-host instances may run without auth → key optional).
+        headers = {"Content-Type": "application/json"}
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+
+        payload = {
+            "query": user_query,
+            "limit": top_k,
+        }
+
+        try:
+            async with httpx.AsyncClient(timeout=90.0) as client:
+                response = await client.post(
+                    search_endpoint,
+                    headers=headers,
+                    json=payload,
+                )
+                response.raise_for_status()
+        except httpx.TimeoutException as exc:
+            print(f"ERROR: fastCRW API request timeout after 90s: {exc!r}")
+            print(f"Endpoint: {search_endpoint}")
+            return {
+                "id": 13,
+                "name": "fastCRW Search",
+                "type": "CRW_API",
+                "sources": [],
+            }, []
+        except httpx.HTTPStatusError as exc:
+            print(f"ERROR: fastCRW API HTTP Status Error: {exc.response.status_code}")
+            print(f"Response text: {exc.response.text[:500]}")
+            print(f"Request URL: {exc.request.url}")
+            return {
+                "id": 13,
+                "name": "fastCRW Search",
+                "type": "CRW_API",
+                "sources": [],
+            }, []
+        except httpx.RequestError as exc:
+            print(f"ERROR: fastCRW API Request Error: {type(exc).__name__}: {exc!r}")
+            print(f"Endpoint: {search_endpoint}")
+            return {
+                "id": 13,
+                "name": "fastCRW Search",
+                "type": "CRW_API",
+                "sources": [],
+            }, []
+        except Exception as exc:
+            print(
+                f"ERROR: Unexpected error calling fastCRW API: {type(exc).__name__}: {exc!r}"
+            )
+            print(f"Endpoint: {search_endpoint}")
+            return {
+                "id": 13,
+                "name": "fastCRW Search",
+                "type": "CRW_API",
+                "sources": [],
+            }, []
+
+        try:
+            data = response.json()
+        except ValueError as e:
+            print(f"ERROR: Failed to decode JSON response from fastCRW: {e}")
+            print(f"Response status: {response.status_code}")
+            print(f"Response text: {response.text[:500]}")  # First 500 chars
+            return {
+                "id": 13,
+                "name": "fastCRW Search",
+                "type": "CRW_API",
+                "sources": [],
+            }, []
+
+        # Firecrawl-compatible envelope: failures set success=False and error.
+        if data.get("success") is False:
+            print(
+                f"WARNING: fastCRW API returned error - "
+                f"Code: {data.get('error_code')}, Message: {data.get('error')}"
+            )
+            return {
+                "id": 13,
+                "name": "fastCRW Search",
+                "type": "CRW_API",
+                "sources": [],
+            }, []
+
+        crw_results = data.get("data", [])
+
+        if not crw_results:
+            return {
+                "id": 13,
+                "name": "fastCRW Search",
+                "type": "CRW_API",
+                "sources": [],
+            }, []
+
+        sources_list: list[dict[str, Any]] = []
+        documents: list[dict[str, Any]] = []
+
+        async with self.counter_lock:
+            for result in crw_results:
+                title = result.get("title", "fastCRW Result")
+                url = result.get("url", "")
+                # Prefer the full markdown when present, fall back to the snippet.
+                content = result.get("markdown") or result.get("description", "")
+
+                source = {
+                    "id": self.source_id_counter,
+                    "title": title,
+                    "description": result.get("description", ""),
+                    "url": url,
+                }
+                sources_list.append(source)
+
+                document = {
+                    "chunk_id": self.source_id_counter,
+                    "content": content,
+                    "score": 1.0,  # fastCRW doesn't provide relevance scores
+                    "document": {
+                        "id": self.source_id_counter,
+                        "title": title,
+                        "document_type": "CRW_API",
+                        "metadata": {
+                            "url": url,
+                            "source": "CRW_API",
+                        },
+                    },
+                }
+                documents.append(document)
+                self.source_id_counter += 1
+
+        result_object = {
+            "id": 13,
+            "name": "fastCRW Search",
+            "type": "CRW_API",
+            "sources": sources_list,
+        }
+
+        return result_object, documents
+
     async def search_slack(
         self,
         user_query: str,

--- a/surfsense_backend/app/utils/validators.py
+++ b/surfsense_backend/app/utils/validators.py
@@ -513,6 +513,15 @@ def validate_connector_config(
             ],
             "validators": {},
         },
+        "CRW_API": {
+            # Self-host instances may run without auth, so the key is optional.
+            "required": [],
+            "optional": [
+                "CRW_API_KEY",
+                "CRW_BASE_URL",
+            ],
+            "validators": {},
+        },
         # "SLACK_CONNECTOR": {
         #     "required": [],  # OAuth uses bot_token (encrypted), legacy uses SLACK_BOT_TOKEN
         #     "optional": [

--- a/surfsense_backend/app/utils/validators.py
+++ b/surfsense_backend/app/utils/validators.py
@@ -520,7 +520,13 @@ def validate_connector_config(
                 "CRW_API_KEY",
                 "CRW_BASE_URL",
             ],
-            "validators": {},
+            "validators": {
+                "CRW_BASE_URL": lambda: (
+                    validate_url_field("CRW_BASE_URL", "fastCRW")
+                    if config.get("CRW_BASE_URL")
+                    else None
+                ),
+            },
         },
         # "SLACK_CONNECTOR": {
         #     "required": [],  # OAuth uses bot_token (encrypted), legacy uses SLACK_BOT_TOKEN

--- a/surfsense_backend/tests/unit/services/test_connector_service_crw.py
+++ b/surfsense_backend/tests/unit/services/test_connector_service_crw.py
@@ -1,0 +1,188 @@
+"""Unit tests for ``ConnectorService.search_crw`` (fastCRW provider).
+
+fastCRW is a Firecrawl-compatible web scraper. ``search_crw`` calls the
+``POST /v1/search`` endpoint and maps the ``{success, data: [...]}`` envelope
+into SurfSense's ``(result_object, documents)`` tuple. These tests mock the
+HTTP layer so no network call is made — mirroring the connector-config pattern
+used by the Tavily / Linkup / Baidu providers.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+from app.services.connector_service import ConnectorService
+
+pytestmark = pytest.mark.unit
+
+
+def _make_service() -> ConnectorService:
+    """Build a ConnectorService without touching the database.
+
+    ``search_crw`` only needs the source-id counter/lock and the patched
+    ``get_connector_by_type`` helper, so we bypass ``__init__``.
+    """
+    import asyncio
+
+    svc = ConnectorService.__new__(ConnectorService)
+    svc.source_id_counter = 100000
+    svc.counter_lock = asyncio.Lock()
+    return svc
+
+
+def _patch_post(monkeypatch, *, json_data=None, exc: Exception | None = None) -> dict:
+    """Patch ``httpx.AsyncClient.post`` and capture the call args."""
+    captured: dict = {}
+
+    class _FakeResponse:
+        status_code = 200
+        text = ""
+
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self):
+            return json_data
+
+    async def _fake_post(self, url, headers=None, json=None):  # noqa: A002
+        captured["url"] = url
+        captured["headers"] = headers
+        captured["json"] = json
+        if exc is not None:
+            raise exc
+        return _FakeResponse()
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", _fake_post)
+    return captured
+
+
+@pytest.mark.asyncio
+async def test_search_crw_no_connector_returns_empty(monkeypatch):
+    svc = _make_service()
+
+    async def _no_connector(connector_type, search_space_id):
+        return None
+
+    monkeypatch.setattr(svc, "get_connector_by_type", _no_connector)
+
+    result_object, documents = await svc.search_crw("python", search_space_id=1)
+
+    assert result_object["type"] == "CRW_API"
+    assert result_object["sources"] == []
+    assert documents == []
+
+
+@pytest.mark.asyncio
+async def test_search_crw_maps_results(monkeypatch):
+    svc = _make_service()
+
+    connector = SimpleNamespace(config={"CRW_API_KEY": "sk-test"})
+
+    async def _connector(connector_type, search_space_id):
+        return connector
+
+    monkeypatch.setattr(svc, "get_connector_by_type", _connector)
+
+    captured = _patch_post(
+        monkeypatch,
+        json_data={
+            "success": True,
+            "data": [
+                {
+                    "title": "Result One",
+                    "url": "https://example.com/1",
+                    "description": "snippet one",
+                    "markdown": "# full markdown one",
+                },
+                {
+                    "title": "Result Two",
+                    "url": "https://example.com/2",
+                    "description": "snippet two",
+                },
+            ],
+        },
+    )
+
+    result_object, documents = await svc.search_crw(
+        "python", search_space_id=1, top_k=5
+    )
+
+    # Defaults to the managed cloud endpoint with Bearer auth.
+    assert captured["url"] == "https://fastcrw.com/api/v1/search"
+    assert captured["headers"]["Authorization"] == "Bearer sk-test"
+    assert captured["json"] == {"query": "python", "limit": 5}
+
+    assert result_object["type"] == "CRW_API"
+    assert len(result_object["sources"]) == 2
+    assert len(documents) == 2
+
+    # Full markdown is preferred when present; otherwise the snippet is used.
+    assert documents[0]["content"] == "# full markdown one"
+    assert documents[1]["content"] == "snippet two"
+    assert documents[0]["document"]["document_type"] == "CRW_API"
+    assert documents[0]["document"]["metadata"]["url"] == "https://example.com/1"
+
+
+@pytest.mark.asyncio
+async def test_search_crw_self_host_base_url_no_key(monkeypatch):
+    svc = _make_service()
+
+    # Self-host: no API key, custom base URL.
+    connector = SimpleNamespace(config={"CRW_BASE_URL": "http://localhost:3000/"})
+
+    async def _connector(connector_type, search_space_id):
+        return connector
+
+    monkeypatch.setattr(svc, "get_connector_by_type", _connector)
+
+    captured = _patch_post(monkeypatch, json_data={"success": True, "data": []})
+
+    result_object, documents = await svc.search_crw("python", search_space_id=1)
+
+    # Trailing slash trimmed; no Authorization header when key is absent.
+    assert captured["url"] == "http://localhost:3000/v1/search"
+    assert "Authorization" not in captured["headers"]
+    assert result_object["sources"] == []
+    assert documents == []
+
+
+@pytest.mark.asyncio
+async def test_search_crw_error_envelope_returns_empty(monkeypatch):
+    svc = _make_service()
+
+    connector = SimpleNamespace(config={"CRW_API_KEY": "sk-test"})
+
+    async def _connector(connector_type, search_space_id):
+        return connector
+
+    monkeypatch.setattr(svc, "get_connector_by_type", _connector)
+    _patch_post(
+        monkeypatch,
+        json_data={"success": False, "error": "bad request", "error_code": "BAD"},
+    )
+
+    result_object, documents = await svc.search_crw("python", search_space_id=1)
+
+    assert result_object["sources"] == []
+    assert documents == []
+
+
+@pytest.mark.asyncio
+async def test_search_crw_http_error_returns_empty(monkeypatch):
+    svc = _make_service()
+
+    connector = SimpleNamespace(config={"CRW_API_KEY": "sk-test"})
+
+    async def _connector(connector_type, search_space_id):
+        return connector
+
+    monkeypatch.setattr(svc, "get_connector_by_type", _connector)
+    _patch_post(monkeypatch, exc=httpx.TimeoutException("timed out"))
+
+    result_object, documents = await svc.search_crw("python", search_space_id=1)
+
+    assert result_object["sources"] == []
+    assert documents == []

--- a/surfsense_backend/tests/unit/services/test_connector_service_crw.py
+++ b/surfsense_backend/tests/unit/services/test_connector_service_crw.py
@@ -47,7 +47,7 @@ def _patch_post(monkeypatch, *, json_data=None, exc: Exception | None = None) ->
         def json(self):
             return json_data
 
-    async def _fake_post(self, url, headers=None, json=None):  # noqa: A002
+    async def _fake_post(self, url, headers=None, json=None):
         captured["url"] = url
         captured["headers"] = headers
         captured["json"] = json
@@ -186,3 +186,120 @@ async def test_search_crw_http_error_returns_empty(monkeypatch):
 
     assert result_object["sources"] == []
     assert documents == []
+
+
+@pytest.mark.asyncio
+async def test_search_crw_non_object_envelope_returns_empty(monkeypatch):
+    """A non-dict JSON body must degrade gracefully, not raise on .get(...)."""
+    svc = _make_service()
+
+    connector = SimpleNamespace(config={"CRW_API_KEY": "sk-test"})
+
+    async def _connector(connector_type, search_space_id):
+        return connector
+
+    monkeypatch.setattr(svc, "get_connector_by_type", _connector)
+    _patch_post(monkeypatch, json_data=["unexpected", "list"])
+
+    result_object, documents = await svc.search_crw("python", search_space_id=1)
+
+    assert result_object["type"] == "CRW_API"
+    assert result_object["sources"] == []
+    assert documents == []
+
+
+@pytest.mark.asyncio
+async def test_search_crw_non_list_data_returns_empty(monkeypatch):
+    """A non-list ``data`` payload must degrade gracefully."""
+    svc = _make_service()
+
+    connector = SimpleNamespace(config={"CRW_API_KEY": "sk-test"})
+
+    async def _connector(connector_type, search_space_id):
+        return connector
+
+    monkeypatch.setattr(svc, "get_connector_by_type", _connector)
+    _patch_post(monkeypatch, json_data={"success": True, "data": {"oops": 1}})
+
+    result_object, documents = await svc.search_crw("python", search_space_id=1)
+
+    assert result_object["sources"] == []
+    assert documents == []
+
+
+@pytest.mark.asyncio
+async def test_search_crw_skips_non_dict_items(monkeypatch):
+    """Non-dict items inside ``data`` are skipped, valid ones still mapped."""
+    svc = _make_service()
+
+    connector = SimpleNamespace(config={"CRW_API_KEY": "sk-test"})
+
+    async def _connector(connector_type, search_space_id):
+        return connector
+
+    monkeypatch.setattr(svc, "get_connector_by_type", _connector)
+    _patch_post(
+        monkeypatch,
+        json_data={
+            "success": True,
+            "data": [
+                "not-a-dict",
+                {
+                    "title": "Valid",
+                    "url": "https://example.com/ok",
+                    "description": "snippet",
+                },
+            ],
+        },
+    )
+
+    result_object, documents = await svc.search_crw("python", search_space_id=1)
+
+    assert len(result_object["sources"]) == 1
+    assert len(documents) == 1
+    assert documents[0]["document"]["metadata"]["url"] == "https://example.com/ok"
+
+
+@pytest.mark.asyncio
+async def test_search_crw_preserves_duplicate_url_entries(monkeypatch):
+    """Distinct chunks sharing a URL must each yield a separate source entry.
+
+    Citation tracking relies on every chunk keeping its own source, so the
+    connector must never collapse results by URL.
+    """
+    svc = _make_service()
+
+    connector = SimpleNamespace(config={"CRW_API_KEY": "sk-test"})
+
+    async def _connector(connector_type, search_space_id):
+        return connector
+
+    monkeypatch.setattr(svc, "get_connector_by_type", _connector)
+    _patch_post(
+        monkeypatch,
+        json_data={
+            "success": True,
+            "data": [
+                {
+                    "title": "Same Page A",
+                    "url": "https://example.com/dup",
+                    "markdown": "chunk one",
+                },
+                {
+                    "title": "Same Page B",
+                    "url": "https://example.com/dup",
+                    "markdown": "chunk two",
+                },
+            ],
+        },
+    )
+
+    result_object, documents = await svc.search_crw("python", search_space_id=1)
+
+    # Both entries are preserved despite sharing a URL.
+    assert len(result_object["sources"]) == 2
+    assert len(documents) == 2
+    # Each retains a unique chunk id for accurate citation tracking.
+    chunk_ids = {doc["chunk_id"] for doc in documents}
+    assert len(chunk_ids) == 2
+    assert [doc["content"] for doc in documents] == ["chunk one", "chunk two"]


### PR DESCRIPTION
## What
Adds **fastCRW** as a web-search connector, alongside the existing ones (SearXNG, Tavily, …).

## Why

[fastCRW](https://fastcrw.com) is a fully open-source (AGPL) web-scraping and search engine — a single ~8 MB Rust binary, ~6 MB RAM at idle — that ships the complete stack in its open core, no cloud dependency required.

### 100% local / open core — stealth, proxies, JS rendering all included

Self-hosted Firecrawl's OSS cannot reach Cloudflare-protected or JS-heavy sites in practice: its real anti-bot / stealth path (`fire-engine`) lives behind a cloud-only flag, so the self-hosted build falls back to plain fetch. fastCRW ships Cloudflare JS-challenge handling, UA rotation, SPA rendering, and BYO-proxy + rotation unconditionally — no flags, no cloud account, no asterisks. The combination of SurfSense + fastCRW gives users an actually-complete, fully self-hosted stack.

### Faster + higher quality (measured on Firecrawl's own benchmark dataset)

On Firecrawl's public benchmark dataset, fastCRW scores **63.74% truth-recall vs 56.04%** for Firecrawl, with faster median latency (p50 ~1.9 s vs ~2.3 s). Single binary deployment means no Redis, no workers, no Playwright sidecar.

### Search — built on SearXNG, with a quality layer on top

crw is not an alternative to SearXNG — it is built on top of it. SearXNG is the metasearch aggregator underneath; crw adds a quality layer: query expansion (multi-variant rewrite), content-aware reranking (re-scoring by fetched content rather than SearXNG's content-blind ordering), a calibrated direct-answer mode, and category routing (research queries fan out to arxiv / Semantic Scholar / Google Scholar, code queries to GitHub). The `/v1/search` endpoint also uses multi-round retrieval for deeper research flows. The result is SearXNG's breadth plus a measurable accuracy layer — all open-source (AGPL) and fully self-hostable with configurable engines.

### Firecrawl-API compatibility — why the diff is tiny

fastCRW implements the Firecrawl REST API, which is why this connector is a small additive diff that mirrors the existing pattern exactly.

## Changes (additive only)
- `app/services/connector_service.py`: `crw` search provider mirroring the existing connector.
- Alembic migration `160_add_crw_api_enum` + `connector_searchable_types.py`, `db.py`, `validators.py`: registers the `CRW_API` connector enum.
- Wired into the research/chat `web_search` tools.
- `tests/unit/services/test_connector_service_crw.py`.

`CRW_API_KEY` from https://fastcrw.com/dashboard (free tier); self-host base URL supported. Happy to adjust — I maintain it and can provide free credits.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds **fastCRW** as a new web-search connector option for SurfSense. The implementation follows the existing pattern used by other search providers (Tavily, Linkup, Baidu) by registering a new `CRW_API` connector type via database migration, implementing the `search_crw` method in the connector service that calls fastCRW's `/v1/search` endpoint, and wiring the new connector into the research and chat agent web search tools. The connector supports both managed cloud and self-hosted deployments with optional API key authentication, and includes comprehensive unit tests covering success cases, error handling, and configuration variants.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_backend/app/db.py` |
| 2 | `surfsense_backend/alembic/versions/160_add_crw_api_enum.py` |
| 3 | `surfsense_backend/app/utils/validators.py` |
| 4 | `surfsense_backend/app/services/connector_service.py` |
| 5 | `surfsense_backend/app/agents/chat/multi_agent_chat/main_agent/runtime/connector_searchable_types.py` |
| 6 | `surfsense_backend/app/agents/chat/multi_agent_chat/subagents/builtins/deliverables/tools/knowledge_base.py` |
| 7 | `surfsense_backend/app/agents/chat/multi_agent_chat/subagents/builtins/research/tools/web_search.py` |
| 8 | `surfsense_backend/app/agents/chat/shared/tools/web_search.py` |
| 9 | `surfsense_backend/app/services/ai_file_sort_service.py` |
| 10 | `surfsense_backend/tests/unit/services/test_connector_service_crw.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added fastCRW (CRW_API) as a live search connector with configurable endpoint and optional API key; integrated into search UI/flows and file-labeling.
* **Chores**
  * Database migration to register the new connector type.
* **Behavior Changes**
  * Web search now returns raw engine/chunk results (no URL-based deduplication); knowledge-base formatting treats fastCRW results as live-search items.
* **Tests**
  * Expanded tests cover fastCRW mapping, error cases, and result formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
