### PR TITLE
feat(google_search): fall back to SearXNG when Google walls every IP

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -558,6 +558,9 @@ NOLOGIN_MODE_ENABLED=FALSE
 # -- Redis exposed port (dev/deps-only only; Redis is internal-only in prod) --
 # REDIS_PORT=6379
 
+# -- SearXNG exposed port (dev/deps-only only; internal-only in prod) --
+# SEARXNG_PORT=8888
+
 # -- WhatsApp bridge exposed port (dev/hybrid only; prod keeps it Docker-internal) --
 # WHATSAPP_BRIDGE_PORT=9929
 

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -531,8 +531,8 @@ NOLOGIN_MODE_ENABLED=FALSE
 # searxng service. Works out of the box; nothing here needs setting.
 # Set empty to disable the fallback, or to another base URL to use your own
 # instance (which must have 'json' in search.formats, or requests get a 403).
-# SEARXNG_FALLBACK_URL=http://your-searxng:8080
-# SEARXNG_FALLBACK_TIMEOUT_S=10
+# SEARXNG_URL=http://your-searxng:8080
+# SEARXNG_TIMEOUT_S=10
 # SEARXNG_SECRET=surfsense-searxng-secret
 
 # Stealth hardening levers on the stealth browser tier. Defaults preserve

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -527,6 +527,14 @@ NOLOGIN_MODE_ENABLED=FALSE
 # CAPTCHA_V3_MIN_SCORE=0.7
 # CAPTCHA_V3_ACTION=verify
 
+# Last-resort fallback for the Google Search scraper, served by the bundled
+# searxng service. Works out of the box; nothing here needs setting.
+# Set empty to disable the fallback, or to another base URL to use your own
+# instance (which must have 'json' in search.formats, or requests get a 403).
+# SEARXNG_FALLBACK_URL=http://your-searxng:8080
+# SEARXNG_FALLBACK_TIMEOUT_S=10
+# SEARXNG_SECRET=surfsense-searxng-secret
+
 # Stealth hardening levers on the stealth browser tier. Defaults preserve
 # current behavior; see surfsense_backend/.env.example for per-flag docs.
 # CRAWL_GEOIP_MATCH_ENABLED=FALSE

--- a/docker/docker-compose.deps-only.yml
+++ b/docker/docker-compose.deps-only.yml
@@ -80,7 +80,7 @@ services:
       retries: 5
 
   # Google Search scraper fallback. The host-run backend reaches it with
-  # SEARXNG_FALLBACK_URL=http://localhost:8888.
+  # SEARXNG_URL=http://localhost:8888.
   searxng:
     image: searxng/searxng:2026.3.13-3c1f68c59
     ports:

--- a/docker/docker-compose.deps-only.yml
+++ b/docker/docker-compose.deps-only.yml
@@ -79,6 +79,22 @@ services:
       timeout: 5s
       retries: 5
 
