### PR TITLE
fix: use token-safe truncation for document embeddings

### DIFF
--- a/surfsense_backend/app/tasks/document_processors/_save.py
+++ b/surfsense_backend/app/tasks/document_processors/_save.py
@@ -10,6 +10,7 @@ from app.utils.document_converters import (
     create_document_chunks,
     embed_text,
     generate_content_hash,
+    truncate_for_embedding,
 )
 
 from ._helpers import (
@@ -73,7 +74,9 @@ async def save_file_document(
             if should_skip:
                 return doc
 
-        document_content = f"File: {file_name}\n\n{markdown_content[:4000]}"
+        document_content = (
+            f"File: {file_name}\n\n{truncate_for_embedding(markdown_content)}"
+        )
         document_embedding = embed_text(document_content)
         chunks = await create_document_chunks(markdown_content)
         doc_metadata = {"FILE_NAME": file_name, "ETL_SERVICE": etl_service}

--- a/surfsense_backend/app/tasks/document_processors/markdown_processor.py
+++ b/surfsense_backend/app/tasks/document_processors/markdown_processor.py
@@ -13,6 +13,7 @@ from app.utils.document_converters import (
     create_document_chunks,
     embed_text,
     generate_content_hash,
+    truncate_for_embedding,
 )
 
 from ._helpers import (
@@ -182,7 +183,9 @@ async def add_received_markdown_file_document(
                 return doc
             # Content changed - continue to update
 
-        summary_content = f"File: {file_name}\n\n{file_in_markdown[:4000]}"
+        summary_content = (
+            f"File: {file_name}\n\n{truncate_for_embedding(file_in_markdown)}"
+        )
         summary_embedding = embed_text(summary_content)
 
         # Process chunks


### PR DESCRIPTION
## Description

In both `_save.py` and `markdown_processor.py`, `summary_content` was being limited using a fixed character slice:

```python
summary_content = f"File: {file_name}\n\n{file_in_markdown[:4000]}"
```

A fixed character limit doesn't always match the embedding model's token limit, especially for multilingual documents. This can result in inconsistent summary content being passed through the embedding pipeline.

This change replaces the hardcoded slice with the existing `truncate_for_embedding()` utility:

```python
summary_content = f"File: {file_name}\n\n{truncate_for_embedding(file_in_markdown)}"
```

## Context

The project already uses `truncate_for_embedding()` inside `embed_text()`. This change applies the same truncation logic when generating document summaries, keeping the content used for RAG and embeddings consistent across the pipeline.


## Change Type
-  Bug fix (non-breaking change which fixes an issue)

## DOne Checklist
-  code follows the code style of this project
- I have tested this change locally
- This change does not introduce new dependencies
- The fix ensures non-ASCII texts won't break the embedding tokenizer length constraints

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a bug in document embedding generation where raw character slicing (`[:4000]`) was used instead of token-aware truncation. The character-based approach could exceed embedding model token limits and potentially split multibyte UTF-8 sequences. Both `_save.py` and `markdown_processor.py` now use the existing `truncate_for_embedding` utility function to properly truncate content based on the embedding model's tokenizer, ensuring safe handling of non-ASCII text and consistent token limit enforcement.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_backend/app/tasks/document_processors/_save.py` |
| 2 | `surfsense_backend/app/tasks/document_processors/markdown_processor.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->