### PR TITLE
fix(image-gen): resolve relative URLs returned by Xinference and compatible backends

### DIFF
--- a/surfsense_backend/app/agents/chat/multi_agent_chat/subagents/builtins/deliverables/tools/generate_image.py
+++ b/surfsense_backend/app/agents/chat/multi_agent_chat/subagents/builtins/deliverables/tools/generate_image.py
@@ -143,6 +143,8 @@ def create_generate_image_tool(
                         choose_auto_model_candidate(candidates, search_space_id)["id"]
                     )
 
+                provider_base_url: str | None = None
+
                 if config_id < 0:
                     global_model = _get_global_model(config_id)
                     if not global_model or not has_capability(
@@ -162,6 +164,7 @@ def create_generate_image_tool(
                         global_model["model_id"],
                     )
                     gen_kwargs.update(resolved_kwargs)
+                    provider_base_url = resolved_kwargs.get("api_base")
 
                     response = await aimage_generation(
                         prompt=prompt, model=model_string, **gen_kwargs
@@ -203,6 +206,7 @@ def create_generate_image_tool(
                         db_model.model_id,
                     )
                     gen_kwargs.update(resolved_kwargs)
+                    provider_base_url = resolved_kwargs.get("api_base")
 
                     response = await aimage_generation(
                         prompt=prompt, model=model_string, **gen_kwargs
@@ -241,8 +245,19 @@ def create_generate_image_tool(
 
             # b64_json (e.g. gpt-image-1) is served via our backend endpoint so
             # megabytes of base64 don't bloat the LLM context.
+            # Some OpenAI-compatible backends (e.g. Xinference) return a relative
+            # URL like /files/image.png. Browsers can't resolve these, so we
+            # prepend the provider's base origin when the URL starts with "/".
             if first_image.get("url"):
-                image_url = first_image["url"]
+                raw_url: str = first_image["url"]
+                if raw_url.startswith("/") and provider_base_url:
+                    from urllib.parse import urlparse
+
+                    parsed = urlparse(provider_base_url)
+                    origin = f"{parsed.scheme}://{parsed.netloc}"
+                    image_url = f"{origin}{raw_url}"
+                else:
+                    image_url = raw_url
             elif first_image.get("b64_json"):
                 backend_url = config.BACKEND_URL or "http://localhost:8000"
                 image_url = (


### PR DESCRIPTION
When using an OpenAI-compatible image backend like Xinference, the API can return a relative URL like `/files/image.png` instead of an absolute one. The browser can't resolve this, so generated images fail to display.

**Root cause:** `generate_image.py` passed `data[0].url` directly to the frontend without checking whether it was absolute. Xinference's file-serving endpoint returns a path-only URL.

**Fix:** After resolving the model config via `to_litellm()`, we now capture `api_base`. When the returned URL starts with `/`, we extract the origin (scheme + host + port) from `api_base` and prepend it to produce a fully-qualified URL. Absolute URLs (OpenAI, Azure, Recraft, etc.) are passed through unchanged.

No behaviour change for providers that already return absolute URLs.

Closes #1496

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes an issue where OpenAI-compatible image generation backends like Xinference return relative URLs (e.g., `/files/image.png`) instead of absolute URLs, causing images to fail to display in the browser. The fix captures the `api_base` from the resolved model configuration and prepends the provider's origin (scheme + host + port) to relative URLs, while leaving absolute URLs unchanged. This ensures all image URLs are fully-qualified and browser-resolvable.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_backend/app/agents/chat/multi_agent_chat/subagents/builtins/deliverables/tools/generate_image.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->