### PR TITLE
fix: wire video_presentation fan-in as a barrier so generate_slide_scene_codes fires once

### DIFF
--- a/surfsense_backend/app/agents/video_presentation/graph.py
+++ b/surfsense_backend/app/agents/video_presentation/graph.py
@@ -24,9 +24,10 @@ def build_graph():
     workflow.add_edge("create_presentation_slides", "create_slide_audio")
     workflow.add_edge("create_presentation_slides", "assign_slide_themes")
 
-    # Fan-in: scene code generation waits for both audio and themes.
-    workflow.add_edge("create_slide_audio", "generate_slide_scene_codes")
-    workflow.add_edge("assign_slide_themes", "generate_slide_scene_codes")
+    # Fan-in: wait for BOTH audio and themes (barrier).
+    workflow.add_edge(
+        ["create_slide_audio", "assign_slide_themes"], "generate_slide_scene_codes"
+    )
 
     workflow.add_edge("generate_slide_scene_codes", "__end__")
 

--- a/surfsense_backend/tests/unit/agents/test_video_presentation_graph.py
+++ b/surfsense_backend/tests/unit/agents/test_video_presentation_graph.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import importlib
+import operator
+import sys
+import types
+from typing import Annotated, Any
+
+import pytest
+from langgraph.graph import END, START, StateGraph
+from typing_extensions import TypedDict
+
+pytestmark = pytest.mark.unit
+
+_GRAPH_MODULE = "app.agents.video_presentation.graph"
+_NODES_MODULE = "app.agents.video_presentation.nodes"
+_TARGET_NODE = "generate_slide_scene_codes"
+_BARRIER_SOURCES = ("create_slide_audio", "assign_slide_themes")
+
+
+class _DelayedState(TypedDict, total=False):
+    calls: Annotated[list[str], operator.add]
+    audio_ready: bool
+    themes_ready: bool
+
+
+def _config(thread_id: str = "video-presentation-graph-test") -> dict[str, Any]:
+    return {
+        "configurable": {
+            "search_space_id": 1,
+            "thread_id": thread_id,
+            "video_title": "Test deck",
+        }
+    }
+
+
+def _input_state() -> dict[str, Any]:
+    return {"db_session": None, "source_content": "source material"}
+
+
+def _build_video_graph(monkeypatch: pytest.MonkeyPatch, calls: list[str]):
+    nodes = types.ModuleType(_NODES_MODULE)
+
+    async def create_presentation_slides(_state, config):
+        _ = config
+        calls.append("create_presentation_slides")
+        return {"slides": [{"slide_number": 1, "title": "Intro"}]}
+
+    async def create_slide_audio(_state, config):
+        _ = config
+        calls.append("create_slide_audio")
+        return {"slide_audio_results": [{"slide_number": 1}]}
+
+    async def assign_slide_themes(_state, config):
+        _ = config
+        calls.append("assign_slide_themes")
+        return {"slide_theme_assignments": {1: ("corporate", "light")}}
+
+    async def generate_slide_scene_codes(state, config):
+        _ = config
+        calls.append(_TARGET_NODE)
+        assert state.slide_audio_results == [{"slide_number": 1}]
+        assert state.slide_theme_assignments == {1: ("corporate", "light")}
+        return {"slide_scene_codes": [{"slide_number": 1, "code": "", "title": ""}]}
+
+    nodes.create_presentation_slides = create_presentation_slides
+    nodes.create_slide_audio = create_slide_audio
+    nodes.assign_slide_themes = assign_slide_themes
+    nodes.generate_slide_scene_codes = generate_slide_scene_codes
+
+    monkeypatch.setitem(sys.modules, _NODES_MODULE, nodes)
+    monkeypatch.delitem(sys.modules, _GRAPH_MODULE, raising=False)
+
+    graph_module = importlib.import_module(_GRAPH_MODULE)
+    return graph_module.build_graph()
+
+
+@pytest.mark.asyncio
+async def test_video_presentation_graph_generates_scene_codes_once(monkeypatch):
+    calls: list[str] = []
+    graph = _build_video_graph(monkeypatch, calls)
+
+    await graph.ainvoke(_input_state(), _config())
+
+    assert calls.count(_TARGET_NODE) == 1
+    scene_index = calls.index(_TARGET_NODE)
+    assert calls.index("create_slide_audio") < scene_index
+    assert calls.index("assign_slide_themes") < scene_index
+
+
+def test_video_presentation_graph_registers_single_barrier_trigger(monkeypatch):
+    graph = _build_video_graph(monkeypatch, [])
+
+    assert graph.builder.waiting_edges == {(_BARRIER_SOURCES, _TARGET_NODE)}
+    assert not {
+        edge
+        for edge in graph.builder.edges
+        if edge[0] in _BARRIER_SOURCES and edge[1] == _TARGET_NODE
+    }
+
+    join_channel = f"join:{'+'.join(_BARRIER_SOURCES)}:{_TARGET_NODE}"
+    assert join_channel in graph.channels
+    assert graph.nodes[_TARGET_NODE].triggers.count(join_channel) == 1
+
+
+@pytest.mark.asyncio
+async def test_barrier_fires_once_when_one_branch_finishes_a_superstep_later():
+    def create_presentation_slides(_state):
+        return {"calls": ["create_presentation_slides"]}
+
+    def create_slide_audio(_state):
+        return {"calls": ["create_slide_audio"]}
+
+    def finish_slide_audio(_state):
+        return {"calls": ["finish_slide_audio"], "audio_ready": True}
+
+    def assign_slide_themes(_state):
+        return {"calls": ["assign_slide_themes"], "themes_ready": True}
+
+    def generate_slide_scene_codes(state):
+        assert state["audio_ready"] is True
+        assert state["themes_ready"] is True
+        return {"calls": [_TARGET_NODE]}
+
+    workflow = StateGraph(_DelayedState)
+    workflow.add_node("create_presentation_slides", create_presentation_slides)
+    workflow.add_node("create_slide_audio", create_slide_audio)
+    workflow.add_node("finish_slide_audio", finish_slide_audio)
+    workflow.add_node("assign_slide_themes", assign_slide_themes)
+    workflow.add_node(_TARGET_NODE, generate_slide_scene_codes)
+
+    workflow.add_edge(START, "create_presentation_slides")
+    workflow.add_edge("create_presentation_slides", "create_slide_audio")
+    workflow.add_edge("create_presentation_slides", "assign_slide_themes")
+    workflow.add_edge("create_slide_audio", "finish_slide_audio")
+    workflow.add_edge(["finish_slide_audio", "assign_slide_themes"], _TARGET_NODE)
+    workflow.add_edge(_TARGET_NODE, END)
+
+    result = await workflow.compile().ainvoke({"calls": []})
+
+    calls = result["calls"]
+    assert calls.count(_TARGET_NODE) == 1
+    assert calls.index("assign_slide_themes") < calls.index(_TARGET_NODE)
+    assert calls.index("finish_slide_audio") < calls.index(_TARGET_NODE)


