### PR TITLE
Fix: add missing default setup env variables

### DIFF
--- a/surfsense_web/.env.example
+++ b/surfsense_web/.env.example
@@ -5,7 +5,7 @@
 # Optional packaged-client override. Leave unset in Docker so browser requests
 # use same-origin relative URLs behind Caddy. Set it for packaged clients
 # (e.g. Electron) or local dev that talks to a separate backend origin.
-# NEXT_PUBLIC_FASTAPI_BACKEND_URL=http://localhost:8000
+NEXT_PUBLIC_FASTAPI_BACKEND_URL=http://localhost:8000
 
 # Server-only. Internal backend URL used by Next.js server code (RSC / route
 # handlers). Cannot be a relative URL.
@@ -40,7 +40,7 @@ NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
 # Zero cache (real-time sync). Leave unset in Docker to use the same-origin
 # "/zero" endpoint behind Caddy. Set it for local dev or packaged clients.
 # ─────────────────────────────────────────────────────────────────────────────
-# NEXT_PUBLIC_ZERO_CACHE_URL=http://localhost:4848
+NEXT_PUBLIC_ZERO_CACHE_URL=http://localhost:4848
 # Server-only shared secret that authorizes zero-cache when it calls
 # /api/zero/query. Leave unset during the compatibility rollout, then set it
 # once every zero-cache instance sends X-Api-Key.


### PR DESCRIPTION
## Summary

Follow-up to #1595  (related). Missed setting these two frontend env vars as active defaults when documenting the `docker-compose.dev.yml` flow. Without Caddy in dev, the browser falls back to same-origin relative URLs and calls `localhost:3000` instead of the backend/zero-cache, 404ing.

## Change

- `surfsense_web/.env.example`: uncomment `NEXT_PUBLIC_FASTAPI_BACKEND_URL` and `NEXT_PUBLIC_ZERO_CACHE_URL` so they're active defaults instead of commented-out examples.

## Testing

Reproduced the 404s on `/users/me` and `/zero/context` in a real browser against `docker-compose.dev.yml` with the vars commented out (as shipped). Confirmed both resolve correctly after uncommenting and rebuilding the frontend container.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a configuration issue by uncommenting two environment variables (`NEXT_PUBLIC_FASTAPI_BACKEND_URL` and `NEXT_PUBLIC_ZERO_CACHE_URL`) in the frontend environment example file. Without these variables set in the development Docker Compose setup (which lacks Caddy), the browser defaults to same-origin relative URLs that incorrectly target `localhost:3000` instead of the backend services, resulting in 404 errors for `/users/me` and `/zero/context` endpoints.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/.env.example` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->