+  # Google Search scraper fallback. The host-run backend reaches it with
+  # SEARXNG_FALLBACK_URL=http://localhost:8888.
+  searxng:
+    image: searxng/searxng:2026.3.13-3c1f68c59
+    ports:
+      - "${SEARXNG_PORT:-8888}:8080"
+    volumes:
+      - ./searxng:/etc/searxng
+    environment:
+      - SEARXNG_SECRET=${SEARXNG_SECRET:-surfsense-searxng-secret}
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8080/healthz"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
   # NOTE: zero-cache requires the `zero_publication` Postgres publication to
   # exist before it starts. In this deps-only stack there is no backend
   # container to run migrations, so you must run `uv run alembic upgrade head`

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -127,6 +127,7 @@ services:
       - AUTH_TYPE=${AUTH_TYPE:-LOCAL}
       - NEXT_FRONTEND_URL=${NEXT_FRONTEND_URL:-http://localhost:3000}
       - WHATSAPP_BRIDGE_URL=${WHATSAPP_BRIDGE_URL:-http://whatsapp-bridge:9929}
+      - SEARXNG_FALLBACK_URL=${SEARXNG_FALLBACK_URL:-http://searxng:8080}
       # Daytona Sandbox – uncomment and set credentials to enable cloud code execution
       # - DAYTONA_SANDBOX_ENABLED=TRUE
       # - DAYTONA_API_KEY=${DAYTONA_API_KEY:-}
@@ -184,6 +185,7 @@ services:
       - CELERY_TASK_DEFAULT_QUEUE=surfsense
       - PYTHONPATH=/app
       - FILE_STORAGE_LOCAL_PATH=/app/.local_object_store
+      - SEARXNG_FALLBACK_URL=${SEARXNG_FALLBACK_URL:-http://searxng:8080}
       - SERVICE_ROLE=worker
     depends_on:
       db:

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -76,6 +76,21 @@ services:
       timeout: 5s
       retries: 5
 
+  # Last-resort fallback for the Google Search scraper.
+  searxng:
+    image: searxng/searxng:2026.3.13-3c1f68c59
+    ports:
+      - "${SEARXNG_PORT:-8888}:8080"
+    volumes:
+      - ./searxng:/etc/searxng
+    environment:
+      - SEARXNG_SECRET=${SEARXNG_SECRET:-surfsense-searxng-secret}
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8080/healthz"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
   otel-lgtm:
     image: grafana/otel-lgtm:latest
     ports:

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -76,7 +76,6 @@ services:
       timeout: 5s
       retries: 5
 
-  # Last-resort fallback for the Google Search scraper.
   searxng:
     image: searxng/searxng:2026.3.13-3c1f68c59
     ports:

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -127,7 +127,7 @@ services:
       - AUTH_TYPE=${AUTH_TYPE:-LOCAL}
       - NEXT_FRONTEND_URL=${NEXT_FRONTEND_URL:-http://localhost:3000}
       - WHATSAPP_BRIDGE_URL=${WHATSAPP_BRIDGE_URL:-http://whatsapp-bridge:9929}
-      - SEARXNG_FALLBACK_URL=${SEARXNG_FALLBACK_URL:-http://searxng:8080}
+      - SEARXNG_URL=${SEARXNG_URL:-http://searxng:8080}
       # Daytona Sandbox – uncomment and set credentials to enable cloud code execution
       # - DAYTONA_SANDBOX_ENABLED=TRUE
       # - DAYTONA_API_KEY=${DAYTONA_API_KEY:-}
@@ -185,7 +185,7 @@ services:
       - CELERY_TASK_DEFAULT_QUEUE=surfsense
       - PYTHONPATH=/app
       - FILE_STORAGE_LOCAL_PATH=/app/.local_object_store
-      - SEARXNG_FALLBACK_URL=${SEARXNG_FALLBACK_URL:-http://searxng:8080}
+      - SEARXNG_URL=${SEARXNG_URL:-http://searxng:8080}
       - SERVICE_ROLE=worker
     depends_on:
       db:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -58,7 +58,7 @@ services:
       timeout: 5s
       retries: 5
 
-  # Last-resort fallback for the Google Search scraper (SEARXNG_FALLBACK_URL).
+  # Last-resort fallback for the Google Search scraper (SEARXNG_URL).
   # Nothing depends_on it: if it is down, searches degrade to Google alone.
   searxng:
     image: searxng/searxng:2026.3.13-3c1f68c59
@@ -149,7 +149,7 @@ services:
       NEXT_FRONTEND_URL: ${NEXT_FRONTEND_URL:-${SURFSENSE_PUBLIC_URL:-http://localhost:${LISTEN_HTTP_PORT:-3929}}}
       BACKEND_URL: ${BACKEND_URL:-${SURFSENSE_PUBLIC_URL:-http://localhost:${LISTEN_HTTP_PORT:-3929}}}
       WHATSAPP_BRIDGE_URL: ${WHATSAPP_BRIDGE_URL:-http://whatsapp-bridge:9929}
-      SEARXNG_FALLBACK_URL: ${SEARXNG_FALLBACK_URL:-http://searxng:8080}
+      SEARXNG_URL: ${SEARXNG_URL:-http://searxng:8080}
       # Daytona Sandbox – uncomment and set credentials to enable cloud code execution
       # DAYTONA_SANDBOX_ENABLED: "TRUE"
       # DAYTONA_API_KEY: ${DAYTONA_API_KEY:-}
@@ -210,7 +210,7 @@ services:
       CELERY_TASK_DEFAULT_QUEUE: surfsense
       PYTHONPATH: /app
       FILE_STORAGE_LOCAL_PATH: /app/.local_object_store
-      SEARXNG_FALLBACK_URL: ${SEARXNG_FALLBACK_URL:-http://searxng:8080}
+      SEARXNG_URL: ${SEARXNG_URL:-http://searxng:8080}
       SERVICE_ROLE: worker
     depends_on:
       db:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -149,6 +149,7 @@ services:
       NEXT_FRONTEND_URL: ${NEXT_FRONTEND_URL:-${SURFSENSE_PUBLIC_URL:-http://localhost:${LISTEN_HTTP_PORT:-3929}}}
       BACKEND_URL: ${BACKEND_URL:-${SURFSENSE_PUBLIC_URL:-http://localhost:${LISTEN_HTTP_PORT:-3929}}}
       WHATSAPP_BRIDGE_URL: ${WHATSAPP_BRIDGE_URL:-http://whatsapp-bridge:9929}
+      SEARXNG_FALLBACK_URL: ${SEARXNG_FALLBACK_URL:-http://searxng:8080}
       # Daytona Sandbox – uncomment and set credentials to enable cloud code execution
       # DAYTONA_SANDBOX_ENABLED: "TRUE"
       # DAYTONA_API_KEY: ${DAYTONA_API_KEY:-}
@@ -209,6 +210,7 @@ services:
       CELERY_TASK_DEFAULT_QUEUE: surfsense
       PYTHONPATH: /app
       FILE_STORAGE_LOCAL_PATH: /app/.local_object_store
+      SEARXNG_FALLBACK_URL: ${SEARXNG_FALLBACK_URL:-http://searxng:8080}
       SERVICE_ROLE: worker
     depends_on:
       db:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -58,6 +58,21 @@ services:
       timeout: 5s
       retries: 5
 
+  # Last-resort fallback for the Google Search scraper (SEARXNG_FALLBACK_URL).
+  # Nothing depends_on it: if it is down, searches degrade to Google alone.
+  searxng:
+    image: searxng/searxng:2026.3.13-3c1f68c59
+    volumes:
+      - ./searxng:/etc/searxng
+    environment:
+      SEARXNG_SECRET: ${SEARXNG_SECRET:-surfsense-searxng-secret}
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8080/healthz"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
   # otel-collector:
   #   image: otel/opentelemetry-collector-contrib:0.152.1
   #   profiles:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -58,8 +58,6 @@ services:
       timeout: 5s
       retries: 5
 
-  # Last-resort fallback for the Google Search scraper (SEARXNG_URL).
-  # Nothing depends_on it: if it is down, searches degrade to Google alone.
   searxng:
     image: searxng/searxng:2026.3.13-3c1f68c59
     volumes:

--- a/docker/scripts/install.ps1
+++ b/docker/scripts/install.ps1
@@ -330,6 +330,7 @@ Write-Info "Installation directory: $InstallDir"
 
 New-Item -ItemType Directory -Path "$InstallDir\scripts" -Force | Out-Null
 New-Item -ItemType Directory -Path "$InstallDir\proxy" -Force | Out-Null
+New-Item -ItemType Directory -Path "$InstallDir\searxng" -Force | Out-Null
 
 $Files = @(
     @{ Src = "docker/docker-compose.yml";                Dest = "docker-compose.yml" }
@@ -338,6 +339,8 @@ $Files = @(
     @{ Src = "docker/proxy/Caddyfile";                   Dest = "proxy/Caddyfile" }
     @{ Src = "docker/postgresql.conf";                   Dest = "postgresql.conf" }
     @{ Src = "docker/scripts/migrate-database.ps1";      Dest = "scripts/migrate-database.ps1" }
+    @{ Src = "docker/searxng/settings.yml";              Dest = "searxng/settings.yml" }
+    @{ Src = "docker/searxng/limiter.toml";              Dest = "searxng/limiter.toml" }
 )
 
 foreach ($f in $Files) {

--- a/docker/scripts/install.sh
+++ b/docker/scripts/install.sh
@@ -333,6 +333,7 @@ step "Downloading SurfSense files"
 info "Installation directory: ${INSTALL_DIR}"
 mkdir -p "${INSTALL_DIR}/scripts"
 mkdir -p "${INSTALL_DIR}/proxy"
+mkdir -p "${INSTALL_DIR}/searxng"
 
 FILES=(
     "docker/docker-compose.yml:docker-compose.yml"
@@ -341,6 +342,8 @@ FILES=(
     "docker/proxy/Caddyfile:proxy/Caddyfile"
     "docker/postgresql.conf:postgresql.conf"
     "docker/scripts/migrate-database.sh:scripts/migrate-database.sh"
+    "docker/searxng/settings.yml:searxng/settings.yml"
+    "docker/searxng/limiter.toml:searxng/limiter.toml"
 )
 
 for entry in "${FILES[@]}"; do

--- a/docker/searxng/limiter.toml
+++ b/docker/searxng/limiter.toml
@@ -1,0 +1,5 @@
+[botdetection.ip_limit]
+link_token = false
+
+[botdetection.ip_lists]
+pass_ip = ["0.0.0.0/0"]

--- a/docker/searxng/settings.yml
+++ b/docker/searxng/settings.yml
@@ -1,0 +1,91 @@
+use_default_settings:
+  engines:
+    remove:
+      - ahmia
+      - torch
+      - qwant
+      - qwant news
+      - qwant images
+      - qwant videos
+      - mojeek
+      - mojeek images
+      - mojeek news
+
+server:
+  secret_key: "override-me-via-env"
+  limiter: false
+  image_proxy: false
+  method: "GET"
+  default_http_headers:
+    X-Robots-Tag: "noindex, nofollow"
+
+search:
+  # Dropping 'json' makes every fallback request 403.
+  formats:
+    - html
+    - json
+  default_lang: "auto"
+  autocomplete: ""
+  safe_search: 0
+  ban_time_on_fail: 5
+  max_ban_time_on_fail: 120
+  suspended_times:
+    SearxEngineAccessDenied: 3600
+    SearxEngineCaptcha: 3600
+    SearxEngineTooManyRequests: 600
+    cf_SearxEngineCaptcha: 7200
+    cf_SearxEngineAccessDenied: 3600
+    recaptcha_SearxEngineCaptcha: 7200
+
+ui:
+  static_use_hash: true
+
+outgoing:
+  request_timeout: 12.0
+  max_request_timeout: 20.0
+  pool_connections: 100
+  pool_maxsize: 20
+  enable_http2: true
+  extra_proxy_timeout: 10
+  retries: 1
+  # Uncomment and set your residential proxy URL to route search engine requests through it.
+  # Format: http://<username>:<base64_password>@<hostname>:<port>/
+  #
+  # proxies:
+  #   all://:
+  #     - http://user:pass@proxy-host:port/
+
+engines:
+  # Off on purpose: this instance only runs after Google walled us, and would
+  # query it from the same address.
+  - name: google
+    disabled: true
+  - name: duckduckgo
+    disabled: false
+    weight: 1.1
+    retry_on_http_error: [429, 503]
+  - name: brave
+    disabled: false
+    weight: 1.0
+    retry_on_http_error: [429, 503]
+  - name: bing
+    disabled: false
+    weight: 0.9
+    retry_on_http_error: [429, 503]
+  - name: wikipedia
+    disabled: false
+    weight: 0.8
+  - name: stackoverflow
+    disabled: false
+    weight: 0.7
+  - name: yahoo
+    disabled: false
+    weight: 0.7
+    retry_on_http_error: [429, 503]
+  - name: wikidata
+    disabled: false
+    weight: 0.6
+  - name: currency
+    disabled: false
+  - name: ddg definitions
+    disabled: false

--- a/surfsense_backend/.env.example
+++ b/surfsense_backend/.env.example
@@ -409,6 +409,13 @@ TURNSTILE_SECRET_KEY=
 # Per-fetch budget before giving up under saturation (a cold solve is ~45s).
 # GOOGLE_SEARCH_FETCH_DEADLINE_S=180
 
+# Last-resort fallback once the ladder above is exhausted. Docker Compose sets
+# this to its bundled searxng service; set it by hand only when running the
+# backend outside Docker (dev/deps-only publish SearXNG on 8888). Unset = off.
+# The instance must have 'json' in search.formats, or requests get a 403.
+# SEARXNG_FALLBACK_URL=http://localhost:8888
+# SEARXNG_FALLBACK_TIMEOUT_S=10
+
 # =====================================================================
 # Captcha solving (Phase 3d) — LAST-resort bypass tier (in-house solver seam,
 # app/utils/captcha/solvers.py). Only fires on the stealth browser tier when a

--- a/surfsense_backend/.env.example
+++ b/surfsense_backend/.env.example
@@ -413,8 +413,8 @@ TURNSTILE_SECRET_KEY=
 # this to its bundled searxng service; set it by hand only when running the
 # backend outside Docker (dev/deps-only publish SearXNG on 8888). Unset = off.
 # The instance must have 'json' in search.formats, or requests get a 403.
-# SEARXNG_FALLBACK_URL=http://localhost:8888
-# SEARXNG_FALLBACK_TIMEOUT_S=10
+# SEARXNG_URL=http://localhost:8888
+# SEARXNG_TIMEOUT_S=10
 
 # =====================================================================
 # Captcha solving (Phase 3d) — LAST-resort bypass tier (in-house solver seam,

--- a/surfsense_backend/app/agents/chat/multi_agent_chat/subagents/builtins/google_search/system_prompt.md
+++ b/surfsense_backend/app/agents/chat/multi_agent_chat/subagents/builtins/google_search/system_prompt.md
@@ -17,6 +17,7 @@ Answer the delegated question from live Google Search data gathered with your ve
 - Scraping a specific results page: pass the full Google Search URL in `queries`.
 - Need more results: raise `max_pages_per_query` to page beyond the first page (cheaper and faster than adding more distinct queries).
 <include snippet="run_reader"/>
+- Provenance: if an item carries `resultsProvider` (e.g. `searxng`), Google was unreachable and these came from a fallback search index — say so in your findings and do not describe them as Google rankings or positions.
 - Handing URLs off for crawling: return the organic result URLs so the supervisor can route them to the web crawling specialist.
 - Comparison requests: pull the current results, compare against prior values already in this conversation's earlier tool results, and report concrete deltas (added, removed, moved up/down).
 </playbook>

--- a/surfsense_backend/app/capabilities/google_search/scrape/schemas.py
+++ b/surfsense_backend/app/capabilities/google_search/scrape/schemas.py
@@ -62,5 +62,11 @@ class ScrapeOutput(BaseModel):
 
     @property
     def billable_units(self) -> int:
-        """One fetched SERP page = one billable unit."""
-        return len(self.items)
+        """One fetched Google SERP page = one billable unit.
+
+        Fallback pages (``resultsProvider`` set) cost no proxy render and no
+        captcha solve, so they are not charged at the Google SERP rate.
+        """
+        return sum(
+            1 for item in self.items if not getattr(item, "resultsProvider", None)
+        )

--- a/surfsense_backend/app/proprietary/platforms/google_search/fetch.py
+++ b/surfsense_backend/app/proprietary/platforms/google_search/fetch.py
@@ -548,7 +548,9 @@ async def fetch_serp_html(url: str, *, mobile: bool = False) -> str | None:
         with contextlib.suppress(Exception):
             page = await _render(url, None, mobile=mobile)
             html = page.html_content or ""
-            return html if (page.status == 200 and _has_results(html)) else None
+            if page.status == 200 and _has_results(html):
+                return html
+        logger.warning("[google_search] gave up on %s (unproxied single render)", url)
         return None
 
     deadline = time.monotonic() + _FETCH_DEADLINE_S

--- a/surfsense_backend/app/proprietary/platforms/google_search/scraper.py
+++ b/surfsense_backend/app/proprietary/platforms/google_search/scraper.py
@@ -15,6 +15,7 @@ import logging
 from collections.abc import AsyncIterator
 from typing import Any
 
+from . import searxng
 from .fetch import fetch_serp_html
 from .parsers import parse_ai_mode, parse_serp
 from .query_builder import (
@@ -38,15 +39,24 @@ _PAID_ADS_MAX_TRIES = 3
 
 
 def _search_query_stamp(
-    term: str | None, url: str, page: int, input_model: GoogleSearchScrapeInput
+    term: str | None,
+    url: str | None,
+    page: int,
+    input_model: GoogleSearchScrapeInput,
+    *,
+    domain: str = "google.com",
 ) -> SearchQuery:
-    """The ``searchQuery`` provenance block Apify stamps on every item."""
+    """The ``searchQuery`` provenance block Apify stamps on every item.
+
+    ``domain`` is overridden when a page came from the fallback provider, so an
+    aggregator result never claims to be a google.com SERP.
+    """
     return SearchQuery(
         term=term,
         url=url,
         device="MOBILE" if input_model.mobileResults else "DESKTOP",
         page=page,
-        domain="google.com",
+        domain=domain,
         countryCode=(input_model.countryCode or "US").upper(),
         languageCode=input_model.languageCode or None,
         locationUule=input_model.locationUule,
@@ -54,12 +64,13 @@ def _search_query_stamp(
 
 
 async def _serp_page_flow(
-    url: str, input_model: GoogleSearchScrapeInput
+    url: str, input_model: GoogleSearchScrapeInput, *, term: str | None, page: int
 ) -> SerpItem | None:
-    """Fetch and parse one SERP page into a :class:`SerpItem`.
+    """Fetch and parse one SERP page into a stamped :class:`SerpItem`.
 
     Renders ``url`` through the proxy and parses organic/paid/related/PAA blocks.
-    Returns ``None`` when the page could not be fetched (all IPs walled), so the
+    When every IP is walled the page falls through to the SearXNG fallback
+    (:func:`_searxng_page`); ``None`` means even that yielded nothing, so the
     caller stops paging.
 
     With ``focusOnPaidAds`` we re-render up to :data:`_PAID_ADS_MAX_TRIES` times
@@ -82,7 +93,8 @@ async def _serp_page_flow(
         if input_model.saveHtml:
             item.html = html
         if not input_model.focusOnPaidAds or item.paidResults or item.paidProducts:
-            return item
+            best = item
+            break
         # No ads yet; keep the render with the most organic results as fallback.
         if best is None or len(item.organicResults) > len(best.organicResults):
             best = item
@@ -91,7 +103,31 @@ async def _serp_page_flow(
             attempt,
             tries,
         )
+    if best is None:
+        return await _searxng_page(term, input_model, page=page)
+    best.searchQuery = _search_query_stamp(term, url, page, input_model)
     return best
+
+
+async def _searxng_page(
+    term: str | None, input_model: GoogleSearchScrapeInput, *, page: int
+) -> SerpItem | None:
+    """Last-resort aggregator page when Google walled every IP.
+
+    Skipped when the caller specifically wants ads (an aggregator serves none,
+    so a result here would be a guaranteed miss dressed up as data) or when
+    there is no plain term — a Google URL whose ``q`` we could not read has
+    nothing to re-search.
+    """
+    if input_model.focusOnPaidAds or not term or not searxng.enabled():
+        return None
+    item = await searxng.search_serp(term, input_model, page=page)
+    if item is None:
+        return None
+    item.searchQuery = _search_query_stamp(
+        term, None, page, input_model, domain=searxng.domain()
+    )
+    return item
 
 
 async def _term_flow(
@@ -102,10 +138,9 @@ async def _term_flow(
     pages = input_model.maxPagesPerQuery or 1
     for page in range(1, pages + 1):
         url = build_search_url(term, input_model, page=page)
-        item = await _serp_page_flow(url, input_model)
+        item = await _serp_page_flow(url, input_model, term=term, page=page)
         if item is None:
             return
-        item.searchQuery = _search_query_stamp(term, url, page, input_model)
         yield item.to_output()
         # An empty organic page means we've run past the last result page.
         if not item.organicResults:
@@ -119,10 +154,9 @@ async def _url_flow(
     over the localization inputs). ``maxPagesPerQuery`` paging (rewriting the
     ``start`` parameter) lands with the fetch implementation."""
     term = term_from_url(url)
-    item = await _serp_page_flow(url, input_model)
+    item = await _serp_page_flow(url, input_model, term=term, page=1)
     if item is None:
         return
-    item.searchQuery = _search_query_stamp(term, url, 1, input_model)
     yield item.to_output()
 
 

--- a/surfsense_backend/app/proprietary/platforms/google_search/searxng.py
+++ b/surfsense_backend/app/proprietary/platforms/google_search/searxng.py
@@ -3,7 +3,8 @@
 When Google walls every vetted IP (``fetch_serp_html`` returns ``None`` after
 its pool/deadline budget), this returns the same ``SerpItem`` shape from a
 SearXNG instance's JSON API, so a search yields organic results instead of
-nothing. Off unless ``SEARXNG_FALLBACK_URL`` is set.
+nothing. Keyed on ``SEARXNG_FALLBACK_URL``, which the Docker stack points at
+its bundled ``searxng`` service; unset elsewhere means off.
 
 SearXNG is a metasearch aggregator, not Google: only organic results (title,
 url, snippet) and query suggestions exist. Ads, People-Also-Ask, AI Overview,

--- a/surfsense_backend/app/proprietary/platforms/google_search/searxng.py
+++ b/surfsense_backend/app/proprietary/platforms/google_search/searxng.py
@@ -1,0 +1,142 @@
+"""Last-resort SearXNG fallback for the Google Search scraper.
+
+When Google walls every vetted IP (``fetch_serp_html`` returns ``None`` after
+its pool/deadline budget), this returns the same ``SerpItem`` shape from a
+SearXNG instance's JSON API, so a search yields organic results instead of
+nothing. Off unless ``SEARXNG_FALLBACK_URL`` is set.
+
+SearXNG is a metasearch aggregator, not Google: only organic results (title,
+url, snippet) and query suggestions exist. Ads, People-Also-Ask, AI Overview,
+sitelinks, icons, and result totals are Google-only and stay empty, and every
+item carries ``resultsProvider="searxng"`` so no consumer reports aggregator
+hits as Google rankings.
+
+``ponytail:`` best-effort — any error/timeout returns ``None`` and the caller
+behaves exactly as it does today. The instance must serve JSON
+(``search.formats`` including ``json`` in its ``settings.yml``); a stock
+self-hosted install answers 403 until it does.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+from urllib.parse import urlsplit
+
+import httpx
+
+from .schemas import (
+    GoogleSearchScrapeInput,
+    OrganicResult,
+    RelatedQuery,
+    SerpItem,
+    SuggestedResult,
+)
+
+logger = logging.getLogger(__name__)
+
+PROVIDER = "searxng"
+
+# Read here rather than in app.config to match the sibling fetch seam, which
+# takes its own knobs straight from the environment.
+_HOST = os.getenv("SEARXNG_FALLBACK_URL", "").strip()
+_TIMEOUT_S = float(os.getenv("SEARXNG_FALLBACK_TIMEOUT_S", "10"))
+# A Google SERP page is 10 results; cap the aggregator to the same so a
+# fallback page never looks anomalously large to a caller that is paging.
+_MAX_RESULTS = 10
+
+# ``quickDateRange`` (Google ``tbs=qdr:``) -> SearXNG ``time_range``. Only the
+# plain units map; compound codes like "m6" have no equivalent and are dropped
+# rather than approximated.
+_TIME_RANGE = {"d": "day", "w": "week", "m": "month", "y": "year"}
+
+
+def enabled() -> bool:
+    """True when a fallback instance is configured."""
+    return bool(_HOST)
+
+
+def domain() -> str:
+    """Instance hostname, for the ``searchQuery.domain`` provenance field."""
+    return urlsplit(_HOST).hostname or PROVIDER
+
+
+def _query(term: str, input_model: GoogleSearchScrapeInput) -> str:
+    """The term with only the operators SearXNG actually honors.
+
+    ``site:`` and exact-match quoting are supported across its engines;
+    ``intitle:``/``intext:``/``inurl:``/``filetype:``/``before:``/``after:``
+    are not, and folding them in returns zero results instead of degrading.
+    """
+    query = f'"{term}"' if input_model.forceExactMatch else term
+    if input_model.site:
+        query = f"{query} site:{input_model.site}"
+    return query
+
+
+async def _fetch_json(params: dict[str, Any]) -> dict[str, Any] | None:
+    try:
+        async with httpx.AsyncClient(timeout=_TIMEOUT_S) as client:
+            response = await client.get(f"{_HOST.rstrip('/')}/search", params=params)
+        response.raise_for_status()
+        return response.json()
+    except Exception as e:
+        logger.warning("[google_search][searxng] fallback request failed: %s", e)
+        return None
+
+
+async def search_serp(
+    term: str, input_model: GoogleSearchScrapeInput, *, page: int = 1
+) -> SerpItem | None:
+    """One SearXNG results page as a ``SerpItem``, or ``None`` if unusable."""
+    if not enabled():
+        return None
+
+    params: dict[str, Any] = {
+        "q": _query(term, input_model),
+        "format": "json",
+        "pageno": page,
+        "categories": "general",
+    }
+    if input_model.languageCode:
+        params["language"] = input_model.languageCode
+    time_range = _TIME_RANGE.get((input_model.quickDateRange or "").lower())
+    if time_range:
+        params["time_range"] = time_range
+
+    payload = await _fetch_json(params)
+    if payload is None:
+        return None
+
+    usable = [r for r in (payload.get("results") or []) if r.get("url")][:_MAX_RESULTS]
+    if not usable:
+        logger.info("[google_search][searxng] no results for %r", term)
+        return None
+
+    suggestions = [s for s in (payload.get("suggestions") or []) if s][:_MAX_RESULTS]
+    logger.info(
+        "[google_search][searxng] fallback served %d result(s) for %r page=%d",
+        len(usable),
+        term,
+        page,
+    )
+    return SerpItem(
+        organicResults=[
+            OrganicResult(
+                title=r.get("title"),
+                url=r.get("url"),
+                description=r.get("content"),
+                position=i,
+            )
+            for i, r in enumerate(usable, start=1)
+        ],
+        relatedQueries=[RelatedQuery(title=s) for s in suggestions],
+        suggestedResults=[
+            SuggestedResult(title=s, position=i)
+            for i, s in enumerate(suggestions, start=1)
+        ],
+        # Extra field (SerpItem is extra="allow"), so it flows untouched through
+        # to_output() into REST, MCP, playground, and the chat subagent.
+        resultsProvider=PROVIDER,
+    )

--- a/surfsense_backend/app/proprietary/platforms/google_search/searxng.py
+++ b/surfsense_backend/app/proprietary/platforms/google_search/searxng.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 import logging
 import os
 from typing import Any
-from urllib.parse import urlsplit
 
 import httpx
 
@@ -58,8 +57,9 @@ def enabled() -> bool:
 
 
 def domain() -> str:
-    """Instance hostname, for the ``searchQuery.domain`` provenance field."""
-    return urlsplit(_HOST).hostname or PROVIDER
+    """Provider label for ``searchQuery.domain`` — not the configured host,
+    which is often a private address that should not reach API output."""
+    return PROVIDER
 
 
 def _query(term: str, input_model: GoogleSearchScrapeInput) -> str:

--- a/surfsense_backend/app/proprietary/platforms/google_search/searxng.py
+++ b/surfsense_backend/app/proprietary/platforms/google_search/searxng.py
@@ -3,8 +3,8 @@
 When Google walls every vetted IP (``fetch_serp_html`` returns ``None`` after
 its pool/deadline budget), this returns the same ``SerpItem`` shape from a
 SearXNG instance's JSON API, so a search yields organic results instead of
-nothing. Keyed on ``SEARXNG_FALLBACK_URL``, which the Docker stack points at
-its bundled ``searxng`` service; unset elsewhere means off.
+nothing. Keyed on ``SEARXNG_URL``, which the Docker stack points at its
+bundled ``searxng`` service; unset elsewhere means off.
 
 SearXNG is a metasearch aggregator, not Google: only organic results (title,
 url, snippet) and query suggestions exist. Ads, People-Also-Ask, AI Overview,
@@ -40,8 +40,8 @@ PROVIDER = "searxng"
 
 # Read here rather than in app.config to match the sibling fetch seam, which
 # takes its own knobs straight from the environment.
-_HOST = os.getenv("SEARXNG_FALLBACK_URL", "").strip()
-_TIMEOUT_S = float(os.getenv("SEARXNG_FALLBACK_TIMEOUT_S", "10"))
+_HOST = os.getenv("SEARXNG_URL", "").strip()
+_TIMEOUT_S = float(os.getenv("SEARXNG_TIMEOUT_S", "10"))
 # A Google SERP page is 10 results; cap the aggregator to the same so a
 # fallback page never looks anomalously large to a caller that is paging.
 _MAX_RESULTS = 10

--- a/surfsense_backend/app/proprietary/platforms/google_search/searxng.py
+++ b/surfsense_backend/app/proprietary/platforms/google_search/searxng.py
@@ -79,6 +79,12 @@ async def _fetch_json(params: dict[str, Any]) -> dict[str, Any] | None:
     try:
         async with httpx.AsyncClient(timeout=_TIMEOUT_S) as client:
             response = await client.get(f"{_HOST.rstrip('/')}/search", params=params)
+        if response.status_code == 403:
+            logger.warning(
+                "[google_search][searxng] instance refused the JSON API (403); "
+                "add 'json' to search.formats in its settings.yml"
+            )
+            return None
         response.raise_for_status()
         return response.json()
     except Exception as e:

--- a/surfsense_backend/tests/unit/platforms/google_search/test_searxng_fallback.py
+++ b/surfsense_backend/tests/unit/platforms/google_search/test_searxng_fallback.py
@@ -5,6 +5,8 @@ aggregator's HTTP call is stubbed, so this exercises the real wiring: when the
 fallback fires, what it maps, and the cases where it must stay silent.
 """
 
+import logging
+
 import pytest
 
 from app.proprietary.platforms.google_search import (
@@ -116,6 +118,30 @@ async def test_no_fallback_for_url_without_readable_query(walled_google, searxng
         GoogleSearchScrapeInput(queries="https://www.google.com/search")
     )
     assert items == []
+
+
+async def test_json_api_disabled_names_the_fix(monkeypatch, caplog):
+    """A stock instance 403s ``format=json``; the log has to name the knob."""
+
+    class _Response:
+        status_code = 403
+
+    class _Client:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        async def get(self, url, params=None):
+            return _Response()
+
+    monkeypatch.setattr(searxng, "_HOST", "https://searx.example")
+    monkeypatch.setattr(searxng.httpx, "AsyncClient", lambda **kw: _Client())
+
+    with caplog.at_level(logging.WARNING, logger=searxng.logger.name):
+        assert await searxng._fetch_json({"q": "x"}) is None
+    assert "search.formats" in caplog.text
 
 
 async def test_google_success_is_unstamped_and_untouched(monkeypatch, searxng_up):

--- a/surfsense_backend/tests/unit/platforms/google_search/test_searxng_fallback.py
+++ b/surfsense_backend/tests/unit/platforms/google_search/test_searxng_fallback.py
@@ -63,7 +63,8 @@ async def test_fallback_serves_organic_results(walled_google, searxng_up):
     assert item["resultsTotal"] is None
     # Provenance survives to_output() so no consumer can mistake this for Google.
     assert item["resultsProvider"] == "searxng"
-    assert item["searchQuery"]["domain"] == "searx.example"
+    # The provider label, not the configured host.
+    assert item["searchQuery"]["domain"] == "searxng"
     assert item["searchQuery"]["term"] == "apple pie"
 
 

--- a/surfsense_backend/tests/unit/platforms/google_search/test_searxng_fallback.py
+++ b/surfsense_backend/tests/unit/platforms/google_search/test_searxng_fallback.py
@@ -1,0 +1,134 @@
+"""Offline checks for the SearXNG last-resort fallback.
+
+Google is stubbed as fully walled (``fetch_serp_html`` -> ``None``) and the
+aggregator's HTTP call is stubbed, so this exercises the real wiring: when the
+fallback fires, what it maps, and the cases where it must stay silent.
+"""
+
+import pytest
+
+from app.proprietary.platforms.google_search import (
+    GoogleSearchScrapeInput,
+    scraper,
+    searxng,
+)
+
+pytestmark = pytest.mark.unit
+
+_PAYLOAD = {
+    "results": [
+        {
+            "title": "Pie Guide",
+            "url": "https://pies.example/guide",
+            "content": "How to bake.",
+        },
+        {"title": "No URL here", "content": "dropped"},
+    ],
+    "suggestions": ["easy pie"],
+}
+
+
+@pytest.fixture
+def walled_google(monkeypatch):
+    async def _none(url, *, mobile=False):
+        return None
+
+    monkeypatch.setattr(scraper, "fetch_serp_html", _none)
+
+
+@pytest.fixture
+def searxng_up(monkeypatch):
+    async def _payload(params):
+        return _PAYLOAD
+
+    monkeypatch.setattr(searxng, "_HOST", "https://searx.example")
+    monkeypatch.setattr(searxng, "_fetch_json", _payload)
+
+
+async def test_fallback_serves_organic_results(walled_google, searxng_up):
+    items = await scraper.scrape_serps(GoogleSearchScrapeInput(queries="apple pie"))
+
+    assert len(items) == 1
+    item = items[0]
+    # URL-less entries are dropped, and positions stay 1-based and contiguous.
+    assert [(r["position"], r["url"]) for r in item["organicResults"]] == [
+        (1, "https://pies.example/guide")
+    ]
+    assert item["organicResults"][0]["description"] == "How to bake."
+    assert item["suggestedResults"][0]["title"] == "easy pie"
+    # Google-only blocks stay empty rather than being faked.
+    assert item["paidResults"] == []
+    assert item["peopleAlsoAsk"] == []
+    assert item["aiOverview"] is None
+    assert item["resultsTotal"] is None
+    # Provenance survives to_output() so no consumer can mistake this for Google.
+    assert item["resultsProvider"] == "searxng"
+    assert item["searchQuery"]["domain"] == "searx.example"
+    assert item["searchQuery"]["term"] == "apple pie"
+
+
+async def test_fallback_query_folds_only_supported_operators(
+    walled_google, monkeypatch
+):
+    seen: dict = {}
+
+    async def _capture(params):
+        seen.update(params)
+        return _PAYLOAD
+
+    monkeypatch.setattr(searxng, "_HOST", "https://searx.example")
+    monkeypatch.setattr(searxng, "_fetch_json", _capture)
+
+    await scraper.scrape_serps(
+        GoogleSearchScrapeInput(
+            queries="apple pie",
+            site="pies.example",
+            forceExactMatch=True,
+            wordsInTitle=["easy"],
+            fileTypes=["pdf"],
+            languageCode="en",
+            quickDateRange="w",
+        )
+    )
+    # site: and exact-match survive; intitle:/filetype: would zero out the
+    # aggregator's engines, so they are dropped.
+    assert seen["q"] == '"apple pie" site:pies.example'
+    assert seen["language"] == "en"
+    assert seen["time_range"] == "week"
+
+
+async def test_no_fallback_when_disabled(walled_google, monkeypatch):
+    monkeypatch.setattr(searxng, "_HOST", "")
+    assert await scraper.scrape_serps(GoogleSearchScrapeInput(queries="q")) == []
+
+
+async def test_no_fallback_when_ads_requested(walled_google, searxng_up):
+    items = await scraper.scrape_serps(
+        GoogleSearchScrapeInput(queries="car insurance", focusOnPaidAds=True)
+    )
+    assert items == []
+
+
+async def test_no_fallback_for_url_without_readable_query(walled_google, searxng_up):
+    # A Google URL whose ``q`` cannot be read has no term to re-search.
+    items = await scraper.scrape_serps(
+        GoogleSearchScrapeInput(queries="https://www.google.com/search")
+    )
+    assert items == []
+
+
+async def test_google_success_is_unstamped_and_untouched(monkeypatch, searxng_up):
+    async def _html(url, *, mobile=False):
+        return (
+            '<html><body><div id="rso">'
+            '<div class="tF2Cxc"><a href="https://x.example/a"><h3>Organic</h3></a>'
+            "</div></div></body></html>"
+        )
+
+    monkeypatch.setattr(scraper, "fetch_serp_html", _html)
+
+    items = await scraper.scrape_serps(GoogleSearchScrapeInput(queries="apple pie"))
+    assert len(items) == 1
+    assert items[0]["searchQuery"]["domain"] == "google.com"
+    assert items[0]["searchQuery"]["url"].startswith("https://www.google.com/search")
+    assert "resultsProvider" not in items[0]

--- a/surfsense_web/content/docs/how-to/web-search.mdx
+++ b/surfsense_web/content/docs/how-to/web-search.mdx
@@ -21,18 +21,31 @@ When the assistant decides a request needs the open web:
 2. The specialist runs a Google search and returns ranked result items (title, URL, snippet).
 3. The assistant summarizes the findings and can follow up by crawling a specific result page.
 
-## Optional SearXNG fallback
+## SearXNG fallback
 
-Google occasionally walls every proxy exit, in which case a search returns nothing. You can point the scraper at a SearXNG instance to serve organic results as a last resort:
+Google occasionally walls every exit IP, in which case a search would return nothing. The Docker stack bundles a [SearXNG](https://docs.searxng.org/) container that serves organic results as a last resort in that case. It works out of the box — there is nothing to configure.
+
+It only fires after Google's own retry ladder is exhausted, and it only serves organic results plus query suggestions. Ads, People Also Ask, AI Overviews, and result totals are Google-only and come back empty, so requests that specifically ask for paid ads are never served from the fallback. Fallback pages are tagged with `resultsProvider: "searxng"` and are not billed at the Google SERP rate.
+
+The container is internal-only in production. The dev and deps-only stacks publish its UI on `http://localhost:8888` (`SEARXNG_PORT`) if you want to query it directly.
+
+### Configuration
 
 | Variable | Value |
 |----------|-------|
-| `SEARXNG_FALLBACK_URL` | Base URL of your instance, e.g. `https://searx.example.org` (unset = fallback off) |
+| `SEARXNG_FALLBACK_URL` | Where the scraper looks. Compose sets it to the bundled service; set it empty to turn the fallback off, or to another base URL to use your own instance |
 | `SEARXNG_FALLBACK_TIMEOUT_S` | Request timeout in seconds (default `10`) |
+| `SEARXNG_SECRET` | Session secret for the bundled container |
 
-Your instance must expose the JSON API — add `json` to `search.formats` in its `settings.yml`, or every fallback request is refused with HTTP 403.
+The instance's own settings live in `docker/searxng/settings.yml`. Two entries there are load-bearing. `search.formats` includes `json`, which is the API the scraper calls — remove it and every request comes back **HTTP 403**, with no environment variable to re-enable it. And the `google` engine is disabled on purpose: this instance only runs after Google walled you, so querying Google again from the same address is self-defeating. DuckDuckGo, Brave, Bing, and Wikipedia tolerate server IPs far better and are what make the fallback useful.
 
-The fallback only fires after Google's own retry ladder is exhausted, and it only serves organic results plus query suggestions. Ads, People Also Ask, AI Overviews, and result totals are Google-only and come back empty, so requests that specifically ask for paid ads are never served from the fallback. Fallback pages are tagged with `resultsProvider: "searxng"` and are not billed at the Google SERP rate.
+SearXNG reads that file only at startup, so restart the container after editing it.
+
+### Using your own instance
+
+Point `SEARXNG_FALLBACK_URL` at it and, if you like, remove the `searxng` service from your compose file. Your instance must have `json` in `search.formats` for the same reason as above; if it does not, SurfSense logs the 403 and names the setting.
+
+Nothing depends on the service being healthy, so a SearXNG that is down or misconfigured degrades searches to Google alone rather than blocking the stack.
 
 <Callout type="warn" title="Not the SearXNG connector">
 This is an operator-level setting for the Google Search scraper. The **SearXNG connector** remains deprecated and still cannot be connected.

--- a/surfsense_web/content/docs/how-to/web-search.mdx
+++ b/surfsense_web/content/docs/how-to/web-search.mdx
@@ -21,6 +21,23 @@ When the assistant decides a request needs the open web:
 2. The specialist runs a Google search and returns ranked result items (title, URL, snippet).
 3. The assistant summarizes the findings and can follow up by crawling a specific result page.
 
+## Optional SearXNG fallback
+
+Google occasionally walls every proxy exit, in which case a search returns nothing. You can point the scraper at a SearXNG instance to serve organic results as a last resort:
+
+| Variable | Value |
+|----------|-------|
+| `SEARXNG_FALLBACK_URL` | Base URL of your instance, e.g. `https://searx.example.org` (unset = fallback off) |
+| `SEARXNG_FALLBACK_TIMEOUT_S` | Request timeout in seconds (default `10`) |
+
+Your instance must expose the JSON API — add `json` to `search.formats` in its `settings.yml`, or every fallback request is refused with HTTP 403.
+
+The fallback only fires after Google's own retry ladder is exhausted, and it only serves organic results plus query suggestions. Ads, People Also Ask, AI Overviews, and result totals are Google-only and come back empty, so requests that specifically ask for paid ads are never served from the fallback. Fallback pages are tagged with `resultsProvider: "searxng"` and are not billed at the Google SERP rate.
+
+<Callout type="warn" title="Not the SearXNG connector">
+This is an operator-level setting for the Google Search scraper. The **SearXNG connector** remains deprecated and still cannot be connected.
+</Callout>
+
 Google web search is workspace-scoped and is not available in the free / anonymous (no-login) chat, which answers purely from the model's own knowledge.
 
 ## Still want Tavily or Linkup?

--- a/surfsense_web/content/docs/how-to/web-search.mdx
+++ b/surfsense_web/content/docs/how-to/web-search.mdx
@@ -33,8 +33,8 @@ The container is internal-only in production. The dev and deps-only stacks publi
 
 | Variable | Value |
 |----------|-------|
-| `SEARXNG_FALLBACK_URL` | Where the scraper looks. Compose sets it to the bundled service; set it empty to turn the fallback off, or to another base URL to use your own instance |
-| `SEARXNG_FALLBACK_TIMEOUT_S` | Request timeout in seconds (default `10`) |
+| `SEARXNG_URL` | Where the scraper looks. Compose sets it to the bundled service; set it empty to turn the fallback off, or to another base URL to use your own instance |
+| `SEARXNG_TIMEOUT_S` | Request timeout in seconds (default `10`) |
 | `SEARXNG_SECRET` | Session secret for the bundled container |
 
 The instance's own settings live in `docker/searxng/settings.yml`. Two entries there are load-bearing. `search.formats` includes `json`, which is the API the scraper calls — remove it and every request comes back **HTTP 403**, with no environment variable to re-enable it. And the `google` engine is disabled on purpose: this instance only runs after Google walled you, so querying Google again from the same address is self-defeating. DuckDuckGo, Brave, Bing, and Wikipedia tolerate server IPs far better and are what make the fallback useful.
@@ -43,7 +43,7 @@ SearXNG reads that file only at startup, so restart the container after editing 
 
 ### Using your own instance
 
-Point `SEARXNG_FALLBACK_URL` at it and, if you like, remove the `searxng` service from your compose file. Your instance must have `json` in `search.formats` for the same reason as above; if it does not, SurfSense logs the 403 and names the setting.
+Point `SEARXNG_URL` at it and, if you like, remove the `searxng` service from your compose file. Your instance must have `json` in `search.formats` for the same reason as above; if it does not, SurfSense logs the 403 and names the setting.
 
 Nothing depends on the service being healthy, so a SearXNG that is down or misconfigured degrades searches to Google alone rather than blocking the stack.
 
@@ -80,4 +80,4 @@ The following connectors are deprecated. Existing rows remain readable/manageabl
 - **Tavily** — add via Custom MCP connector (see above).
 - **Linkup** — add via Custom MCP connector (see above).
 - **Baidu Search** — no longer bundled; use the built-in Google Search or a Custom MCP connector for a provider of your choice.
-- **SearXNG** — the bundled SearXNG container and its `SEARXNG_*` environment variables have been removed from all Docker Compose files.
+- **SearXNG** — no longer a connectable source. The bundled `searxng` container still ships, but serves only as the Google Search scraper's fallback (see above).


### PR DESCRIPTION
<!--- Summarize your pull request in a few sentences -->

## Description
<!--- Clearly describe what has changed in this pull request -->
- When Google walls or captchas every proxy IP, `fetch_serp_html` returns nothing and the scraper drops that page and stops paging. This adds a bundled SearXNG instance as a last-resort provider so a walled run returns organic results instead of an empty one.
- New `platforms/google_search/searxng.py` queries the instance's JSON API and builds a `SerpItem` directly, translating only what SearXNG actually honors: `site:`, exact-match quoting, `languageCode` → `language`, and plain `quickDateRange` units → `time_range`. Compound codes like `m6` are dropped rather than approximated, and results are capped at 10 so a fallback page never looks anomalously large to a caller that is paging.
- Wired in at `_serp_page_flow`, the single seam every caller shares, so REST, MCP, the playground, and the chat subagent all get the fallback without surface-specific code.
- Skipped when it could only produce a guaranteed miss: `focusOnPaidAds` (aggregators serve no ads), a URL whose `q` could not be read, or no `SEARXNG_URL` configured — in which case behavior is exactly as before.
- Fallback pages are labelled rather than passed off as Google: items carry `resultsProvider: "searxng"`, and `_search_query_stamp` gained a `domain` override so `searchQuery.domain` reads `searxng` instead of claiming `google.com`. The label is the provider name, not the configured host, which is usually a private address that should not reach API output.
- `billable_units` now skips items carrying `resultsProvider`. A fallback page costs no proxy render and no captcha solve, so it is not charged at the Google SERP rate; the pre-flight gate still reserves worst case, since a fallback cannot be predicted before trying.
- The `google_search` subagent prompt now requires disclosing fallback provenance and forbids describing those items as Google rankings or positions.
- Restores the `searxng` service to the prod, dev, and deps-only stacks on a pinned image with a healthcheck, and injects `SEARXNG_URL` (default `http://searxng:8080`) into `backend` and `celery_worker`. Deliberately no `depends_on`, so an unhealthy SearXNG can never block backend startup — it is a fallback, not a dependency.
- Adds `docker/searxng/settings.yml` and `limiter.toml`. Two entries there are load-bearing: `json` in `search.formats`, without which every fallback request 403s, and the `google` engine explicitly disabled, since this instance only runs after Google walled us and would query it from the same address.
- `install.sh` and `install.ps1` create the `searxng/` directory and fetch both config files, so a fresh self-hosted install is complete.
- Both `.env.example` files document `SEARXNG_URL` and `SEARXNG_TIMEOUT_S` with how to point at an external instance or disable the fallback, plus `SEARXNG_PORT` for the port the dev and deps-only stacks expose.
- `web-search.mdx` documents the bundled fallback and corrects the stale note claiming SearXNG was removed entirely.
- Two diagnostics for the failure modes that were previously silent: a warning when the unproxied single render path gives up, and a 403 from SearXNG that names the exact `settings.yml` knob to fix.
- Covered by 7 offline tests: results served, operator folding, disabled, ads-requested, unreadable query, the 403 log, and a Google success left unstamped and untouched. Verified end to end through the playground with Google forced to fail, confirming the three-stage log trail and `resultsProvider` reaching the run payload.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If this PR relates to an open issue, please link to the issue here: FIX #123 -->
FIX #


## Screenshots
<!-- If applicable, add screenshots or images to demonstrate the changes visually -->

## API Changes
<!-- Document any API changes if applicable -->
- [ ] This PR includes API changes

## Change Type
<!--- Indicate what kind(s) of changes this PR includes: -->
- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Dependency/Build system
- [ ] Breaking change
- [ ] Other (specify):

## Testing Performed
<!--- Briefly describe how you have tested these changes and what verification was performed -->
- [ ] Tested locally
- [ ] Manual/QA verification

## Checklist
<!--- Please confirm the following by marking with an 'x' as appropriate -->
- [ ] Follows project coding standards and conventions
- [ ] Documentation updated as needed
- [ ] Dependencies updated as needed
- [ ] No lint/build errors or new warnings
- [ ] All relevant tests are passing

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds an optional SearXNG fallback mechanism for the Google Search scraper to provide organic search results when Google walls all proxy IPs. The fallback is controlled via environment variables (`SEARXNG_FALLBACK_URL` and timeout settings) and only activates after Google's retry attempts are exhausted. Fallback results are tagged with `resultsProvider: "searxng"` to distinguish them from native Google results, and they are not billed at the Google SERP rate. The implementation includes Docker configuration files for running a SearXNG instance, core fallback logic that maps aggregator responses to the existing `SerpItem` schema (organic results and suggestions only, no ads or PAA), and comprehensive unit tests to verify the fallback wiring and edge cases.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/content/docs/how-to/web-search.mdx` |
| 2 | `docker/searxng/settings.yml` |
| 3 | `docker/searxng/limiter.toml` |
| 4 | `surfsense_backend/app/proprietary/platforms/google_search/searxng.py` |
| 5 | `surfsense_backend/app/proprietary/platforms/google_search/scraper.py` |
| 6 | `surfsense_backend/app/capabilities/google_search/scrape/schemas.py` |
| 7 | `surfsense_backend/app/agents/chat/multi_agent_chat/subagents/builtins/google_search/system_prompt.md` |
| 8 | `surfsense_backend/tests/unit/platforms/google_search/test_searxng_fallback.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->