### PR TITLE
fix: improve error handling on model setup

### DIFF
--- a/surfsense_backend/app/routes/model_connections_routes.py
+++ b/surfsense_backend/app/routes/model_connections_routes.py
@@ -460,7 +460,7 @@ async def preview_connection_models(
     try:
         discovered = await discover_models(draft)
     except ModelDiscoveryError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        raise HTTPException(status_code=400, detail=f"{exc}. Try typing the model id manually.") from exc
     return [_preview_model_read(item) for item in discovered]
 
 

--- a/surfsense_backend/app/services/model_connection_service.py
+++ b/surfsense_backend/app/services/model_connection_service.py
@@ -93,6 +93,16 @@ def _model_test_error(conn: Connection, model_id: str, exc: Exception) -> Verify
         raw,
     )
 
+    if status_code == 400:
+        if "api key" in normalized:
+            return VerifyResult(
+                "AUTH_FAILED",
+                False,
+                f"Authentication failed. Check your {provider_name} credentials and try again.",
+            )
+        
+
+
     if status_code in (401, 403) or "authentication" in exc_name or "401" in normalized:
         return VerifyResult(
             "AUTH_FAILED",
@@ -114,7 +124,7 @@ def _model_test_error(conn: Connection, model_id: str, exc: Exception) -> Verify
         return VerifyResult(
             "RATE_LIMITED",
             False,
-            f"{provider_name} rate limited the model test. Try again later.",
+            f"{provider_name} rate limited the model test. Try again later or check your provider for possible insufficient quotas or unavailable model.",
         )
 
     if "timeout" in exc_name or "timed out" in normalized:


### PR DESCRIPTION
## Summary
Improves the error feedback shown to users when setting up a model
connection — both when testing a model and when discovering available
models. Maps common provider failures (bad API key, rate limit) to
clearer, more actionable messages instead of surfacing raw upstream
errors.

## Fix
**The problem:** When a model test or discovery failed, the UI often
surfaced the raw upstream provider error (e.g. a bare 400), which is
hard to interpret and doesn't guide the user toward a fix.

**What changed:**
- `model_connection_service.py`
  - `_model_test_error` now maps a `400` containing "api key" to a
    clear `AUTH_FAILED` result ("Authentication failed. Check your
    <provider> credentials and try again.") instead of a generic 400.
  - The rate-limit message now also hints at insufficient quota or an
    unavailable model, not just a transient throttle.

- `model_connections_routes.py`
  - `preview_connection_models` returns a friendlier hint
    ("Try typing the model id manually.") when discovery fails, since
    the next best action is manual entry.

## Testing
1. Set up a model connection with an **invalid API key** → verify the
   error reads as an authentication failure, not a generic 400.
2. Using refresh button on model setup for automatic discover on a non-cataloged provider
    returns 400 with explicit direction
4. Trigger a **rate limit** (or simulate a 429) → verify the message
   mentions quota / unavailable model.


<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR improves error handling when users set up model connections by mapping common provider failures to clearer, more actionable error messages. When authentication fails with a `400` status code mentioning "api key", the system now returns a specific authentication error instead of a generic message. Rate limit errors now include additional context about possible quota issues or unavailable models. The model discovery endpoint also provides a helpful hint to manually enter the model ID when automatic discovery fails.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_backend/app/services/model_connection_service.py` |
| 2 | `surfsense_backend/app/routes/model_connections_routes.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection error messages when model discovery fails, including guidance to enter the model ID manually.
  * More accurately identifies certain API key authentication failures and provides provider-specific guidance.
  * Updated rate-limit messages with clearer troubleshooting information about quotas and model availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->