### PR TITLE
fix: handle missing text_as_html metadata for Unstructured table elements

### DIFF
--- a/surfsense_backend/app/utils/document_converters.py
+++ b/surfsense_backend/app/utils/document_converters.py
@@ -221,7 +221,11 @@ async def convert_element_to_markdown(element) -> str:
         "EmailAddress": lambda x: f"`{x}`",
         "Image": lambda x: f"![{x}]({x})",
         "PageBreak": lambda x: "\n---\n",
-        "Table": lambda x: f"```html\n{element.metadata['text_as_html']}\n```",
+        "Table": lambda x: (
+            f"```html\n{element.metadata['text_as_html']}\n```"
+            if element.metadata.get("text_as_html")
+            else x
+        ),
         "Header": lambda x: f"## {x}\n\n",
         "Footer": lambda x: f"*{x}*\n\n",
         "CodeSnippet": lambda x: f"```\n{x}\n```",


### PR DESCRIPTION
## Description
This PR prevents `convert_element_to_markdown()` from raising a `KeyError` when a `Table` element does not include `text_as_html` metadata.

Instead of failing, the converter now falls back to the extracted table text when `text_as_html` is unavailable. Existing behavior is unchanged when the metadata is present.

## Context
Some `Table` elements may not include `text_as_html`, even though valid table content is available. This change allows document conversion to continue gracefully while preserving the current behavior for supported inputs.


## Change Type
*  Bug fix


## Testing Performed
* Tested locally

Validation performed:
* Verified documents with `text_as_html` continue to produce HTML table output.
* Verified documents without `text_as_html` no longer raise `KeyError` and fall back to the extracted table text.
* `ruff check`
* `ruff format --check`
* Relevant tests pass.

## Done Checklists
*  Follows project coding standards and conventions
*  No lint/build errors or new warnings
*  All relevant tests are passing

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a `KeyError` bug in the document converter when processing `Table` elements from Unstructured that lack `text_as_html` metadata. The fix adds a fallback mechanism using the `.get()` method to check for the metadata's existence, returning the extracted table text when `text_as_html` is unavailable while preserving the existing HTML output behavior when the metadata is present.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_backend/app/utils/document_converters.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->