### PR TITLE
fix(docker): add reverse proxy for zero sync auth context in Caddyfile

### DIFF
--- a/docker/proxy/Caddyfile
+++ b/docker/proxy/Caddyfile
@@ -31,6 +31,10 @@
 		flush_interval -1
 	}
 
+	# Zero sync auth context is a backend (FastAPI) endpoint. More specific than
+	# /zero/*, so Caddy's matcher-specificity sort routes it here, not to zero-cache.
+	reverse_proxy /zero/context backend:8000
+
 	# Zero accepts a single path-component base URL (Zero >= 0.6).
 	# Preserve /zero so browser cacheURL can be ${SURFSENSE_PUBLIC_URL}/zero.
 	reverse_proxy /zero/* zero-cache:4848


### PR DESCRIPTION
<!--- Summarize your pull request in a few sentences -->

## Description
<!--- Clearly describe what has changed in this pull request -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If this PR relates to an open issue, please link to the issue here: FIX #123 -->
FIX #


## Screenshots
<!-- If applicable, add screenshots or images to demonstrate the changes visually -->

## API Changes
<!-- Document any API changes if applicable -->
- [ ] This PR includes API changes

## Change Type
<!--- Indicate what kind(s) of changes this PR includes: -->
- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Dependency/Build system
- [ ] Breaking change
- [ ] Other (specify):

## Testing Performed
<!--- Briefly describe how you have tested these changes and what verification was performed -->
- [ ] Tested locally
- [ ] Manual/QA verification

## Checklist
<!--- Please confirm the following by marking with an 'x' as appropriate -->
- [ ] Follows project coding standards and conventions
- [ ] Documentation updated as needed
- [ ] Dependencies updated as needed
- [ ] No lint/build errors or new warnings
- [ ] All relevant tests are passing

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds a specific reverse proxy rule in the Caddyfile to route the `/zero/context` endpoint directly to the backend FastAPI service. This ensures that authentication context requests are handled by the backend rather than being routed to the zero-cache service, which would otherwise catch all `/zero/*` requests due to less specific path matching.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `docker/proxy/Caddyfile` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Requests to `/zero/context` now go directly to the backend instead of being handled by the cache.
  * Routing for other `/zero/*` paths remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->