### PR TITLE
fix(web): don't submit chat on Enter during IME composition

### DIFF
--- a/surfsense_web/components/assistant-ui/inline-mention-editor.tsx
+++ b/surfsense_web/components/assistant-ui/inline-mention-editor.tsx
@@ -696,7 +696,9 @@ export const InlineMentionEditor = forwardRef<InlineMentionEditorRef, InlineMent
 				onKeyDown?.(e);
 				if (e.defaultPrevented) return;
 
-				if (e.key === "Enter" && !e.shiftKey) {
+				// Ignore Enter while an IME composition is active (e.g. confirming a
+				// Japanese/Chinese/Korean conversion) so it doesn't submit the message.
+				if (e.key === "Enter" && !e.shiftKey && !e.nativeEvent.isComposing) {
 					e.preventDefault();
 					onSubmit?.();
 					return;

--- a/surfsense_web/components/assistant-ui/thread.tsx
+++ b/surfsense_web/components/assistant-ui/thread.tsx
@@ -713,6 +713,10 @@ const Composer: FC = () => {
 	// Arrow / Enter / Escape navigation for the active picker.
 	const handleKeyDown = useCallback(
 		(e: React.KeyboardEvent) => {
+			// While an IME composition is active (e.g. confirming a Japanese/Chinese/
+			// Korean conversion), let the Enter/Arrow keys reach the IME instead of
+			// driving picker navigation/selection.
+			if (e.nativeEvent.isComposing) return;
 			if (showPromptPicker) {
 				if (e.key === "ArrowDown") {
 					e.preventDefault();

--- a/surfsense_web/components/free-chat/free-composer.tsx
+++ b/surfsense_web/components/free-chat/free-composer.tsx
@@ -99,7 +99,9 @@ export const FreeComposer: FC = () => {
 				gate("mention documents");
 				return;
 			}
-			if (e.key === "Enter" && !e.shiftKey) {
+			// Ignore Enter while an IME composition is active (e.g. confirming a
+			// Japanese/Chinese/Korean conversion) so it doesn't submit the message.
+			if (e.key === "Enter" && !e.shiftKey && !e.nativeEvent.isComposing) {
 				e.preventDefault();
 				if (text.trim()) {
 					aui.composer().send();


### PR DESCRIPTION
## Summary

Fixes #1558.

Chat composers submitted on **Enter even during an active IME composition**, so confirming a Japanese/Chinese/Korean conversion (変換確定) with Enter sent a half-typed message. The Enter handlers only checked `!e.shiftKey` and never `isComposing` (which was unused anywhere in `surfsense_web`).

This guards the Enter handlers with `e.nativeEvent.isComposing`:

- `components/assistant-ui/inline-mention-editor.tsx` — main chat editor: skip `onSubmit` while composing.
- `components/free-chat/free-composer.tsx` — anonymous/free composer: skip `send` while composing.
- `components/assistant-ui/thread.tsx` — bail out of mention/prompt picker key navigation while composing, so conversion-confirm Enter/Arrows reach the IME instead of selecting a picker item.

A normal Enter (no active composition) still submits; Shift+Enter still inserts a newline.

## How to test
1. Switch the OS keyboard to a Japanese (or other CJK) IME.
2. Type `にほんご`, press Space to convert, then Enter to confirm.
3. Before: the message is submitted on that Enter. After: the conversion is confirmed and nothing is sent; a subsequent Enter sends.

## Notes
- Targets `dev` per CONTRIBUTING.md.
- `isComposing` is the standard `KeyboardEvent` flag (React 19 `e.nativeEvent.isComposing`); no new deps.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes an issue where pressing **Enter** during IME composition (used for Japanese, Chinese, Korean input) would incorrectly submit chat messages instead of confirming the character conversion. The fix adds checks for `e.nativeEvent.isComposing` to prevent message submission or picker navigation while the user is actively composing text with an IME. Normal **Enter** behavior (submit) and **Shift+Enter** (newline) remain unchanged when IME is not active.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/components/assistant-ui/inline-mention-editor.tsx` |
| 2 | `surfsense_web/components/free-chat/free-composer.tsx` |
| 3 | `surfsense_web/components/assistant-ui/thread.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->