### PR TITLE
[Fix] MCP: install curl for container healthcheck

### DIFF
--- a/surfsense_mcp/Dockerfile
+++ b/surfsense_mcp/Dockerfile
@@ -7,6 +7,10 @@ FROM python:3.12-slim AS deps
 
 WORKDIR /app
 
+# curl is used by the container healthcheck probe against /health.
+RUN apt-get update && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY pyproject.toml uv.lock ./
 RUN pip install --no-cache-dir uv && \
     uv export --frozen --no-dev --no-emit-project --no-hashes \


### PR DESCRIPTION
The MCP image is `python:3.12-slim`, which ships without `curl`/`wget`, so Coolify's default container healthcheck against `/health` fails with `curl: not found`. Install `curl` (matching the backend image) so the probe works out of the box.

**Tested:** image builds; inside the container `curl http://localhost:8080/health` → `200`.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a container healthcheck issue in the MCP service by installing `curl` in the Docker image. The base `python:3.12-slim` image doesn't include `curl` or `wget`, which causes Coolify's default healthcheck against the `/health` endpoint to fail. The fix adds `curl` to the image using `apt-get`, following best practices by cleaning up the apt cache to keep the image size minimal.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_mcp/Dockerfile` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container health checks so the service can be reliably probed for a healthy state.
  * Reduced image size slightly by cleaning up package lists after installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->