### PR TITLE
fix: avoid blocking audio writes

### DIFF
--- a/surfsense_backend/app/agents/video_presentation/nodes.py
+++ b/surfsense_backend/app/agents/video_presentation/nodes.py
@@ -17,6 +17,7 @@ from app.config import config as app_config
 from app.services.kokoro_tts_service import get_kokoro_tts_service
 from app.services.llm_service import get_agent_llm
 from app.utils.content_utils import extract_text_content, strip_markdown_fences
+from app.utils.file_io import write_bytes
 
 from .configuration import Configuration
 from .prompts import (
@@ -137,8 +138,7 @@ async def create_slide_audio(state: State, config: RunnableConfig) -> dict[str, 
                 kwargs["api_base"] = app_config.TTS_SERVICE_API_BASE
 
             response = await aspeech(**kwargs)
-            with open(chunk_path, "wb") as f:
-                f.write(response.content)
+            await write_bytes(chunk_path, response.content)
 
         return chunk_path
 

--- a/surfsense_backend/app/utils/file_io.py
+++ b/surfsense_backend/app/utils/file_io.py
@@ -1,0 +1,7 @@
+import asyncio
+from pathlib import Path
+
+
+async def write_bytes(path: str, content: bytes) -> None:
+    """Write bytes without blocking the event loop."""
+    await asyncio.to_thread(Path(path).write_bytes, content)

--- a/surfsense_backend/tests/unit/agents/video_presentation/test_file_io.py
+++ b/surfsense_backend/tests/unit/agents/video_presentation/test_file_io.py
@@ -1,0 +1,29 @@
+import asyncio
+import threading
+
+import pytest
+
+from app.utils.file_io import write_bytes
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.asyncio
+async def test_write_bytes_does_not_block_event_loop(monkeypatch, tmp_path):
+    write_started = threading.Event()
+    release_write = threading.Event()
+
+    def blocking_write(_path, _content):
+        write_started.set()
+        release_write.wait(timeout=1)
+        return 5
+
+    monkeypatch.setattr("pathlib.Path.write_bytes", blocking_write)
+
+    task = asyncio.create_task(write_bytes(str(tmp_path / "audio.mp3"), b"audio"))
+    while not write_started.is_set():
+        await asyncio.sleep(0)
+
+    assert not task.done()
+    release_write.set()
+    await task


### PR DESCRIPTION
## Description
Moves TTS response writes off the asyncio event loop so concurrent presentation requests are not stalled by synchronous file I/O.

## Motivation and Context
Fixes #1603.

## Screenshots
N/A

## API Changes
- [ ] This PR includes API changes

## Change Type
- [x] Bug fix
- [ ] New feature
- [x] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Dependency/Build system
- [ ] Breaking change
- [ ] Other (specify):

## Testing Performed
- [x] Tested locally
- [x] Manual/QA verification

Focused async regression test, Ruff check/format, and Python compilation pass.

## Checklist
- [x] Follows project coding standards and conventions
- [x] Documentation updated as needed
- [x] Dependencies updated as needed
- [x] No lint/build errors or new warnings
- [x] All relevant tests are passing

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a performance issue where synchronous file I/O operations for TTS audio responses were blocking the asyncio event loop, preventing concurrent presentation requests from being processed. The fix introduces a new utility function `write_bytes` that uses `asyncio.to_thread` to offload file writes to a thread pool, and replaces the blocking `open().write()` call in the TTS chunk generation with this non-blocking alternative.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_backend/app/utils/file_io.py` |
| 2 | `surfsense_backend/tests/unit/agents/video_presentation/test_file_io.py` |
| 3 | `surfsense_backend/app/agents/video_presentation/nodes.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->