### PR TITLE
feat(auth-utils): add '/blog' to public route prefixes for fixed navi…

### DIFF
--- a/surfsense_web/lib/auth-utils.ts
+++ b/surfsense_web/lib/auth-utils.ts
@@ -33,6 +33,7 @@ const PUBLIC_ROUTE_PREFIXES = [
 	"/terms",
 	"/changelog",
 	"/announcements",
+	"/blog",
 	// Connector marketing pages (see lib/connectors-marketing)
 	"/connectors",
 	"/mcp-server",


### PR DESCRIPTION
…gation

<!--- Summarize your pull request in a few sentences -->

## Description
<!--- Clearly describe what has changed in this pull request -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If this PR relates to an open issue, please link to the issue here: FIX #123 -->
FIX #


## Screenshots
<!-- If applicable, add screenshots or images to demonstrate the changes visually -->

## API Changes
<!-- Document any API changes if applicable -->
- [ ] This PR includes API changes

## Change Type
<!--- Indicate what kind(s) of changes this PR includes: -->
- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Dependency/Build system
- [ ] Breaking change
- [ ] Other (specify):

## Testing Performed
<!--- Briefly describe how you have tested these changes and what verification was performed -->
- [ ] Tested locally
- [ ] Manual/QA verification

## Checklist
<!--- Please confirm the following by marking with an 'x' as appropriate -->
- [ ] Follows project coding standards and conventions
- [ ] Documentation updated as needed
- [ ] Dependencies updated as needed
- [ ] No lint/build errors or new warnings
- [ ] All relevant tests are passing

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds `/blog` to the list of public route prefixes in the authentication utilities, allowing unauthenticated users to access blog pages without requiring login. This is a simple configuration change that aligns the blog route with other public marketing and informational pages like `/terms`, `/changelog`, and `/announcements`.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/lib/auth-utils.ts` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Blog pages are now treated as public routes, so unauthorized responses on `/blog` no longer send visitors to the login page.
  * Legacy stored sign-in tokens are still cleared when needed, helping keep access behavior consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->