### PR DESCRIPTION
Re-opening #1538 against the `dev` branch as requested by @MODSetter.

The video-presentation agent graph now uses a LangGraph list-based fan-in edge so the slide-generation node runs once after all upstream nodes complete, instead of once per incoming edge.

## Description

The presentation node was wired to multiple upstream nodes with separate edges, so LangGraph triggered it once per completed predecessor rather than as a single join, producing duplicate slide-generation passes. This switches those edges to a list-based fan-in edge, which creates a proper barrier so the node runs exactly once.

## Motivation and Context

Fixes #1531

## Screenshots

N/A — backend agent-graph change with no visual surface.

## API Changes

- [ ] This PR includes API changes

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Dependency/Build system
- [ ] Breaking change

## Testing Performed

- [x] Tested locally
- [x] Manual/QA verification

Added unit tests under `surfsense_backend/tests/unit/agents/` that drive the graph and assert the fan-in node is triggered exactly once.

## Checklist

- [x] Follows project coding standards and conventions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the video presentation workflow so scene code generation waits for both required preparation steps to finish before running.
  * Prevented scene code generation from running more than once when branches complete at different times.

* **Tests**
  * Added unit coverage for the new workflow behavior, including execution order and single-trigger validation.
  * Added a state-based test to confirm the join behavior remains consistent across staggered completion timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a bug in the video presentation agent graph where the slide scene generation node was being triggered multiple times instead of once. The fix changes the fan-in pattern from separate edges to a single list-based barrier edge, ensuring that `generate_slide_scene_codes` runs exactly once after both `create_slide_audio` and `assign_slide_themes` complete. Unit tests are added to verify the single-trigger behavior and execution order, including a test case that validates the barrier works correctly even when branches complete at different times.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_backend/app/agents/video_presentation/graph.py` |
| 2 | `surfsense_backend/tests/unit/agents/test_video_presentation_graph.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->