### PR TITLE
Add raw OpenAI-compatible provider without /v1 normalization

### DIFF
--- a/surfsense_backend/app/services/provider_registry.py
+++ b/surfsense_backend/app/services/provider_registry.py
@@ -87,6 +87,15 @@ REGISTRY: dict[str, ProviderSpec] = {
         "bearer",
         "OpenAI-compatible provider",
     ),
+    "openai_compatible_raw": ProviderSpec(
+        Transport.NATIVE,
+        "openai",
+        "none",
+        None,
+        True,
+        "bearer",
+        "OpenAI-compatible raw endpoint",
+    ),
     "lm_studio": ProviderSpec(
         Transport.OPENAI_COMPATIBLE,
         "openai",

--- a/surfsense_backend/tests/unit/services/test_model_connections.py
+++ b/surfsense_backend/tests/unit/services/test_model_connections.py
@@ -64,6 +64,22 @@ def test_openai_compatible_resolver_uses_explicit_api_base() -> None:
     assert ensure_v1("http://example.com/v1") == "http://example.com/v1"
 
 
+def test_openai_compatible_raw_resolver_does_not_append_v1() -> None:
+    model, kwargs = to_litellm(
+        {
+            "provider": "openai_compatible_raw",
+            "base_url": "https://ark.cn-beijing.volces.com/api/v3",
+            "api_key": "ark-key",
+            "extra": {},
+        },
+        "ep-20260101000000-test",
+    )
+
+    assert model == "openai/ep-20260101000000-test"
+    assert kwargs["api_base"] == "https://ark.cn-beijing.volces.com/api/v3"
+    assert kwargs["api_key"] == "ark-key"
+
+
 def test_ollama_resolver_uses_native_api_base() -> None:
     model, kwargs = to_litellm(
         {

--- a/surfsense_web/components/settings/model-connections/default-connect-form.tsx
+++ b/surfsense_web/components/settings/model-connections/default-connect-form.tsx
@@ -9,7 +9,10 @@ function baseUrlHint(provider: string) {
 		return "For local servers, use host.docker.internal instead of localhost.";
 	}
 	if (provider === "openai_compatible") {
-		return "Enter the full endpoint URL.";
+		return "Enter the full endpoint URL. This provider expects a /v1-compatible endpoint.";
+	}
+	if (provider === "openai_compatible_raw") {
+		return "Enter the exact chat-completions API base URL. SurfSense will not append /v1.";
 	}
 	if (provider === "openai" || provider === "anthropic" || provider === "openrouter") {
 		return "Override only if you route through a proxy or gateway.";

--- a/surfsense_web/components/settings/model-connections/provider-metadata.tsx
+++ b/surfsense_web/components/settings/model-connections/provider-metadata.tsx
@@ -10,6 +10,7 @@ export const PROVIDER_ORDER = [
 	"ollama_chat",
 	"lm_studio",
 	"openai_compatible",
+	"openai_compatible_raw",
 ];
 
 export const PROVIDER_DISPLAY: Record<
@@ -35,6 +36,11 @@ export const PROVIDER_DISPLAY: Record<
 	openai_compatible: {
 		name: "OpenAI-Compatible",
 		subtitle: "OpenAI-compatible endpoint",
+		iconKey: "custom",
+	},
+	openai_compatible_raw: {
+		name: "OpenAI-Compatible Raw",
+		subtitle: "Use the exact base URL, no /v1 is appended",
 		iconKey: "custom",
 	},
 	openrouter: {


### PR DESCRIPTION
<!--- Summarize your pull request in a few sentences -->

## Description
Adds a new `OpenAI-Compatible Raw` provider for model connections.

Unlike the existing `OpenAI-Compatible` provider, the raw provider uses the configured base URL exactly as entered and does not automatically append `/v1`. The UI copy also explains this difference so users can choose the right provider type.

## Motivation and Context
Some OpenAI-compatible providers use OpenAI-style request and response formats, but expose their APIs under non-`/v1` paths. This is common among China-based LLM providers, where endpoints may use paths such as `/api/v3`.

For example:  https://xxx.com/api/v3


## Screenshots
<!-- If applicable, add screenshots or images to demonstrate the changes visually -->

## API Changes
<!-- Document any API changes if applicable -->
- [ ] This PR includes API changes

## Change Type
<!--- Indicate what kind(s) of changes this PR includes: -->
- [ ] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Dependency/Build system
- [ ] Breaking change
- [ ] Other (specify):

## Testing Performed
<!--- Briefly describe how you have tested these changes and what verification was performed -->
- [x] Tested locally
- [x] Manual/QA verification
Manually verified that `OpenAI-Compatible Raw` preserves a non-`/v1` base URL such as `/api/v3` instead of appending `/v1`.
Also ran:  python -m pytest tests/unit/services/test_model_connections.py

## Checklist
<!--- Please confirm the following by marking with an 'x' as appropriate -->
- [x] Follows project coding standards and conventions
- [ ] Documentation updated as needed
- [ ] Dependencies updated as needed
- [ ] No lint/build errors or new warnings
- [x] All relevant tests are passing

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds a new `OpenAI-Compatible Raw` provider type that preserves the user's configured base URL exactly as entered, without automatically appending `/v1` to the endpoint path. This allows connection to OpenAI-compatible APIs that use non-standard paths like `/api/v3`, which is common among some providers (particularly China-based LLM providers). The change includes backend provider registration, frontend UI updates with explanatory text to help users choose between the standard and raw variants, and test coverage for the new behavior.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_backend/app/services/provider_registry.py` |
| 2 | `surfsense_backend/tests/unit/services/test_model_connections.py` |
| 3 | `surfsense_web/components/settings/model-connections/provider-metadata.tsx` |
| 4 | `surfsense_web/components/settings/model-connections/default-connect-form.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->