### PR TITLE
feat: add new autofill environment section on automatic issues

### DIFF
--- a/surfsense_web/app/global-error.tsx
+++ b/surfsense_web/app/global-error.tsx
@@ -4,6 +4,7 @@ import "./globals.css";
 import posthog from "posthog-js";
 import { useEffect, useMemo } from "react";
 import { Button } from "@/components/ui/button";
+import { detectEnvironment } from "@/lib/env-config";
 
 const ISSUES_URL = "https://github.com/MODSetter/SurfSense/issues/new";
 
@@ -19,6 +20,7 @@ function buildBasicIssueUrl(error: Error & { digest?: string }) {
 		"",
 		`- **Error:** ${error.message}`,
 		...(error.digest ? [`- **Digest:** \`${error.digest}\``] : []),
+		`- **Environment:** ${detectEnvironment()}`,
 		`- **Timestamp:** ${new Date().toISOString()}`,
 		`- **Page:** \`${typeof window !== "undefined" ? window.location.pathname : "unknown"}\``,
 		`- **User Agent:** \`${typeof navigator !== "undefined" ? navigator.userAgent : "unknown"}\``,

--- a/surfsense_web/lib/env-config.ts
+++ b/surfsense_web/lib/env-config.ts
@@ -67,6 +67,21 @@ export const BUILD_TIME_ETL_SERVICE = process.env.NEXT_PUBLIC_ETL_SERVICE || "DO
 // DEPLOYMENT_MODE through the runtime config provider first, then falls back to this baked value.
 export const BUILD_TIME_DEPLOYMENT_MODE = process.env.NEXT_PUBLIC_DEPLOYMENT_MODE || "self-hosted";
 
+/**
+ * Detect the environment for diagnostics (e.g. GitHub issue auto-fill).
+ * Inferred from the hostname so it needs no configuration from the operator.
+ *
+ * - "SurfSense Cloud": served from the official SurfSense domain (root + subdomains)
+ * - "self-hosted": everything else (covers self-hosted and community cloud deploys)
+ */
+export function detectEnvironment(): "SurfSense Cloud" | "self-hosted" {
+	const hostname = typeof window !== "undefined" ? window.location.hostname : "";
+	if (hostname === "surfsense.com" || hostname.endsWith(".surfsense.com")) {
+		return "SurfSense Cloud";
+	}
+	return "self-hosted";
+}
+
 // App version - defaults to package.json version
 // Can be overridden at build time with NEXT_PUBLIC_APP_VERSION for full git tag version
 export const APP_VERSION = process.env.NEXT_PUBLIC_APP_VERSION || packageJson.version;

--- a/surfsense_web/lib/error-toast.ts
+++ b/surfsense_web/lib/error-toast.ts
@@ -1,5 +1,6 @@
 import { toast } from "sonner";
 import { AbortedError, AppError, AuthenticationError, SURFSENSE_ISSUES_URL } from "./error";
+import { detectEnvironment } from "./env-config";
 
 /**
  * Build a GitHub issue URL pre-filled with diagnostic context.
@@ -7,6 +8,8 @@ import { AbortedError, AppError, AuthenticationError, SURFSENSE_ISSUES_URL } fro
  */
 export function buildIssueUrl(error: unknown): string {
 	const params = new URLSearchParams();
+
+	const environment = detectEnvironment();
 
 	const lines: string[] = ["## Bug Report", "", "**Describe what happened:**", "", ""];
 
@@ -16,9 +19,11 @@ export function buildIssueUrl(error: unknown): string {
 		if (error.requestId) lines.push(`- **Request ID:** \`${error.requestId}\``);
 		if (error.status) lines.push(`- **HTTP status:** ${error.status}`);
 		lines.push(`- **Message:** ${error.message}`);
+		lines.push(`- **Environment:** ${environment}`);
 	} else if (error instanceof Error) {
 		lines.push("## Diagnostics (auto-filled)", "");
 		lines.push(`- **Error:** ${error.message}`);
+		lines.push(`- **Environment:** ${environment}`);
 	}
 
 	lines.push(`- **Timestamp:** ${new Date().toISOString()}`);


### PR DESCRIPTION

## Summary
Auto-fills an **Environment** line in the GitHub issue body generated by
the "Report Issue", so maintainers can tell at a glance whether 
a report came from SurfSense server or a self-hosted install.

## What it does
- Adds `detectEnvironment()` to `lib/env-config.ts`, inferring the
  deployment from `window.location.hostname`:
  - `surfsense.com` and `*.surfsense.com` → `SurfSense Cloud`
  - everything else → `self-hosted`
- Both issue builders now include an `- **Environment:** …` line:
  - `lib/error-toast.ts` (`buildIssueUrl` — the in-app error toast)
  - `app/global-error.tsx` (`buildBasicIssueUrl` — the global error boundary)

Inferred from the hostname, so it needs **no configuration from the
operator** and adds no build/runtime env var.

## Testing
1. Run a self-hosted stack, trigger an error, click **Report Issue** →
   the opened GitHub form shows `- **Environment:** self-hosted`.
2. On `surfsense.com` (or a `*.surfsense.com` subdomain), the same flow
   shows `- **Environment:** SurfSense Cloud`.
3. Trigger the full-page error boundary to confirm the global error path
   also includes the field.

## Note
There are many issues reported by the "Report issue" button that the user don't 
provide details, so probably this will help someway on providing few more info of user's env.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR automatically adds environment information to GitHub issue reports generated by the application's error reporting features. It introduces a `detectEnvironment()` function that infers whether the app is running on **SurfSense Cloud** (official domain) or **self-hosted** based on the hostname, and includes this information in both the error toast issue builder and the global error boundary issue builder. This helps maintainers quickly identify the deployment context when users report issues without needing any manual configuration or build-time environment variables.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/lib/env-config.ts` |
| 2 | `surfsense_web/lib/error-toast.ts` |
| 3 | `surfsense_web/app/global-error.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->