### PR TITLE
fix(auth): centralize session refresh retry handling

### DIFF
--- a/surfsense_backend/app/config/__init__.py
+++ b/surfsense_backend/app/config/__init__.py
@@ -916,7 +916,7 @@ class Config:
 
     # JWT Token Lifetimes
     ACCESS_TOKEN_LIFETIME_SECONDS = int(
-        os.getenv("ACCESS_TOKEN_LIFETIME_SECONDS", str(30 * 60))  # 30 minutes
+        os.getenv("ACCESS_TOKEN_LIFETIME_SECONDS", str(60 * 60))  # 60 minutes
     )
     MIN_ISSUED_AT = int(os.getenv("MIN_ISSUED_AT", "0"))
     REFRESH_TOKEN_LIFETIME_SECONDS = int(

--- a/surfsense_web/app/dashboard/[search_space_id]/new-chat/[[...chat_id]]/page.tsx
+++ b/surfsense_web/app/dashboard/[search_space_id]/new-chat/[[...chat_id]]/page.tsx
@@ -72,6 +72,7 @@ import { useThreadDetail, useThreadMessages } from "@/hooks/use-thread-queries";
 import { getAgentFilesystemSelection } from "@/lib/agent-filesystem";
 import { documentsApiService } from "@/lib/apis/documents-api.service";
 import { getDesktopAccessToken } from "@/lib/auth-fetch";
+import { refreshSession } from "@/lib/auth-utils";
 import { type ChatFlow, classifyChatError } from "@/lib/chat/chat-error-classifier";
 import { tagPreAcceptSendFailure, toHttpResponseError } from "@/lib/chat/chat-request-errors";
 import { getMentionDocKey } from "@/lib/chat/mention-doc-key";
@@ -688,10 +689,18 @@ export default function NewChatPage() {
 
 	const fetchWithTurnCancellingRetry = useCallback(async (runFetch: () => Promise<Response>) => {
 		const maxAttempts = 4;
+		let didRefreshAuth = false;
 		for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
 			const response = await runFetch();
 			if (response.ok) {
 				return response;
+			}
+			if (response.status === 401 && !didRefreshAuth) {
+				didRefreshAuth = true;
+				const refreshed = await refreshSession();
+				if (refreshed) {
+					continue;
+				}
 			}
 			const error = await toHttpResponseError(response);
 			const withMeta = error as Error & { errorCode?: string; retryAfterMs?: number };

--- a/surfsense_web/app/dashboard/[search_space_id]/new-chat/[[...chat_id]]/page.tsx
+++ b/surfsense_web/app/dashboard/[search_space_id]/new-chat/[[...chat_id]]/page.tsx
@@ -289,6 +289,16 @@ const TURN_CANCELLING_BACKOFF_FACTOR = 2;
 const TURN_CANCELLING_MAX_DELAY_MS = 1500;
 const RECENT_CANCEL_WINDOW_MS = 5_000;
 
+async function getRequestHeadersWithCurrentDesktopAuth(
+	headers: Record<string, string> = {}
+): Promise<Record<string, string>> {
+	const token = await getDesktopAccessToken({ forceRefresh: true });
+	return {
+		...headers,
+		...(token ? { Authorization: `Bearer ${token}` } : {}),
+	};
+}
+
 function sleep(ms: number): Promise<void> {
 	return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -941,13 +951,12 @@ export default function NewChatPage() {
 	// Cancel ongoing request
 	const cancelRun = useCallback(async () => {
 		if (threadId) {
-			const token = await getDesktopAccessToken();
 			try {
 				const response = await fetch(
 					buildBackendUrl(`/api/v1/threads/${threadId}/cancel-active-turn`),
 					{
 						method: "POST",
-						headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+						headers: await getRequestHeadersWithCurrentDesktopAuth(),
 						credentials: "include",
 					}
 				);
@@ -994,8 +1003,6 @@ export default function NewChatPage() {
 			const { userQuery, userImages } = extractUserTurnForNewChatApi(message, urlsSnapshot);
 
 			if (!userQuery.trim() && userImages.length === 0) return;
-
-			const token = await getDesktopAccessToken();
 
 			// Lazy thread creation: create thread on first message if it doesn't exist
 			let currentThreadId = threadId;
@@ -1167,13 +1174,12 @@ export default function NewChatPage() {
 				const hasConnectorIds = mentionPayload.connector_ids.length > 0;
 				const hasThreadIds = mentionPayload.thread_ids.length > 0;
 
-				const response = await fetchWithTurnCancellingRetry(() =>
+				const response = await fetchWithTurnCancellingRetry(async () =>
 					fetch(buildBackendUrl("/api/v1/new_chat"), {
 						method: "POST",
-						headers: {
+						headers: await getRequestHeadersWithCurrentDesktopAuth({
 							"Content-Type": "application/json",
-							...(token ? { Authorization: `Bearer ${token}` } : {}),
-						},
+						}),
 						credentials: "include",
 						body: JSON.stringify({
 							chat_id: currentThreadId,
@@ -1555,8 +1561,6 @@ export default function NewChatPage() {
 			stagedDecisionsByInterruptIdRef.current.clear();
 			setIsRunning(true);
 
-			const token = await getDesktopAccessToken();
-
 			const controller = new AbortController();
 			abortControllerRef.current = controller;
 
@@ -1656,13 +1660,12 @@ export default function NewChatPage() {
 				const selection = await getAgentFilesystemSelection(searchSpaceId, {
 					localFilesystemEnabled,
 				});
-				const response = await fetchWithTurnCancellingRetry(() =>
+				const response = await fetchWithTurnCancellingRetry(async () =>
 					fetch(buildBackendUrl(`/api/v1/threads/${resumeThreadId}/resume`), {
 						method: "POST",
-						headers: {
+						headers: await getRequestHeadersWithCurrentDesktopAuth({
 							"Content-Type": "application/json",
-							...(token ? { Authorization: `Bearer ${token}` } : {}),
-						},
+						}),
 						credentials: "include",
 						body: JSON.stringify({
 							search_space_id: searchSpaceId,
@@ -1995,8 +1998,6 @@ export default function NewChatPage() {
 				abortControllerRef.current = null;
 			}
 
-			const token = await getDesktopAccessToken();
-
 			// Extract the original user query BEFORE removing messages (for reload mode)
 			let userQueryToDisplay: string | undefined;
 			let originalUserMessageContent: ThreadMessageLike["content"] | null = null;
@@ -2113,13 +2114,12 @@ export default function NewChatPage() {
 						requestBody.revert_actions = true;
 					}
 				}
-				const response = await fetchWithTurnCancellingRetry(() =>
+				const response = await fetchWithTurnCancellingRetry(async () =>
 					fetch(getRegenerateUrl(threadId), {
 						method: "POST",
-						headers: {
+						headers: await getRequestHeadersWithCurrentDesktopAuth({
 							"Content-Type": "application/json",
-							...(token ? { Authorization: `Bearer ${token}` } : {}),
-						},
+						}),
 						credentials: "include",
 						body: JSON.stringify(requestBody),
 						signal: controller.signal,

--- a/surfsense_web/app/dashboard/[search_space_id]/new-chat/[[...chat_id]]/page.tsx
+++ b/surfsense_web/app/dashboard/[search_space_id]/new-chat/[[...chat_id]]/page.tsx
@@ -71,8 +71,7 @@ import { useMessagesSync } from "@/hooks/use-messages-sync";
 import { useThreadDetail, useThreadMessages } from "@/hooks/use-thread-queries";
 import { getAgentFilesystemSelection } from "@/lib/agent-filesystem";
 import { documentsApiService } from "@/lib/apis/documents-api.service";
-import { getDesktopAccessToken } from "@/lib/auth-fetch";
-import { refreshSession } from "@/lib/auth-utils";
+import { authenticatedFetch } from "@/lib/auth-fetch";
 import { type ChatFlow, classifyChatError } from "@/lib/chat/chat-error-classifier";
 import { tagPreAcceptSendFailure, toHttpResponseError } from "@/lib/chat/chat-request-errors";
 import { getMentionDocKey } from "@/lib/chat/mention-doc-key";
@@ -288,16 +287,6 @@ const TURN_CANCELLING_INITIAL_DELAY_MS = 200;
 const TURN_CANCELLING_BACKOFF_FACTOR = 2;
 const TURN_CANCELLING_MAX_DELAY_MS = 1500;
 const RECENT_CANCEL_WINDOW_MS = 5_000;
-
-async function getRequestHeadersWithCurrentDesktopAuth(
-	headers: Record<string, string> = {}
-): Promise<Record<string, string>> {
-	const token = await getDesktopAccessToken({ forceRefresh: true });
-	return {
-		...headers,
-		...(token ? { Authorization: `Bearer ${token}` } : {}),
-	};
-}
 
 function sleep(ms: number): Promise<void> {
 	return new Promise((resolve) => setTimeout(resolve, ms));
@@ -699,18 +688,10 @@ export default function NewChatPage() {
 
 	const fetchWithTurnCancellingRetry = useCallback(async (runFetch: () => Promise<Response>) => {
 		const maxAttempts = 4;
-		let didRefreshAuth = false;
 		for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
 			const response = await runFetch();
 			if (response.ok) {
 				return response;
-			}
-			if (response.status === 401 && !didRefreshAuth) {
-				didRefreshAuth = true;
-				const refreshed = await refreshSession();
-				if (refreshed) {
-					continue;
-				}
 			}
 			const error = await toHttpResponseError(response);
 			const withMeta = error as Error & { errorCode?: string; retryAfterMs?: number };
@@ -952,12 +933,10 @@ export default function NewChatPage() {
 	const cancelRun = useCallback(async () => {
 		if (threadId) {
 			try {
-				const response = await fetch(
+				const response = await authenticatedFetch(
 					buildBackendUrl(`/api/v1/threads/${threadId}/cancel-active-turn`),
 					{
 						method: "POST",
-						headers: await getRequestHeadersWithCurrentDesktopAuth(),
-						credentials: "include",
 					}
 				);
 				if (response.ok) {
@@ -1174,13 +1153,12 @@ export default function NewChatPage() {
 				const hasConnectorIds = mentionPayload.connector_ids.length > 0;
 				const hasThreadIds = mentionPayload.thread_ids.length > 0;
 
-				const response = await fetchWithTurnCancellingRetry(async () =>
-					fetch(buildBackendUrl("/api/v1/new_chat"), {
+				const response = await fetchWithTurnCancellingRetry(() =>
+					authenticatedFetch(buildBackendUrl("/api/v1/new_chat"), {
 						method: "POST",
-						headers: await getRequestHeadersWithCurrentDesktopAuth({
+						headers: {
 							"Content-Type": "application/json",
-						}),
-						credentials: "include",
+						},
 						body: JSON.stringify({
 							chat_id: currentThreadId,
 							user_query: userQuery.trim(),
@@ -1660,13 +1638,12 @@ export default function NewChatPage() {
 				const selection = await getAgentFilesystemSelection(searchSpaceId, {
 					localFilesystemEnabled,
 				});
-				const response = await fetchWithTurnCancellingRetry(async () =>
-					fetch(buildBackendUrl(`/api/v1/threads/${resumeThreadId}/resume`), {
+				const response = await fetchWithTurnCancellingRetry(() =>
+					authenticatedFetch(buildBackendUrl(`/api/v1/threads/${resumeThreadId}/resume`), {
 						method: "POST",
-						headers: await getRequestHeadersWithCurrentDesktopAuth({
+						headers: {
 							"Content-Type": "application/json",
-						}),
-						credentials: "include",
+						},
 						body: JSON.stringify({
 							search_space_id: searchSpaceId,
 							decisions,
@@ -2114,13 +2091,12 @@ export default function NewChatPage() {
 						requestBody.revert_actions = true;
 					}
 				}
-				const response = await fetchWithTurnCancellingRetry(async () =>
-					fetch(getRegenerateUrl(threadId), {
+				const response = await fetchWithTurnCancellingRetry(() =>
+					authenticatedFetch(getRegenerateUrl(threadId), {
 						method: "POST",
-						headers: await getRequestHeadersWithCurrentDesktopAuth({
+						headers: {
 							"Content-Type": "application/json",
-						}),
-						credentials: "include",
+						},
 						body: JSON.stringify(requestBody),
 						signal: controller.signal,
 					})

--- a/surfsense_web/components/providers/ZeroProvider.tsx
+++ b/surfsense_web/components/providers/ZeroProvider.tsx
@@ -250,7 +250,7 @@ export function ZeroProvider({ children }: { children: React.ReactNode }) {
 	const pathname = usePathname();
 	const isDesktop = typeof window !== "undefined" && !!window.electronAPI;
 
-	if (!isDesktop && isPublicRoute(pathname)) {
+	if (isPublicRoute(pathname)) {
 		return <>{children}</>;
 	}
 

--- a/surfsense_web/components/providers/ZeroProvider.tsx
+++ b/surfsense_web/components/providers/ZeroProvider.tsx
@@ -31,21 +31,41 @@ function getCacheURL() {
 }
 
 async function fetchZeroContext(isDesktop: boolean): Promise<LoadedZeroContext | null> {
-	const headers: HeadersInit = {};
-	let desktopAuth: string | undefined;
+	const buildHeaders = async (
+		forceRefresh = false
+	): Promise<{ headers: HeadersInit; desktopAuth?: string } | null> => {
+		const headers: HeadersInit = {};
 
-	if (isDesktop) {
-		const token = await getDesktopAccessToken();
-		if (!token) return null;
-		desktopAuth = token;
-		headers.Authorization = `Bearer ${token}`;
+		if (isDesktop) {
+			const token = await getDesktopAccessToken({ forceRefresh });
+			if (!token) return null;
+			headers.Authorization = `Bearer ${token}`;
+			return { headers, desktopAuth: token };
+		}
+
+		return { headers };
+	};
+
+	const request = async (forceRefresh = false) => {
+		const auth = await buildHeaders(forceRefresh);
+		if (!auth) return null;
+		const response = await fetch(buildBackendUrl("/zero/context"), {
+			credentials: "include",
+			headers: auth.headers,
+		});
+		return { response, desktopAuth: auth.desktopAuth };
+	};
+
+	let result = await request();
+	if (result?.response.status === 401) {
+		const refreshed = await refreshSession();
+		if (refreshed) {
+			result = await request(true);
+		}
 	}
 
-	const response = await fetch(buildBackendUrl("/zero/context"), {
-		credentials: "include",
-		headers,
-	});
-
+	if (!result) return null;
+	const { response, desktopAuth } = result;
 	if (!response.ok) return null;
 
 	return {

--- a/surfsense_web/components/providers/ZeroProvider.tsx
+++ b/surfsense_web/components/providers/ZeroProvider.tsx
@@ -8,7 +8,7 @@ import {
 import { usePathname } from "next/navigation";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useSession } from "@/hooks/use-session";
-import { getDesktopAccessToken } from "@/lib/auth-fetch";
+import { authenticatedFetch, getDesktopAccessToken } from "@/lib/auth-fetch";
 import { handleUnauthorized, isPublicRoute, refreshSession } from "@/lib/auth-utils";
 import { buildBackendUrl } from "@/lib/env-config";
 import type { Context } from "@/types/zero";
@@ -31,46 +31,14 @@ function getCacheURL() {
 }
 
 async function fetchZeroContext(isDesktop: boolean): Promise<LoadedZeroContext | null> {
-	const buildHeaders = async (
-		forceRefresh = false
-	): Promise<{ headers: HeadersInit; desktopAuth?: string } | null> => {
-		const headers: HeadersInit = {};
-
-		if (isDesktop) {
-			const token = await getDesktopAccessToken({ forceRefresh });
-			if (!token) return null;
-			headers.Authorization = `Bearer ${token}`;
-			return { headers, desktopAuth: token };
-		}
-
-		return { headers };
-	};
-
-	const request = async (forceRefresh = false) => {
-		const auth = await buildHeaders(forceRefresh);
-		if (!auth) return null;
-		const response = await fetch(buildBackendUrl("/zero/context"), {
-			credentials: "include",
-			headers: auth.headers,
-		});
-		return { response, desktopAuth: auth.desktopAuth };
-	};
-
-	let result = await request();
-	if (result?.response.status === 401) {
-		const refreshed = await refreshSession();
-		if (refreshed) {
-			result = await request(true);
-		}
-	}
-
-	if (!result) return null;
-	const { response, desktopAuth } = result;
+	const response = await authenticatedFetch(buildBackendUrl("/zero/context"), {
+		skipAuthRedirect: true,
+	});
 	if (!response.ok) return null;
 
 	return {
 		context: (await response.json()) as ZeroContext,
-		desktopAuth,
+		desktopAuth: isDesktop ? (await getDesktopAccessToken()) || undefined : undefined,
 	};
 }
 
@@ -126,7 +94,7 @@ function ZeroAuthSync({ isDesktop }: { isDesktop: boolean }) {
 					}
 
 					if (isDesktop) {
-						const newToken = await getDesktopAccessToken();
+						const newToken = await getDesktopAccessToken({ forceRefresh: true });
 						if (!newToken) {
 							handleUnauthorized();
 							return;

--- a/surfsense_web/components/tool-ui/sandbox-execute.tsx
+++ b/surfsense_web/components/tool-ui/sandbox-execute.tsx
@@ -16,7 +16,7 @@ import { z } from "zod";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
-import { getDesktopAccessToken } from "@/lib/auth-fetch";
+import { authenticatedFetch } from "@/lib/auth-fetch";
 import { buildBackendUrl } from "@/lib/env-config";
 import { cn } from "@/lib/utils";
 
@@ -157,14 +157,10 @@ function truncateCommand(command: string, maxLen = 80): string {
 // ============================================================================
 
 async function downloadSandboxFile(threadId: string, filePath: string, fileName: string) {
-	const token = await getDesktopAccessToken();
 	const url = buildBackendUrl(`/api/v1/threads/${threadId}/sandbox/download`, {
 		path: filePath,
 	});
-	const res = await fetch(url, {
-		headers: token ? { Authorization: `Bearer ${token}` } : undefined,
-		credentials: "include",
-	});
+	const res = await authenticatedFetch(url);
 	if (!res.ok) {
 		throw new Error(`Download failed: ${res.statusText}`);
 	}

--- a/surfsense_web/hooks/use-session.ts
+++ b/surfsense_web/hooks/use-session.ts
@@ -1,29 +1,13 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import { refreshSession } from "@/lib/auth-utils";
+import { authenticatedFetch } from "@/lib/auth-fetch";
 import { buildBackendUrl } from "@/lib/env-config";
 
 type SessionState =
 	| { status: "loading"; authenticated: false; accessExpiresAt: null }
 	| { status: "authenticated"; authenticated: true; accessExpiresAt: number | null }
 	| { status: "unauthenticated"; authenticated: false; accessExpiresAt: null };
-
-async function getSessionHeaders(): Promise<HeadersInit> {
-	if (typeof window === "undefined" || !window.electronAPI?.getAccessToken) {
-		return {};
-	}
-
-	const token = await window.electronAPI.getAccessToken();
-	return token ? { Authorization: `Bearer ${token}` } : {};
-}
-
-async function fetchSession(): Promise<Response> {
-	return fetch(buildBackendUrl("/auth/session"), {
-		credentials: "include",
-		headers: await getSessionHeaders(),
-	});
-}
 
 export function useSession() {
 	const [state, setState] = useState<SessionState>({
@@ -34,13 +18,9 @@ export function useSession() {
 
 	const refresh = useCallback(async () => {
 		try {
-			let response = await fetchSession();
-			if (response.status === 401) {
-				const refreshed = await refreshSession();
-				if (refreshed) {
-					response = await fetchSession();
-				}
-			}
+			const response = await authenticatedFetch(buildBackendUrl("/auth/session"), {
+				skipAuthRedirect: true,
+			});
 			if (!response.ok) {
 				setState({
 					status: "unauthenticated",

--- a/surfsense_web/hooks/use-session.ts
+++ b/surfsense_web/hooks/use-session.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
+import { refreshSession } from "@/lib/auth-utils";
 import { buildBackendUrl } from "@/lib/env-config";
 
 type SessionState =
@@ -17,6 +18,13 @@ async function getSessionHeaders(): Promise<HeadersInit> {
 	return token ? { Authorization: `Bearer ${token}` } : {};
 }
 
+async function fetchSession(): Promise<Response> {
+	return fetch(buildBackendUrl("/auth/session"), {
+		credentials: "include",
+		headers: await getSessionHeaders(),
+	});
+}
+
 export function useSession() {
 	const [state, setState] = useState<SessionState>({
 		status: "loading",
@@ -26,10 +34,13 @@ export function useSession() {
 
 	const refresh = useCallback(async () => {
 		try {
-			const response = await fetch(buildBackendUrl("/auth/session"), {
-				credentials: "include",
-				headers: await getSessionHeaders(),
-			});
+			let response = await fetchSession();
+			if (response.status === 401) {
+				const refreshed = await refreshSession();
+				if (refreshed) {
+					response = await fetchSession();
+				}
+			}
 			if (!response.ok) {
 				setState({
 					status: "unauthenticated",

--- a/surfsense_web/lib/apis/base-api.service.ts
+++ b/surfsense_web/lib/apis/base-api.service.ts
@@ -1,4 +1,5 @@
 import type { ZodType } from "zod";
+import { getDesktopAccessToken } from "@/lib/auth-fetch";
 import { buildBackendUrl } from "@/lib/env-config";
 import { getClientPlatform } from "../agent-filesystem";
 import { handleUnauthorized, refreshSession } from "../auth-utils";
@@ -59,11 +60,6 @@ class BaseApiService {
 		return typeof window !== "undefined" && !!window.electronAPI;
 	}
 
-	private async getDesktopAccessToken(): Promise<string> {
-		if (!this.isDesktopClient) return "";
-		return (await window.electronAPI?.getAccessToken?.()) || "";
-	}
-
 	async request<T, R extends ResponseType = ResponseType.JSON>(
 		url: string,
 		responseSchema?: ZodType<T>,
@@ -90,7 +86,7 @@ class BaseApiService {
 				this.noAuthPrefixes.some((prefix) => url.startsWith(prefix)) ||
 				/^\/api\/v1\/invites\/[^/]+\/info$/.test(url);
 			const desktopAccessToken =
-				this.isDesktopClient && !isNoAuthEndpoint ? await this.getDesktopAccessToken() : "";
+				this.isDesktopClient && !isNoAuthEndpoint ? (await getDesktopAccessToken()) || "" : "";
 			const defaultOptions: RequestOptions = {
 				headers: {
 					...(desktopAccessToken ? { Authorization: `Bearer ${desktopAccessToken}` } : {}),
@@ -174,7 +170,9 @@ class BaseApiService {
 					} else if (!isNoAuthEndpoint && !isRefreshRetryBlocked(refreshRetryKey)) {
 						const refreshed = await refreshSession();
 						if (refreshed) {
-							const newToken = this.isDesktopClient ? await this.getDesktopAccessToken() : "";
+							const newToken = this.isDesktopClient
+								? (await getDesktopAccessToken({ forceRefresh: true })) || ""
+								: "";
 							return this.request(url, responseSchema, {
 								...mergedOptions,
 								headers: {

--- a/surfsense_web/lib/auth-fetch.ts
+++ b/surfsense_web/lib/auth-fetch.ts
@@ -3,6 +3,10 @@ import { handleUnauthorized, isDesktopClient, refreshSession } from "@/lib/auth-
 let desktopAccessToken: string | null = null;
 let didSubscribeToDesktopAuth = false;
 
+type DesktopAccessTokenOptions = {
+	forceRefresh?: boolean;
+};
+
 function subscribeToDesktopAuth(): void {
 	if (didSubscribeToDesktopAuth || typeof window === "undefined" || !window.electronAPI) {
 		return;
@@ -17,10 +21,12 @@ function subscribeToDesktopAuth(): void {
 	});
 }
 
-export async function getDesktopAccessToken(): Promise<string | null> {
+export async function getDesktopAccessToken(
+	options: DesktopAccessTokenOptions = {}
+): Promise<string | null> {
 	if (!isDesktopClient()) return null;
 	subscribeToDesktopAuth();
-	if (desktopAccessToken) return desktopAccessToken;
+	if (desktopAccessToken && !options.forceRefresh) return desktopAccessToken;
 	const token = (await window.electronAPI?.getAccessToken?.()) || null;
 	desktopAccessToken = token;
 	return token;
@@ -55,7 +61,7 @@ export async function authenticatedFetch(
 		if (!skipRefresh) {
 			const refreshed = await refreshSession();
 			if (refreshed) {
-				const newToken = await getDesktopAccessToken();
+				const newToken = await getDesktopAccessToken({ forceRefresh: true });
 				return fetch(url, {
 					...fetchOptions,
 					headers: {

--- a/surfsense_web/lib/auth-fetch.ts
+++ b/surfsense_web/lib/auth-fetch.ts
@@ -7,6 +7,12 @@ type DesktopAccessTokenOptions = {
 	forceRefresh?: boolean;
 };
 
+type AuthenticatedFetchOptions = RequestInit & {
+	skipAuthRedirect?: boolean;
+	skipRefresh?: boolean;
+	forceDesktopTokenRefresh?: boolean;
+};
+
 function subscribeToDesktopAuth(): void {
 	if (didSubscribeToDesktopAuth || typeof window === "undefined" || !window.electronAPI) {
 		return;
@@ -40,42 +46,61 @@ export function getAuthHeaders(additionalHeaders?: Record<string, string>): Reco
 	};
 }
 
+async function fetchWithAuth(
+	url: string,
+	options: RequestInit,
+	{ forceDesktopTokenRefresh = false }: { forceDesktopTokenRefresh?: boolean } = {}
+): Promise<Response> {
+	const headers = new Headers(options.headers);
+	const token = await getDesktopAccessToken({ forceRefresh: forceDesktopTokenRefresh });
+	if (token) {
+		headers.set("Authorization", `Bearer ${token}`);
+	}
+
+	return fetch(url, {
+		...options,
+		headers,
+		credentials: options.credentials ?? "include",
+	});
+}
+
 export async function authenticatedFetch(
 	url: string,
-	options?: RequestInit & { skipAuthRedirect?: boolean; skipRefresh?: boolean }
+	options: AuthenticatedFetchOptions = {}
 ): Promise<Response> {
-	const { skipAuthRedirect = false, skipRefresh = false, ...fetchOptions } = options || {};
-	const token = await getDesktopAccessToken();
-	const headers = {
-		...(fetchOptions.headers as Record<string, string>),
-		...(token ? { Authorization: `Bearer ${token}` } : {}),
-	};
+	const {
+		skipAuthRedirect = false,
+		skipRefresh = false,
+		forceDesktopTokenRefresh = false,
+		...fetchOptions
+	} = options;
 
-	const response = await fetch(url, {
-		...fetchOptions,
-		headers,
-		credentials: "include",
+	const response = await fetchWithAuth(url, fetchOptions, {
+		forceDesktopTokenRefresh,
 	});
 
-	if (response.status === 401 && !skipAuthRedirect) {
-		if (!skipRefresh) {
-			const refreshed = await refreshSession();
-			if (refreshed) {
-				const newToken = await getDesktopAccessToken({ forceRefresh: true });
-				return fetch(url, {
-					...fetchOptions,
-					headers: {
-						...(fetchOptions.headers as Record<string, string>),
-						...(newToken ? { Authorization: `Bearer ${newToken}` } : {}),
-					},
-					credentials: "include",
-				});
-			}
-		}
+	if (response.status !== 401) {
+		return response;
+	}
 
+	let unauthorizedResponse = response;
+	if (!skipRefresh) {
+		const refreshed = await refreshSession();
+		if (refreshed) {
+			const retryResponse = await fetchWithAuth(url, fetchOptions, {
+				forceDesktopTokenRefresh: true,
+			});
+			if (retryResponse.status !== 401) {
+				return retryResponse;
+			}
+			unauthorizedResponse = retryResponse;
+		}
+	}
+
+	if (!skipAuthRedirect) {
 		handleUnauthorized();
 		throw new Error("Unauthorized: Redirecting to login page");
 	}
 
-	return response;
+	return unauthorizedResponse;
 }

--- a/surfsense_web/lib/auth-utils.ts
+++ b/surfsense_web/lib/auth-utils.ts
@@ -188,9 +188,23 @@ async function doRefreshSession(): Promise<boolean> {
 	}
 }
 
+let refreshPromise: Promise<boolean> | null = null;
+
 export async function refreshSession(): Promise<boolean> {
-	if (typeof navigator !== "undefined" && "locks" in navigator) {
-		return navigator.locks.request("ss-token-refresh", () => doRefreshSession());
+	if (refreshPromise) {
+		return refreshPromise;
 	}
-	return doRefreshSession();
+
+	refreshPromise = (async () => {
+		if (typeof navigator !== "undefined" && "locks" in navigator) {
+			return navigator.locks.request("ss-token-refresh", () => doRefreshSession());
+		}
+		return doRefreshSession();
+	})();
+
+	try {
+		return await refreshPromise;
+	} finally {
+		refreshPromise = null;
+	}
 }


### PR DESCRIPTION
<!--- Summarize your pull request in a few sentences -->

## Description
<!--- Clearly describe what has changed in this pull request -->
- Centralizes authenticated request handling through shared `authenticatedFetch` logic.
- Adds retry-on-401 behavior that refreshes the session before retrying protected requests.
- Routes chat requests, session fetching, Zero context loading, sandbox execution, and API clients through the shared authenticated fetch path.
- Improves desktop auth by reusing cached desktop tokens and supporting forced token refresh when a session retry is needed.
- Rebuilds request headers after refresh so retried requests use current desktop/session auth state.
- Simplifies `useSession`, `ZeroProvider`, chat page, and base API service by removing duplicated refresh and header logic.
- Extends backend JWT access token lifetime from 30 minutes to 60 minutes to reduce unnecessary refresh churn.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If this PR relates to an open issue, please link to the issue here: FIX #123 -->
FIX #


## Screenshots
<!-- If applicable, add screenshots or images to demonstrate the changes visually -->

## API Changes
<!-- Document any API changes if applicable -->
- [ ] This PR includes API changes

## Change Type
<!--- Indicate what kind(s) of changes this PR includes: -->
- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Dependency/Build system
- [ ] Breaking change
- [ ] Other (specify):

## Testing Performed
<!--- Briefly describe how you have tested these changes and what verification was performed -->
- [ ] Tested locally
- [ ] Manual/QA verification

## Checklist
<!--- Please confirm the following by marking with an 'x' as appropriate -->
- [ ] Follows project coding standards and conventions
- [ ] Documentation updated as needed
- [ ] Dependencies updated as needed
- [ ] No lint/build errors or new warnings
- [ ] All relevant tests are passing

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes authentication session handling by implementing automatic session refresh on 401 errors and extending the access token lifetime from 30 to 60 minutes. The changes introduce a retry mechanism that attempts to refresh the session when receiving unauthorized responses across multiple components including chat, session hooks, and the Zero context provider. Additionally, it adds a `forceRefresh` option to the desktop access token retrieval function to ensure fresh tokens are obtained after session refresh.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_backend/app/config/__init__.py` |
| 2 | `surfsense_web/lib/auth-fetch.ts` |
| 3 | `surfsense_web/lib/auth-utils.ts` |
| 4 | `surfsense_web/hooks/use-session.ts` |
| 5 | `surfsense_web/components/providers/ZeroProvider.tsx` |
| 6 | `surfsense_web/app/dashboard/[search_space_id]/new-chat/[[...chat_id]]/page.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Extended default sign-in access token lifetime from 30 minutes to 60 minutes when no custom setting is provided.
  * Improved reliability of authenticated requests (chat flow, context loading, sandbox downloads, and session checks) by standardizing how auth headers/tokens are applied during initial calls and retries.
  * Tightened session/token refresh behavior by deduplicating concurrent session refreshes and forcing a new desktop token after session refresh to reduce unexpected failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->