### PR TITLE
fix: dispatch periodic BookStack indexing from the scheduler task_map

### DIFF
--- a/surfsense_backend/app/tasks/celery_tasks/schedule_checker_task.py
+++ b/surfsense_backend/app/tasks/celery_tasks/schedule_checker_task.py
@@ -48,6 +48,7 @@ async def _check_and_trigger_schedules():
             # Live connectors (Linear, Slack, Jira, ClickUp, Airtable, Discord,
             # Teams, Gmail, Calendar, Luma) use real-time tools instead.
             from app.tasks.celery_tasks.connector_tasks import (
+                index_bookstack_pages_task,
                 index_confluence_pages_task,
                 index_crawled_urls_task,
                 index_elasticsearch_documents_task,
@@ -58,6 +59,7 @@ async def _check_and_trigger_schedules():
 
             task_map = {
                 SearchSourceConnectorType.NOTION_CONNECTOR: index_notion_pages_task,
+                SearchSourceConnectorType.BOOKSTACK_CONNECTOR: index_bookstack_pages_task,
                 SearchSourceConnectorType.GITHUB_CONNECTOR: index_github_repos_task,
                 SearchSourceConnectorType.CONFLUENCE_CONNECTOR: index_confluence_pages_task,
                 SearchSourceConnectorType.ELASTICSEARCH_CONNECTOR: index_elasticsearch_documents_task,

--- a/surfsense_backend/tests/unit/tasks/celery_tasks/test_schedule_checker_task.py
+++ b/surfsense_backend/tests/unit/tasks/celery_tasks/test_schedule_checker_task.py
@@ -1,0 +1,129 @@
+"""Unit tests for the periodic schedule checker's connector-to-task dispatch."""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.db import SearchSourceConnectorType
+from app.tasks.celery_tasks import schedule_checker_task
+
+pytestmark = pytest.mark.unit
+
+
+class _FakeScalars:
+    def __init__(self, connectors):
+        self._connectors = connectors
+
+    def all(self):
+        return self._connectors
+
+
+class _FakeDueConnectorsResult:
+    def __init__(self, connectors):
+        self._connectors = connectors
+
+    def scalars(self):
+        return _FakeScalars(self._connectors)
+
+
+class _FakeEmptyResult:
+    def first(self):
+        return None
+
+
+class _FakeSession:
+    """Session stub: first execute() returns due connectors, later ones no rows."""
+
+    def __init__(self, connectors):
+        self._results = [_FakeDueConnectorsResult(connectors)]
+        self.commits = 0
+
+    async def execute(self, _query):
+        if self._results:
+            return self._results.pop(0)
+        return _FakeEmptyResult()
+
+    async def commit(self):
+        self.commits += 1
+
+    async def rollback(self):
+        pass
+
+
+def _due_connector(connector_type: SearchSourceConnectorType) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=42,
+        connector_type=connector_type,
+        search_space_id=7,
+        user_id="00000000-0000-0000-0000-000000000001",
+        config={},
+        periodic_indexing_enabled=True,
+        indexing_frequency_minutes=60,
+        next_scheduled_at=datetime.now(UTC) - timedelta(minutes=5),
+    )
+
+
+async def _run_checker(monkeypatch: pytest.MonkeyPatch, connector: SimpleNamespace):
+    session = _FakeSession([connector])
+
+    @asynccontextmanager
+    async def _session_ctx():
+        yield session
+
+    monkeypatch.setattr(
+        schedule_checker_task, "get_celery_session_maker", lambda: _session_ctx
+    )
+    monkeypatch.setattr(
+        schedule_checker_task, "is_connector_indexing_locked", lambda _id: False
+    )
+    await schedule_checker_task._check_and_trigger_schedules()
+    return session
+
+
+@pytest.mark.asyncio
+async def test_due_bookstack_connector_dispatches_indexing_task(monkeypatch):
+    """A due BookStack connector must dispatch index_bookstack_pages_task.
+
+    Regression test for the connector type missing from the scheduler's
+    task_map, which made periodic BookStack syncs silently no-op with only a
+    "No task found" warning.
+    """
+    from app.tasks.celery_tasks import connector_tasks
+
+    task_mock = MagicMock()
+    monkeypatch.setattr(connector_tasks, "index_bookstack_pages_task", task_mock)
+
+    connector = _due_connector(SearchSourceConnectorType.BOOKSTACK_CONNECTOR)
+    session = await _run_checker(monkeypatch, connector)
+
+    task_mock.delay.assert_called_once_with(
+        connector.id,
+        connector.search_space_id,
+        str(connector.user_id),
+        None,
+        None,
+    )
+    # The next run must be rescheduled, otherwise the connector stays "due"
+    # and is re-examined every minute.
+    assert connector.next_scheduled_at > datetime.now(UTC)
+    assert session.commits == 1
+
+
+@pytest.mark.asyncio
+async def test_unmapped_connector_type_does_not_dispatch(monkeypatch):
+    """Connector types absent from task_map are skipped without dispatching."""
+    from app.tasks.celery_tasks import connector_tasks
+
+    task_mock = MagicMock()
+    monkeypatch.setattr(connector_tasks, "index_bookstack_pages_task", task_mock)
+
+    connector = _due_connector(SearchSourceConnectorType.TAVILY_API)
+    session = await _run_checker(monkeypatch, connector)
+
+    task_mock.delay.assert_not_called()
+    assert session.commits == 0


### PR DESCRIPTION
BookStack connectors with periodic sync enabled never actually sync — `BOOKSTACK_CONNECTOR` isn't in the scheduler's `task_map`, so the sync silently no-ops.

## Description

The BookStack connect form lets you turn on periodic sync, but `check_periodic_schedules` has no `task_map` entry for `BOOKSTACK_CONNECTOR`. A due connector falls into the warning branch:

```python
logger.warning(
    f"No task found for connector type {connector.connector_type}"
)
```

That branch also never advances `next_scheduled_at`, so the connector stays "due" forever and logs this warning every minute.

The fix is two lines: import `index_bookstack_pages_task` and add it to `task_map`. It takes `(connector_id, search_space_id, user_id, start_date, end_date)` like the other generically-dispatched tasks (Notion/Confluence/GitHub), so no special handling needed.

One note: #891 also mentions Obsidian, but I left that out on purpose — Obsidian moved to push-based indexing via the plugin routes (`index_obsidian_attachment_task`), there's no vault-pull task to schedule anymore.

## Motivation and Context

Enabling periodic sync on BookStack does nothing right now, and the only symptom is a log warning every minute. There was an earlier fix attempt (#893) but it was closed for targeting `main` and never re-raised on `dev`.

FIX #891

## Screenshots

N/A — backend scheduler change.

## API Changes

- [ ] This PR includes API changes

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Dependency/Build system
- [ ] Breaking change
- [ ] Other (specify):

## Testing Performed

- [x] Tested locally
- [ ] Manual/QA verification

Added unit tests in `tests/unit/tasks/celery_tasks/test_schedule_checker_task.py` that run `_check_and_trigger_schedules` with the DB session, Redis lock and Celery `.delay` mocked:

- a due BookStack connector dispatches `index_bookstack_pages_task` and gets `next_scheduled_at` advanced — this fails on `dev` (reproduces the exact "No task found" warning) and passes with the fix
- an unmapped connector type still dispatches nothing

Run with `cd surfsense_backend && uv run pytest tests/unit/tasks/celery_tasks/test_schedule_checker_task.py`. Full unit suite passes (2380 tests), pre-commit hooks clean.

I didn't test against a live BookStack instance, but the dispatched task is the same one the manual "index now" route already uses.

## Checklist

- [x] Follows project coding standards and conventions
- [ ] Documentation updated as needed
- [ ] Dependencies updated as needed
- [x] No lint/build errors or new warnings
- [x] All relevant tests are passing
