### PR TITLE
fix: memoize formatRelativeTime in thread list to prevent unnecessary re-renders

### DIFF
--- a/surfsense_web/components/assistant-ui/thread-list.tsx
+++ b/surfsense_web/components/assistant-ui/thread-list.tsx
@@ -9,7 +9,7 @@ import {
 	TrashIcon,
 } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { memo, useCallback, useEffect, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
 	DropdownMenu,
@@ -224,6 +224,11 @@ const ThreadListItemComponent = memo(function ThreadListItemComponent({
 	onUnarchive,
 	onDelete,
 }: ThreadListItemComponentProps) {
+	const relativeTime = useMemo(
+		() => formatRelativeTime(new Date(thread.updatedAt)),
+		[thread.updatedAt]
+	);
+
 	return (
 		<button
 			type="button"
@@ -237,7 +242,7 @@ const ThreadListItemComponent = memo(function ThreadListItemComponent({
 			<div className="flex-1 min-w-0">
 				<p className="truncate text-sm font-medium">{thread.title || "New Chat"}</p>
 				<p className="truncate text-xs text-muted-foreground">
-					{formatRelativeTime(new Date(thread.updatedAt))}
+					{relativeTime}
 				</p>
 			</div>
 			<DropdownMenu>


### PR DESCRIPTION
`ThreadListItemComponent` is wrapped in `memo()`, but `formatRelativeTime(new Date(thread.updatedAt))` was being called inline during render — creating a new `Date` object and recomputing the formatted string on every parent re-render, even when `updatedAt` hadn't changed.

This wraps the call in `useMemo` keyed on `thread.updatedAt`, so the formatting only runs when the timestamp actually changes.

**Changes:**
- Add `useMemo` to the React import
- Memoize `formatRelativeTime` result in `ThreadListItemComponent`

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR optimizes the `ThreadListItemComponent` by memoizing the `formatRelativeTime` computation to prevent unnecessary re-renders. Previously, the component was creating a new `Date` object and formatting the timestamp on every parent re-render, even when the `updatedAt` value hadn't changed. The fix uses `useMemo` to cache the formatted time string and only recompute it when `thread.updatedAt` actually changes, improving rendering performance.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/components/assistant-ui/thread-list.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->