### PR TITLE
fix: normalize image URLs before persistence and add model selector aria-label

### DIFF
--- a/surfsense_backend/app/agents/chat/multi_agent_chat/subagents/builtins/deliverables/tools/generate_image.py
+++ b/surfsense_backend/app/agents/chat/multi_agent_chat/subagents/builtins/deliverables/tools/generate_image.py
@@ -240,24 +240,23 @@ def create_generate_image_tool(
                     error="No images were generated",
                 )
 
+            # Update all image URLs in response_dict to be absolute (for the serving endpoint)
+            from urllib.parse import urlparse
+            for image in images:
+                if image.get("url"):
+                    raw_url: str = image["url"]
+                    if raw_url.startswith("/") and provider_base_url:
+                        parsed = urlparse(provider_base_url)
+                        origin = f"{parsed.scheme}://{parsed.netloc}"
+                        image["url"] = f"{origin}{raw_url}"  # Update the stored dict!
+
             first_image = images[0]
             revised_prompt = first_image.get("revised_prompt", prompt)
 
             # b64_json (e.g. gpt-image-1) is served via our backend endpoint so
             # megabytes of base64 don't bloat the LLM context.
-            # Some OpenAI-compatible backends (e.g. Xinference) return a relative
-            # URL like /files/image.png. Browsers can't resolve these, so we
-            # prepend the provider's base origin when the URL starts with "/".
             if first_image.get("url"):
-                raw_url: str = first_image["url"]
-                if raw_url.startswith("/") and provider_base_url:
-                    from urllib.parse import urlparse
-
-                    parsed = urlparse(provider_base_url)
-                    origin = f"{parsed.scheme}://{parsed.netloc}"
-                    image_url = f"{origin}{raw_url}"
-                else:
-                    image_url = raw_url
+                image_url = first_image["url"]
             elif first_image.get("b64_json"):
                 backend_url = config.BACKEND_URL or "http://localhost:8000"
                 image_url = (

--- a/surfsense_backend/app/routes/image_generation_routes.py
+++ b/surfsense_backend/app/routes/image_generation_routes.py
@@ -213,13 +213,27 @@ async def _execute_image_generation(
         )
 
     # Store response
-    image_gen.response_data = (
+    response_dict = (
         response.model_dump() if hasattr(response, "model_dump") else dict(response)
     )
     if not image_gen.model and hasattr(response, "_hidden_params"):
         hidden = response._hidden_params
         if isinstance(hidden, dict) and hidden.get("model"):
             image_gen.model = hidden["model"]
+
+    # Fix relative URLs in response data (for the serving endpoint)
+    from urllib.parse import urlparse
+    images = response_dict.get("data", [])
+    provider_base_url = resolved_kwargs.get("api_base")
+    for image in images:
+        if image.get("url"):
+            raw_url: str = image["url"]
+            if raw_url.startswith("/") and provider_base_url:
+                parsed = urlparse(provider_base_url)
+                origin = f"{parsed.scheme}://{parsed.netloc}"
+                image["url"] = f"{origin}{raw_url}"
+
+    image_gen.response_data = response_dict
 
 
 # =============================================================================

--- a/surfsense_web/components/new-chat/model-selector.tsx
+++ b/surfsense_web/components/new-chat/model-selector.tsx
@@ -272,6 +272,7 @@ export function ModelSelector({
 			type="button"
 			variant="ghost"
 			size="sm"
+			aria-label="Select chat model"
 			className={cn(
 				"h-8 min-w-0 gap-2 rounded-md px-3 text-muted-foreground transition-colors",
 				"select-none",


### PR DESCRIPTION
## Summary

This PR fixes two issues related to image generation URL handling and chat model selector accessibility.

### Image Generation Fixes

Some OpenAI-compatible image generation providers (such as Xinference) return relative image URLs (e.g. `/files/image.png`). These URLs were not consistently converted to absolute URLs before being persisted, causing generated images to fail when rendered in the frontend or accessed through image serving endpoints.

The fix ensures that all image URLs are normalized to absolute URLs before being stored, regardless of which image generation path is used.

### Accessibility Improvements

The chat model selector button was missing an accessible label, making it difficult for screen reader users to identify its purpose. This PR adds an appropriate `aria-label` to improve accessibility and align behavior with the existing image model selector component.

## Changes Made

### Backend

**File:** `surfsense_backend/app/agents/chat/multi_agent_chat/subagents/builtins/deliverables/tools/generate_image.py`

* Added URL normalization logic before persisting `response_dict`.
* Converts relative image URLs to absolute URLs using the configured backend origin.

**File:** `surfsense_backend/app/routes/image_generation_routes.py`

* Added the same URL normalization logic in `_execute_image_generation()`.
* Ensures image URLs stored in `response_data` are always absolute.

### Frontend

**File:** `surfsense_web/components/new-chat/model-selector.tsx`

* Added:

```tsx
aria-label="Select chat model"
```

to the model selector button.

## Linked Issue

Fixes #1526

## Type of Change

* [x] Bug fix (non-breaking change that fixes an issue)
* [x] Accessibility improvement

## Testing

### Tested Scenarios

#### Image Generation

* [x] Generated images through the chat agent workflow.
* [x] Generated images through the Image Generation API endpoint.
* [x] Verified relative URLs are converted to absolute URLs before storage.
* [x] Verified generated images load correctly in the frontend.

#### Accessibility

* [x] Verified the chat model selector exposes an accessible name.
* [x] Confirmed screen readers can identify the button purpose.
* [x] Verified no regression in existing selector functionality.

## Example

### Before

```json
{
  "data": [
    {
      "url": "/files/generated-image.png"
    }
  ]
}
```

### After

```json
{
  "data": [
    {
      "url": "http://localhost:9999/files/generated-image.png"
    }
  ]
}
```

## Checklist

* [x] My code follows the project's coding standards
* [x] I have tested the changes locally
* [x] I have verified both image generation code paths
* [x] I have verified accessibility improvements
* [x] This PR fixes the linked issue

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes two issues: it ensures that relative image URLs returned by OpenAI-compatible image generation providers (like Xinference) are normalized to absolute URLs before being persisted to the database, and it adds an `aria-label` to the chat model selector button to improve screen reader accessibility.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/components/new-chat/model-selector.tsx` |
| 2 | `surfsense_backend/app/agents/chat/multi_agent_chat/subagents/builtins/deliverables/tools/generate_image.py` |
| 3 | `surfsense_backend/app/routes/image_generation_routes.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->