### PR TITLE
fix: add same origin check on csrf middleware

### DIFF
--- a/surfsense_backend/app/auth/csrf.py
+++ b/surfsense_backend/app/auth/csrf.py
@@ -32,6 +32,15 @@ def _allowed_origins() -> set[str]:
     return origins
 
 
+# Lets self-hosted deployments work from any address (LAN IP, custom domain)
+# without pre-configuring the static allowlist on .env.
+def _is_same_origin(origin: str | None, host: str | None) -> bool:
+    if not origin or not host:
+        return False
+    parsed_origin = urlparse(origin)
+    return parsed_origin.netloc == host
+
+
 class CsrfOriginMiddleware(BaseHTTPMiddleware):
     async def dispatch(
         self,
@@ -52,6 +61,11 @@ class CsrfOriginMiddleware(BaseHTTPMiddleware):
         origin = request.headers.get("Origin") or _origin_from_url(
             request.headers.get("Referer")
         )
+        host = request.headers.get("Host")
+
+        if _is_same_origin(origin, host):
+            return await call_next(request)
+
         if origin not in _allowed_origins():
             return JSONResponse(
                 {"detail": "CSRF origin check failed"},


### PR DESCRIPTION
## Summary

Fixes CSRF false-positives for self-hosted deployments accessed via an address that isn't in the static CSRF allowlist (e.g. a LAN IP instead of `localhost`, or a different device on the network). This happens whenever `SURFSENSE_PUBLIC_URL`/`CSRF_ALLOWED_ORIGINS` doesn't match the address actually used to reach the instance which the docs apparently never explained, so most self-hosters never configure it.

Closes #1598 
Closes #1556 

## Root cause

`CsrfOriginMiddleware` only accepted origins from a static, pre-configured allowlist. Any legitimate request from an address not in that list (LAN IP, custom domain, etc.) was rejected with a confusing `"CSRF origin check failed"`, even though the request was genuinely same-site written as the literal IP instead of "localhost".

## Fix

Added a same-origin check: if the request's `Origin` matches its own `Host`, it's inherently same-site and gets accepted. No static configuration needed for the common self-hosted case. This is the "Verifying Origin with Standard Headers" technique from the [OWASP CSRF Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html). The static allowlist stays in place as a fallback for cases where Origin and Host legitimately differ (e.g. a reverse proxy that changes the host).

## Testing

Reproduced against `docker-compose.yml`, accessing via LAN IP instead of `localhost`.

**Before (LAN IP access, unpatched):**
`POST http://192.168.1.106:3929/api/v1/threads`
{"detail":"CSRF origin check failed"}



**After (LAN IP access, same-origin, patched):**
`POST http://192.168.1.106:3929/api/v1/threads`
200 OK



**After — genuinely unauthorized origin still blocked (patched):**
`curl -X POST http://localhost:3929/api/v1/threads -H "Origin: http://hacker_site/" `
{"detail":"CSRF origin check failed"}
403

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes CSRF false-positives for self-hosted deployments by adding a same-origin check to the CSRF middleware. Previously, the middleware only accepted origins from a static pre-configured allowlist, causing legitimate requests from LAN IPs or custom domains to be rejected. The fix implements the OWASP-recommended "Verifying Origin with Standard Headers" technique, automatically accepting requests where the `Origin` header matches the `Host` header, eliminating the need for explicit configuration in common self-hosted scenarios while maintaining the existing allowlist as a fallback for edge cases like reverse proxies.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_backend/app/auth/csrf.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->