### PR TITLE
feat: update authentication defaults to LOCAL

### DIFF
--- a/surfsense_backend/app/config/__init__.py
+++ b/surfsense_backend/app/config/__init__.py
@@ -762,7 +762,7 @@ class Config:
     TURNSTILE_SECRET_KEY = os.getenv("TURNSTILE_SECRET_KEY", "")
 
     # Auth
-    AUTH_TYPE = os.getenv("AUTH_TYPE")
+    AUTH_TYPE = os.getenv("AUTH_TYPE", "LOCAL")
     REGISTRATION_ENABLED = os.getenv("REGISTRATION_ENABLED", "TRUE").upper() == "TRUE"
 
     # Google OAuth

--- a/surfsense_web/lib/env-config.ts
+++ b/surfsense_web/lib/env-config.ts
@@ -8,9 +8,9 @@
 
 import packageJson from "../package.json";
 
-// Build-time fallback for packaged clients. Docker runtime reads plain AUTH_TYPE
-// through the runtime config provider first, then falls back to this baked value.
-export const BUILD_TIME_AUTH_TYPE = process.env.NEXT_PUBLIC_AUTH_TYPE || "GOOGLE";
+// Build-time fallback for packaged clients. Docker/runtime deployments default to
+// local auth unless AUTH_TYPE/NEXT_PUBLIC_AUTH_TYPE explicitly selects Google.
+export const BUILD_TIME_AUTH_TYPE = process.env.NEXT_PUBLIC_AUTH_TYPE || "LOCAL";
 
 // Backend API URL. An empty string is valid in proxy mode and means
 // same-origin relative requests (e.g. /api/v1/... and /auth/...).

--- a/surfsense_web/lib/runtime-auth-config.ts
+++ b/surfsense_web/lib/runtime-auth-config.ts
@@ -4,7 +4,7 @@ export type RuntimeAuthUiMode = "GOOGLE" | "LOCAL";
 
 export function resolveRuntimeAuthUiMode(
 	value: string | null | undefined,
-	fallback: string | null | undefined = "GOOGLE"
+	fallback: string | null | undefined = "LOCAL"
 ): RuntimeAuthUiMode {
 	const candidate = value?.trim().toUpperCase();
 	if (candidate === "GOOGLE") return "GOOGLE";


### PR DESCRIPTION
- Changed default AUTH_TYPE in backend configuration to "LOCAL".
- Updated frontend environment configuration to reflect the new default for packaged clients.
- Adjusted runtime authentication resolution to use "LOCAL" as the fallback value.

<!--- Summarize your pull request in a few sentences -->

## Description
<!--- Clearly describe what has changed in this pull request -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If this PR relates to an open issue, please link to the issue here: FIX #123 -->
FIX #


## Screenshots
<!-- If applicable, add screenshots or images to demonstrate the changes visually -->

## API Changes
<!-- Document any API changes if applicable -->
- [ ] This PR includes API changes

## Change Type
<!--- Indicate what kind(s) of changes this PR includes: -->
- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Dependency/Build system
- [ ] Breaking change
- [ ] Other (specify):

## Testing Performed
<!--- Briefly describe how you have tested these changes and what verification was performed -->
- [ ] Tested locally
- [ ] Manual/QA verification

## Checklist
<!--- Please confirm the following by marking with an 'x' as appropriate -->
- [ ] Follows project coding standards and conventions
- [ ] Documentation updated as needed
- [ ] Dependencies updated as needed
- [ ] No lint/build errors or new warnings
- [ ] All relevant tests are passing

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR changes the default authentication type from `GOOGLE` to `LOCAL` across the application. The backend configuration now defaults to `LOCAL` when the `AUTH_TYPE` environment variable is not set, and the frontend build-time and runtime configurations have been updated to align with this new default, ensuring consistent behavior for packaged clients and Docker deployments.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_backend/app/config/__init__.py` |
| 2 | `surfsense_web/lib/env-config.ts` |
| 3 | `surfsense_web/lib/runtime-auth-config.ts` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Authentication now defaults to **Local** when no auth type is configured.
  * Build-time and runtime auth behavior have been aligned to use **Local** as the default fallback.
* **Bug Fixes**
  * Fixed inconsistent auth mode selection when environment variables are missing or unset, reducing unexpected Google auth defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->