### PR TITLE
fix: prevent spurious leading spaces in nested codeBlock interior lines

### DIFF
--- a/surfsense_backend/app/utils/blocknote_to_markdown.py
+++ b/surfsense_backend/app/utils/blocknote_to_markdown.py
@@ -133,7 +133,7 @@ def _render_block(
         code_text = _render_inline_content(content) if content else ""
         lines.append(f"{prefix}```{language}")
         for code_line in code_text.split("\n"):
-            lines.append(f"{prefix}{code_line}")
+            lines.append(code_line)
         lines.append(f"{prefix}```")
 
     elif block_type == "table":


### PR DESCRIPTION
## Description

this fixes the rendering of nested `codeBlock` elements in `app/utils/blocknote_to_markdown.py`.

curently, when a `codeBlock` was nested inside an indented block (such as a list item), the renderer added the indentation to every line of the code block. This caused extra leading spaces to be included in the rendered markdown.

with this change:
* Code fences keep the existing indentation.
* Code content is rendered exactly as written.
* No extra leading spaces are added to the code block.

## Context

This is a isolated fix to the markdown renderer.
* Only nested `codeBlock` rendering is affected.
* Other block types are unchanged.
* Code snippets stored for RAG keep their original formatting.

## Change Type
* Bug fix

## Testing Performed
* Tested locally
* `ruff check`
* `ruff format --check`
* Verified nested code blocks preserve their original content while keeping the existing markdown structure.

## Done Checklist
*  Follows project coding standards and conventions
* No Lint errors 
* All relevant tests are passing

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a bug in the markdown renderer where nested code blocks incorrectly included leading indentation spaces on every line of the code content. The fix ensures that when a `codeBlock` appears inside an indented structure like a list item, only the code fence markers retain the indentation prefix while the actual code lines are rendered exactly as written without extra leading spaces.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_backend/app/utils/blocknote_to_markdown.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->