### PR TITLE
fix(model-connections): use OpenAI-compatible base URL verbatim and deprecate raw provider

### DIFF
--- a/surfsense_backend/app/automations/services/automation.py
+++ b/surfsense_backend/app/automations/services/automation.py
@@ -171,7 +171,7 @@ class AutomationService:
                 self.auth,
                 "automation_status_changed",
                 {
-                    "automation_id": automation.id,
+                    "automation_id": automation_id,
                     "workspace_id": automation.workspace_id,
                     "next_status": str(data["status"]),
                 },
@@ -182,7 +182,7 @@ class AutomationService:
                 self.auth,
                 "automation_updated",
                 {
-                    "automation_id": automation.id,
+                    "automation_id": automation_id,
                     "workspace_id": automation.workspace_id,
                     "has_definition_change": "definition" in data,
                 },

--- a/surfsense_backend/app/routes/model_connections_routes.py
+++ b/surfsense_backend/app/routes/model_connections_routes.py
@@ -260,6 +260,7 @@ async def _default_unset_roles(
 async def list_model_providers(auth: AuthContext = Depends(require_session_context)):
     del auth
     local_only = {"ollama_chat", "lm_studio"}
+    hidden = {"openai_compatible_raw"}  # deprecated; superseded by openai_compatible
     return [
         ModelProviderRead(
             provider=provider,
@@ -271,6 +272,7 @@ async def list_model_providers(auth: AuthContext = Depends(require_session_conte
             local_only=provider in local_only,
         )
         for provider, spec in sorted(REGISTRY.items())
+        if provider not in hidden
     ]
 
 

--- a/surfsense_backend/app/routes/workspaces_routes.py
+++ b/surfsense_backend/app/routes/workspaces_routes.py
@@ -236,7 +236,7 @@ async def read_workspaces(
 
 
 @router.get("/workspaces/limits")
-async def read_workspace_limits(_auth: AuthContext = Depends(allow_any_principal)):
+async def read_workspace_limits(_auth: AuthContext = Depends(require_session_context)):
     return {"max_workspaces_per_user": config.MAX_WORKSPACES_PER_USER}
 
 

--- a/surfsense_backend/app/services/model_connection_service.py
+++ b/surfsense_backend/app/services/model_connection_service.py
@@ -141,6 +141,10 @@ def _model_test_error(conn: Connection, model_id: str, exc: Exception) -> Verify
     )
 
 
+def _openai_compatible_404_hint(url: str) -> str:
+    return f"Got 404 from {url}. Check your API Base URL."
+
+
 async def verify_connection(conn: Connection) -> VerifyResult:
     spec = spec_for(conn.provider)
     base_url = _base_url_or_default(conn)
@@ -172,9 +176,9 @@ async def verify_connection(conn: Connection) -> VerifyResult:
             if spec.transport == Transport.OLLAMA and url.endswith("/v1/models"):
                 message = "Ollama native API should not use /v1."
             elif spec.transport == Transport.OPENAI_COMPATIBLE:
-                message = "OpenAI-compatible servers should expose /v1/models."
+                message = _openai_compatible_404_hint(url)
             else:
-                message = "Endpoint returned 404."
+                message = f"Endpoint returned 404 for {url}."
             return VerifyResult("NOT_FOUND", False, message)
         response.raise_for_status()
         return VerifyResult("OK", True, "Connection verified.")
@@ -194,9 +198,10 @@ def _discovery_error_message(conn: Connection, exc: httpx.HTTPError) -> str:
             return "Authentication failed while discovering models."
         if status_code == 404:
             spec = spec_for(conn.provider)
+            attempted = str(exc.request.url)
             if spec.transport == Transport.OPENAI_COMPATIBLE:
-                return "OpenAI-compatible servers should expose /v1/models."
-            return "Model discovery endpoint returned 404."
+                return _openai_compatible_404_hint(attempted)
+            return f"Model discovery endpoint returned 404 for {attempted}."
         return f"Model discovery failed with HTTP {status_code}."
     if isinstance(exc, httpx.TimeoutException):
         return f"Model discovery timed out: {exc}"

--- a/surfsense_backend/app/services/model_connection_service.py
+++ b/surfsense_backend/app/services/model_connection_service.py
@@ -12,7 +12,7 @@ import httpx
 import litellm
 
 from app.db import Connection, Model, ModelSource
-from app.services.model_resolver import ensure_v1, to_litellm
+from app.services.model_resolver import to_litellm
 from app.services.openrouter_model_normalizer import normalize_openrouter_models
 from app.services.provider_registry import Transport, provider_label, spec_for
 from app.services.requesty_model_normalizer import normalize_requesty_models
@@ -149,10 +149,8 @@ async def verify_connection(conn: Connection) -> VerifyResult:
 
     if spec.transport == Transport.OLLAMA and base_url:
         url = f"{base_url.rstrip('/')}/api/version"
-    elif spec.discovery == "openai_models" and base_url:
+    elif spec.discovery in {"openai_models", "openrouter", "requesty"} and base_url:
         url = f"{base_url.rstrip('/')}/models"  # verbatim; user owns the path
-    elif spec.discovery in {"openrouter", "requesty"} and base_url:
-        url = f"{ensure_v1(base_url)}/models"
     elif spec.discovery == "anthropic_models" and base_url:
         url = f"{base_url.rstrip('/')}/models"
     else:
@@ -355,7 +353,7 @@ async def _openrouter_models(conn: Connection) -> list[dict[str, Any]]:
     base_url = _base_url_or_default(conn) or "https://openrouter.ai/api/v1"
     async with httpx.AsyncClient(timeout=DISCOVERY_TIMEOUT_SECONDS) as client:
         response = await client.get(
-            f"{ensure_v1(base_url)}/models", headers=_auth_headers(conn)
+            f"{base_url.rstrip('/')}/models", headers=_auth_headers(conn)
         )
     response.raise_for_status()
     return normalize_openrouter_models(response.json().get("data", []))
@@ -365,7 +363,7 @@ async def _requesty_models(conn: Connection) -> list[dict[str, Any]]:
     base_url = _base_url_or_default(conn) or "https://router.requesty.ai/v1"
     async with httpx.AsyncClient(timeout=DISCOVERY_TIMEOUT_SECONDS) as client:
         response = await client.get(
-            f"{ensure_v1(base_url)}/models", headers=_auth_headers(conn)
+            f"{base_url.rstrip('/')}/models", headers=_auth_headers(conn)
         )
     response.raise_for_status()
     return normalize_requesty_models(response.json().get("data", []))

--- a/surfsense_backend/app/services/model_connection_service.py
+++ b/surfsense_backend/app/services/model_connection_service.py
@@ -149,7 +149,9 @@ async def verify_connection(conn: Connection) -> VerifyResult:
 
     if spec.transport == Transport.OLLAMA and base_url:
         url = f"{base_url.rstrip('/')}/api/version"
-    elif spec.discovery in {"openai_models", "openrouter", "requesty"} and base_url:
+    elif spec.discovery == "openai_models" and base_url:
+        url = f"{base_url.rstrip('/')}/models"  # verbatim; user owns the path
+    elif spec.discovery in {"openrouter", "requesty"} and base_url:
         url = f"{ensure_v1(base_url)}/models"
     elif spec.discovery == "anthropic_models" and base_url:
         url = f"{base_url.rstrip('/')}/models"
@@ -265,7 +267,7 @@ async def _discover_openai_shaped_models(
     if not resolved_base_url:
         return []
 
-    url = f"{ensure_v1(resolved_base_url)}/models"
+    url = f"{resolved_base_url.rstrip('/')}/models"  # verbatim; user owns the path
     async with httpx.AsyncClient(timeout=DISCOVERY_TIMEOUT_SECONDS) as client:
         response = await client.get(url, headers=_auth_headers(conn))
     response.raise_for_status()

--- a/surfsense_backend/app/services/model_resolver.py
+++ b/surfsense_backend/app/services/model_resolver.py
@@ -15,15 +15,6 @@ if TYPE_CHECKING:
 from app.services.provider_registry import spec_for
 
 
-def ensure_v1(base_url: str | None) -> str | None:
-    if not base_url:
-        return None
-    stripped = base_url.rstrip("/")
-    if stripped.endswith("/v1"):
-        return stripped
-    return f"{stripped}/v1"
-
-
 def strip_version_suffix(base_url: str | None) -> str | None:
     """Drop a trailing ``/v1`` segment from a base URL.
 
@@ -109,7 +100,6 @@ def native_connection_from_config(config: Mapping[str, Any]) -> dict[str, Any]:
 
 
 __all__ = [
-    "ensure_v1",
     "native_connection_from_config",
     "strip_version_suffix",
     "to_litellm",

--- a/surfsense_backend/app/services/model_resolver.py
+++ b/surfsense_backend/app/services/model_resolver.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from app.db import Connection
 
-from app.services.provider_registry import Transport, spec_for
+from app.services.provider_registry import spec_for
 
 
 def ensure_v1(base_url: str | None) -> str | None:
@@ -67,13 +67,12 @@ def to_litellm(
     prefix = spec.litellm_prefix or str(provider)
     model_string = f"{prefix}/{model_id}" if prefix else model_id
     if base_url:
-        if spec.transport == Transport.OPENAI_COMPATIBLE:
-            api_base = ensure_v1(base_url)
-        elif provider == "anthropic":
+        if provider == "anthropic":
             # LiteLLM's Anthropic handler appends ``/v1/messages`` to api_base,
             # so a base URL ending in ``/v1`` must be reduced to the API root.
             api_base = strip_version_suffix(base_url)
         else:
+            # Verbatim: the user owns the path (/v1 or custom); LiteLLM appends the route.
             api_base = base_url.rstrip("/")
         kwargs["api_base"] = api_base
 

--- a/surfsense_backend/app/services/provider_registry.py
+++ b/surfsense_backend/app/services/provider_registry.py
@@ -97,6 +97,9 @@ REGISTRY: dict[str, ProviderSpec] = {
         "bearer",
         "OpenAI-compatible provider",
     ),
+    # DEPRECATED: hidden from the catalog; superseded by "openai_compatible"
+    # (now verbatim). Kept so existing connections still resolve. Remove once none
+    # remain (provider='openai_compatible_raw').
     "openai_compatible_raw": ProviderSpec(
         Transport.NATIVE,
         "openai",

--- a/surfsense_backend/tests/unit/services/test_model_connections.py
+++ b/surfsense_backend/tests/unit/services/test_model_connections.py
@@ -64,6 +64,36 @@ def test_openai_compatible_resolver_uses_explicit_api_base() -> None:
     assert ensure_v1("http://example.com/v1") == "http://example.com/v1"
 
 
+def test_openai_compatible_resolver_uses_base_url_verbatim() -> None:
+    # A bare host is NOT rewritten to append ``/v1``.
+    _model, kwargs = to_litellm(
+        {
+            "provider": "openai_compatible",
+            "base_url": "https://api.example.com",
+            "api_key": "ex-key",
+            "extra": {},
+        },
+        "some-model",
+    )
+
+    assert kwargs["api_base"] == "https://api.example.com"
+
+
+def test_openai_compatible_resolver_preserves_custom_path() -> None:
+    # Custom (non-/v1) paths survive verbatim, covering the old ``_raw`` case.
+    _model, kwargs = to_litellm(
+        {
+            "provider": "openai_compatible",
+            "base_url": "https://ark.cn-beijing.volces.com/api/v3/",
+            "api_key": "ark-key",
+            "extra": {},
+        },
+        "ep-20260101000000-test",
+    )
+
+    assert kwargs["api_base"] == "https://ark.cn-beijing.volces.com/api/v3"
+
+
 def test_lm_studio_resolver_supplies_dummy_api_key_when_empty() -> None:
     model, kwargs = to_litellm(
         {

--- a/surfsense_backend/tests/unit/services/test_model_connections.py
+++ b/surfsense_backend/tests/unit/services/test_model_connections.py
@@ -1,5 +1,5 @@
 from app.services.global_model_catalog import materialize_global_model_catalog
-from app.services.model_resolver import ensure_v1, strip_version_suffix, to_litellm
+from app.services.model_resolver import strip_version_suffix, to_litellm
 
 
 def test_anthropic_resolver_strips_trailing_v1_from_api_base() -> None:
@@ -61,7 +61,6 @@ def test_openai_compatible_resolver_uses_explicit_api_base() -> None:
     assert model == "openai/qwen/qwen3"
     assert kwargs["api_base"] == "http://host.docker.internal:1234/v1"
     assert kwargs["api_key"] == "local-key"
-    assert ensure_v1("http://example.com/v1") == "http://example.com/v1"
 
 
 def test_openai_compatible_resolver_uses_base_url_verbatim() -> None:

--- a/surfsense_backend/tests/unit/services/test_model_connections.py
+++ b/surfsense_backend/tests/unit/services/test_model_connections.py
@@ -1,4 +1,9 @@
+from types import SimpleNamespace
+
+import httpx
+
 from app.services.global_model_catalog import materialize_global_model_catalog
+from app.services.model_connection_service import _discovery_error_message
 from app.services.model_resolver import strip_version_suffix, to_litellm
 
 
@@ -181,3 +186,18 @@ def test_global_materialization_preserves_tier_and_keeps_key_server_side() -> No
         for connection in connections
     ]
     assert "sk-" not in repr(public_connections)
+
+
+def test_discovery_404_message_points_at_base_url_and_echoes_url() -> None:
+    request = httpx.Request("GET", "http://host.docker.internal:1234/models")
+    exc = httpx.HTTPStatusError(
+        "404", request=request, response=httpx.Response(404, request=request)
+    )
+    conn = SimpleNamespace(
+        provider="openai_compatible", base_url="http://host.docker.internal:1234"
+    )
+
+    message = _discovery_error_message(conn, exc)
+
+    assert "http://host.docker.internal:1234/models" in message
+    assert "API Base URL" in message

--- a/surfsense_web/components/settings/model-connections/default-connect-form.tsx
+++ b/surfsense_web/components/settings/model-connections/default-connect-form.tsx
@@ -9,10 +9,7 @@ function baseUrlHint(provider: string) {
 		return "For local servers, use host.docker.internal instead of localhost.";
 	}
 	if (provider === "openai_compatible") {
-		return "Enter the full endpoint URL. This provider expects a /v1-compatible endpoint.";
-	}
-	if (provider === "openai_compatible_raw") {
-		return "Enter the exact chat-completions API base URL. SurfSense will not append /v1.";
+		return "Enter the exact API base URL, used as-is. Most endpoints end in /v1 (e.g. https://api.example.com/v1).";
 	}
 	if (
 		provider === "openai" ||

--- a/surfsense_web/content/docs/local-models/lm-studio.mdx
+++ b/surfsense_web/content/docs/local-models/lm-studio.mdx
@@ -59,7 +59,7 @@ Replace `<host>` with the LAN IP or domain for that machine.
 6. Select the models you want to enable.
 7. Save the connection.
 
-SurfSense discovers models from `/v1/models`. If you enter the URL without `/v1`, SurfSense adds it for requests.
+SurfSense discovers models from `/v1/models`. The URL is used exactly as entered, so include `/v1`.
 
 ## Verify
 
@@ -89,4 +89,4 @@ Load a model in LM Studio, then refresh model discovery in SurfSense.
 
 ### Endpoint returned 404
 
-Use an OpenAI compatible server URL. The models endpoint must be available at `/v1/models`.
+Check that your API Base URL includes `/v1`. The URL is used exactly as entered, so a missing `/v1` is the most common cause. The models endpoint must be available at `/v1/models`.

--- a/surfsense_web/content/docs/local-models/other-local-servers.mdx
+++ b/surfsense_web/content/docs/local-models/other-local-servers.mdx
@@ -64,7 +64,7 @@ http://<host>:<port>/v1
 6. Select the models you want to enable.
 7. Save the connection.
 
-If you enter the URL without `/v1`, SurfSense adds `/v1` for requests.
+The URL is used exactly as entered. Include `/v1`, since most servers expose their OpenAI compatible routes under `/v1`.
 
 ## Verify
 
@@ -92,9 +92,9 @@ Use the LM Studio provider for LM Studio. Its default URL is already set.
 
 ### Endpoint returned 404
 
-The server does not expose `/v1/models`.
+First, check that your API Base URL includes `/v1`. The URL is used exactly as entered, so a missing `/v1` is the most common cause.
 
-Enable the server's OpenAI compatible mode.
+If `/v1` is present, the server does not expose `/v1/models`. Enable the server's OpenAI compatible mode.
 
 ### Connection refused
 


### PR DESCRIPTION
<!--- Summarize your pull request in a few sentences -->

## Description
<!--- Clearly describe what has changed in this pull request -->
- Use the OpenAI-compatible base URL exactly as entered across chat, model discovery, and connection verification; SurfSense no longer auto-appends `/v1`, matching how LiteLLM and the OpenAI SDK treat `api_base`.
- Remove the `ensure_v1` helper entirely; `to_litellm` now only special-cases Anthropic (strips a trailing `/v1` so LiteLLM's native handler doesn't produce `/v1/v1/messages`) and passes every other provider's base URL through verbatim.
- Apply verbatim handling to all OpenAI-compatible discovery, including OpenRouter and Requesty; their default base URLs already include `/v1`, so real-world behavior is unchanged, but the path is no longer forced.
- Query `{base_url}/models` exactly as entered for discovery and verification.
- Deprecate `openai_compatible_raw`: hidden from the provider catalog so it can no longer be added, while kept in the registry so pre-existing connections still resolve and work; the merged `openai_compatible` (now verbatim) covers the former raw use case.
- Simplify the connect form to a single OpenAI-compatible option with a hint that the base URL is used as-is (include `/v1`), dropping the separate raw-endpoint guidance and the endpoint preview.
- Update unit tests: drop the `ensure_v1` assertions and add coverage that a bare host is not rewritten with `/v1` and that custom paths (e.g. `/api/v3`) are preserved.
- Correct the LM Studio and other-local-servers docs to state the base URL is used verbatim (include `/v1`) and lead 404 troubleshooting with a check that the base URL contains `/v1`.
- No database migration or backfill required; the only affected case is pre-existing bare-host `openai_compatible` connections, which fail loudly and are fixed by adding `/v1` to the URL.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If this PR relates to an open issue, please link to the issue here: FIX #123 -->
FIX #


## Screenshots
<!-- If applicable, add screenshots or images to demonstrate the changes visually -->

## API Changes
<!-- Document any API changes if applicable -->
- [ ] This PR includes API changes

## Change Type
<!--- Indicate what kind(s) of changes this PR includes: -->
- [x] Bug fix
- [ ] New feature
- [x] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Dependency/Build system
- [ ] Breaking change
- [ ] Other (specify):

## Testing Performed
<!--- Briefly describe how you have tested these changes and what verification was performed -->
- [x] Tested locally
- [ ] Manual/QA verification

## Checklist
<!--- Please confirm the following by marking with an 'x' as appropriate -->
- [ ] Follows project coding standards and conventions
- [ ] Documentation updated as needed
- [ ] Dependencies updated as needed
- [ ] No lint/build errors or new warnings
- [ ] All relevant tests are passing

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR changes how OpenAI-compatible base URLs are handled throughout the system. Previously, the system would automatically append `/v1` to base URLs; now the URL is used exactly as entered by the user. The `openai_compatible_raw` provider is deprecated (hidden from the catalog but kept for backward compatibility), as the main `openai_compatible` provider now handles both standard and custom paths. Special handling for Anthropic (stripping version suffixes) and fixed endpoints like OpenRouter/Requesty (which still append `/v1`) are preserved. The UI, documentation, and tests are updated to reflect that users must include `/v1` in their base URLs when needed.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_backend/app/services/provider_registry.py` |
| 2 | `surfsense_backend/app/services/model_resolver.py` |
| 3 | `surfsense_backend/app/services/model_connection_service.py` |
| 4 | `surfsense_backend/tests/unit/services/test_model_connections.py` |
| 5 | `surfsense_backend/app/routes/model_connections_routes.py` |
| 6 | `surfsense_web/components/settings/model-connections/default-connect-form.tsx` |
| 7 | `surfsense_web/content/docs/local-models/lm-studio.mdx` |
| 8 | `surfsense_web/content/docs/local-models/other-local-servers.mdx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->