### PR TITLE
Feat: adjust max file size to have customizable limit

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -93,6 +93,10 @@ CERT_EMAIL=
 # If a CDN/load balancer sits in front of Caddy, narrow this to that proxy's CIDRs.
 # TRUSTED_PROXIES=0.0.0.0/0
 # SURFSENSE_MAX_BODY_SIZE=5GB
+# Per-file cap for authenticated document uploads (MB). Keep it at or below
+# SURFSENSE_MAX_BODY_SIZE above, which limits the whole request at the proxy.
+# Passed to both the backend (enforcement) and the frontend (pre-upload check).
+# MAX_FILE_SIZE_MB=500
 #
 # Browser API and Zero URLs are same-origin relative behind bundled Caddy.
 # Next.js server-side calls use Docker DNS through SURFSENSE_BACKEND_INTERNAL_URL

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -127,6 +127,7 @@ services:
       - NEXT_FRONTEND_URL=${NEXT_FRONTEND_URL:-http://localhost:3000}
       - WHATSAPP_BRIDGE_URL=${WHATSAPP_BRIDGE_URL:-http://whatsapp-bridge:9929}
       - SEARXNG_URL=${SEARXNG_URL:-http://searxng:8080}
+      - MAX_FILE_SIZE_MB=${MAX_FILE_SIZE_MB:-500}
       # Daytona Sandbox – uncomment and set credentials to enable cloud code execution
       # - DAYTONA_SANDBOX_ENABLED=TRUE
       # - DAYTONA_API_KEY=${DAYTONA_API_KEY:-}
@@ -268,6 +269,7 @@ services:
       ETL_SERVICE: ${ETL_SERVICE:-DOCLING}
       DEPLOYMENT_MODE: ${DEPLOYMENT_MODE:-self-hosted}
       SURFSENSE_BACKEND_INTERNAL_URL: http://backend:8000
+      MAX_FILE_SIZE_MB: ${MAX_FILE_SIZE_MB:-500}
     depends_on:
       backend:
         condition: service_healthy

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -148,6 +148,7 @@ services:
       BACKEND_URL: ${BACKEND_URL:-${SURFSENSE_PUBLIC_URL:-http://localhost:${LISTEN_HTTP_PORT:-3929}}}
       WHATSAPP_BRIDGE_URL: ${WHATSAPP_BRIDGE_URL:-http://whatsapp-bridge:9929}
       SEARXNG_URL: ${SEARXNG_URL:-http://searxng:8080}
+      MAX_FILE_SIZE_MB: ${MAX_FILE_SIZE_MB:-500}
       # Daytona Sandbox – uncomment and set credentials to enable cloud code execution
       # DAYTONA_SANDBOX_ENABLED: "TRUE"
       # DAYTONA_API_KEY: ${DAYTONA_API_KEY:-}
@@ -295,6 +296,7 @@ services:
       ETL_SERVICE: ${ETL_SERVICE:-DOCLING}
       DEPLOYMENT_MODE: ${DEPLOYMENT_MODE:-self-hosted}
       SURFSENSE_BACKEND_INTERNAL_URL: http://backend:8000
+      MAX_FILE_SIZE_MB: ${MAX_FILE_SIZE_MB:-500}
     labels:
       - "com.centurylinklabs.watchtower.enable=true"
     depends_on:

--- a/surfsense_backend/.env.example
+++ b/surfsense_backend/.env.example
@@ -457,8 +457,8 @@ TURNSTILE_SECRET_KEY=
 # (empty to headless Chromium). Entrypoint starts Xvfb when TRUE.
 # CRAWL_HEADED_XVFB_ENABLED=FALSE
 
-# File Parser Service
-ETL_SERVICE=UNSTRUCTURED or LLAMACLOUD or DOCLING
+# File Parser Service: DOCLING, UNSTRUCTURED, or LLAMACLOUD
+ETL_SERVICE=DOCLING
 UNSTRUCTURED_API_KEY=Tpu3P0U8iy
 LLAMA_CLOUD_API_KEY=llx-nnn
 # Optional: Azure Document Intelligence accelerator (used when ETL_SERVICE=LLAMACLOUD)

--- a/surfsense_backend/.env.example
+++ b/surfsense_backend/.env.example
@@ -469,6 +469,11 @@ LLAMA_CLOUD_API_KEY=llx-nnn
 # Where to persist the original bytes of uploaded documents (for download today,
 # redaction / form-filling later). "local" needs no cloud creds and is the dev default.
 FILE_STORAGE_BACKEND=local
+# Per-file upload cap (MB). Raise this for self-hosted deployments with the
+# hardware to handle larger documents. Keep it at or below the proxy's
+# SURFSENSE_MAX_BODY_SIZE (see docker/.env.example) or large uploads will be
+# rejected by Caddy before reaching the backend.
+# MAX_FILE_SIZE_MB=500
 # Local backend: directory for stored files (defaults to surfsense_backend/.local_object_store)
 # FILE_STORAGE_LOCAL_PATH=/var/lib/surfsense/object-store
 # Azure Blob backend (set FILE_STORAGE_BACKEND=azure):

--- a/surfsense_backend/app/routes/documents_routes.py
+++ b/surfsense_backend/app/routes/documents_routes.py
@@ -56,7 +56,10 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
-MAX_FILE_SIZE_BYTES = 500 * 1024 * 1024  # 500 MB per file
+# Per-file upload cap. Operators raise MAX_FILE_SIZE_MB when self-hosting on
+# hardware that can take it; the frontend reads the same value for its
+# pre-upload check.
+MAX_FILE_SIZE_BYTES = int(os.getenv("MAX_FILE_SIZE_MB", "500")) * 1024 * 1024
 
 
 @router.post("/documents")

--- a/surfsense_backend/app/routes/documents_routes.py
+++ b/surfsense_backend/app/routes/documents_routes.py
@@ -59,7 +59,22 @@ router = APIRouter()
 # Per-file upload cap. Operators raise MAX_FILE_SIZE_MB when self-hosting on
 # hardware that can take it; the frontend reads the same value for its
 # pre-upload check.
-MAX_FILE_SIZE_BYTES = int(os.getenv("MAX_FILE_SIZE_MB", "500")) * 1024 * 1024
+def _resolve_max_file_size_mb(default: int = 500) -> int:
+    raw = os.getenv("MAX_FILE_SIZE_MB", "").strip()
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning("Invalid MAX_FILE_SIZE_MB=%r, falling back to %d MB", raw, default)
+        return default
+    if value <= 0:
+        logger.warning("MAX_FILE_SIZE_MB must be positive, got %d, falling back to %d MB", value, default)
+        return default
+    return value
+
+
+MAX_FILE_SIZE_BYTES = _resolve_max_file_size_mb() * 1024 * 1024
 
 
 @router.post("/documents")

--- a/surfsense_backend/app/routes/documents_routes.py
+++ b/surfsense_backend/app/routes/documents_routes.py
@@ -56,6 +56,7 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
+
 # Per-file upload cap. Operators raise MAX_FILE_SIZE_MB when self-hosting on
 # hardware that can take it; the frontend reads the same value for its
 # pre-upload check.
@@ -66,10 +67,16 @@ def _resolve_max_file_size_mb(default: int = 500) -> int:
     try:
         value = int(raw)
     except ValueError:
-        logger.warning("Invalid MAX_FILE_SIZE_MB=%r, falling back to %d MB", raw, default)
+        logger.warning(
+            "Invalid MAX_FILE_SIZE_MB=%r, falling back to %d MB", raw, default
+        )
         return default
     if value <= 0:
-        logger.warning("MAX_FILE_SIZE_MB must be positive, got %d, falling back to %d MB", value, default)
+        logger.warning(
+            "MAX_FILE_SIZE_MB must be positive, got %d, falling back to %d MB",
+            value,
+            default,
+        )
         return default
     return value
 

--- a/surfsense_backend/tests/integration/document_upload/test_upload_limits.py
+++ b/surfsense_backend/tests/integration/document_upload/test_upload_limits.py
@@ -1,8 +1,11 @@
 """
 Integration tests for backend file upload limit enforcement.
 
-These tests verify that the API rejects uploads that exceed:
-  - Max per-file size (500 MB)
+These tests verify that the API rejects uploads that exceed the per-file
+size cap. The cap is configurable via MAX_FILE_SIZE_MB (default 500 MB),
+so tests derive their sizes from the value the app actually resolved at
+import time rather than hardcoding it — otherwise this suite fails for
+anyone who has MAX_FILE_SIZE_MB set in their environment.
 
 No file count or total size limits are enforced — the frontend batches
 uploads in groups of 5 and there is no cap on how many files a user can
@@ -19,16 +22,18 @@ import io
 import httpx
 import pytest
 
+from app.routes.documents_routes import MAX_FILE_SIZE_BYTES
+
 pytestmark = pytest.mark.integration
 
 
 # ---------------------------------------------------------------------------
-# Test: Per-file size limit (500 MB)
+# Test: Per-file size limit
 # ---------------------------------------------------------------------------
 
 
 class TestPerFileSizeLimit:
-    """A single file exceeding 500 MB should be rejected."""
+    """A single file exceeding MAX_FILE_SIZE_BYTES should be rejected."""
 
     async def test_oversized_file_returns_413(
         self,
@@ -36,7 +41,7 @@ class TestPerFileSizeLimit:
         headers: dict[str, str],
         workspace_id: int,
     ):
-        oversized = io.BytesIO(b"\x00" * (500 * 1024 * 1024 + 1))
+        oversized = io.BytesIO(b"\x00" * (MAX_FILE_SIZE_BYTES + 1))
         resp = await client.post(
             "/api/v1/documents/fileupload",
             headers=headers,
@@ -53,11 +58,11 @@ class TestPerFileSizeLimit:
         workspace_id: int,
         cleanup_doc_ids: list[int],
     ):
-        at_limit = io.BytesIO(b"\x00" * (500 * 1024 * 1024))
+        at_limit = io.BytesIO(b"\x00" * MAX_FILE_SIZE_BYTES)
         resp = await client.post(
             "/api/v1/documents/fileupload",
             headers=headers,
-            files=[("files", ("exact500mb.txt", at_limit, "text/plain"))],
+            files=[("files", ("exactlimit.txt", at_limit, "text/plain"))],
             data={"workspace_id": str(workspace_id)},
         )
         assert resp.status_code == 200

--- a/surfsense_web/components/providers/runtime-config.server.tsx
+++ b/surfsense_web/components/providers/runtime-config.server.tsx
@@ -6,6 +6,21 @@ import {
 	BUILD_TIME_ETL_SERVICE,
 } from "@/lib/env-config";
 
+// Per-file upload cap. Falls back to 500 on unset, empty, or malformed
+// MAX_FILE_SIZE_MB so an operator typo can't zero out uploads (empty string)
+// or silently disable the pre-upload check (NaN).
+function resolveMaxFileSizeMB(defaultValue = 500): number {
+	const raw = process.env.MAX_FILE_SIZE_MB?.trim() ?? "";
+	if (!raw) return defaultValue;
+
+	const parsed = Number.parseInt(raw, 10);
+	if (!Number.isFinite(parsed) || parsed <= 0) {
+		console.warn(`Invalid MAX_FILE_SIZE_MB="${raw}", falling back to ${defaultValue} MB`);
+		return defaultValue;
+	}
+	return parsed;
+}
+
 export async function RuntimeConfig({ children }: { children: React.ReactNode }) {
 	await connection();
 
@@ -13,7 +28,7 @@ export async function RuntimeConfig({ children }: { children: React.ReactNode })
 		authType: process.env.AUTH_TYPE ?? BUILD_TIME_AUTH_TYPE,
 		etlService: process.env.ETL_SERVICE ?? BUILD_TIME_ETL_SERVICE,
 		deploymentMode: process.env.DEPLOYMENT_MODE ?? BUILD_TIME_DEPLOYMENT_MODE,
-		maxFileSizeMB: Number(process.env.MAX_FILE_SIZE_MB ?? "500")
+		maxFileSizeMB: resolveMaxFileSizeMB(),
 	};
 
 	return <RuntimeConfigProvider value={value}>{children}</RuntimeConfigProvider>;

--- a/surfsense_web/components/providers/runtime-config.server.tsx
+++ b/surfsense_web/components/providers/runtime-config.server.tsx
@@ -13,6 +13,7 @@ export async function RuntimeConfig({ children }: { children: React.ReactNode })
 		authType: process.env.AUTH_TYPE ?? BUILD_TIME_AUTH_TYPE,
 		etlService: process.env.ETL_SERVICE ?? BUILD_TIME_ETL_SERVICE,
 		deploymentMode: process.env.DEPLOYMENT_MODE ?? BUILD_TIME_DEPLOYMENT_MODE,
+		maxFileSizeMB: Number(process.env.MAX_FILE_SIZE_MB ?? "500")
 	};
 
 	return <RuntimeConfigProvider value={value}>{children}</RuntimeConfigProvider>;

--- a/surfsense_web/components/providers/runtime-config.tsx
+++ b/surfsense_web/components/providers/runtime-config.tsx
@@ -9,6 +9,7 @@ export interface RuntimeConfigValue {
 	authType: AuthType;
 	etlService: string;
 	deploymentMode: DeploymentMode;
+	maxFileSizeMB: number;
 }
 
 const RuntimeConfigContext = createContext<RuntimeConfigValue | null>(null);

--- a/surfsense_web/components/sources/DocumentUploadTab.tsx
+++ b/surfsense_web/components/sources/DocumentUploadTab.tsx
@@ -121,8 +121,7 @@ function flattenTree(
 const FOLDER_BATCH_SIZE_BYTES = 20 * 1024 * 1024;
 const FOLDER_BATCH_MAX_FILES = 10;
 
-const MAX_FILE_SIZE_MB = 500;
-const MAX_FILE_SIZE_BYTES = MAX_FILE_SIZE_MB * 1024 * 1024;
+
 
 const toggleRowClass =
 	"flex items-center justify-between rounded-lg bg-slate-400/5 dark:bg-white/5 p-3";
@@ -133,7 +132,7 @@ export function DocumentUploadTab({
 	onAccordionStateChange,
 }: DocumentUploadTabProps) {
 	const t = useTranslations("upload_documents");
-	const { etlService } = useRuntimeConfig();
+	const { etlService, maxFileSizeMB } = useRuntimeConfig();
 	const [files, setFiles] = useState<FileWithId[]>([]);
 	const [uploadProgress, setUploadProgress] = useState(0);
 	const [accordionValue, setAccordionValue] = useState<string>("");
@@ -146,7 +145,8 @@ export function DocumentUploadTab({
 	const progressIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 	const [folderUpload, setFolderUpload] = useState<FolderUploadData | null>(null);
 	const [isFolderUploading, setIsFolderUploading] = useState(false);
-
+	const MAX_FILE_SIZE_BYTES = maxFileSizeMB * 1024 * 1024;
+	
 	useEffect(() => {
 		return () => {
 			if (progressIntervalRef.current) {
@@ -175,7 +175,7 @@ export function DocumentUploadTab({
 				toast.error(t("file_too_large"), {
 					description: t("file_too_large_desc", {
 						name: oversized[0].name,
-						maxMB: MAX_FILE_SIZE_MB,
+						maxMB: maxFileSizeMB,
 					}),
 				});
 			}
@@ -191,7 +191,7 @@ export function DocumentUploadTab({
 				return [...prev, ...newEntries];
 			});
 		},
-		[t]
+		[t, MAX_FILE_SIZE_BYTES, maxFileSizeMB]
 	);
 
 	const onDrop = useCallback(

--- a/surfsense_web/components/sources/DocumentUploadTab.tsx
+++ b/surfsense_web/components/sources/DocumentUploadTab.tsx
@@ -121,8 +121,6 @@ function flattenTree(
 const FOLDER_BATCH_SIZE_BYTES = 20 * 1024 * 1024;
 const FOLDER_BATCH_MAX_FILES = 10;
 
-
-
 const toggleRowClass =
 	"flex items-center justify-between rounded-lg bg-slate-400/5 dark:bg-white/5 p-3";
 
@@ -145,8 +143,8 @@ export function DocumentUploadTab({
 	const progressIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 	const [folderUpload, setFolderUpload] = useState<FolderUploadData | null>(null);
 	const [isFolderUploading, setIsFolderUploading] = useState(false);
-	const MAX_FILE_SIZE_BYTES = maxFileSizeMB * 1024 * 1024;
-	
+	const MAX_FILE_SIZE_BYTES = useMemo(() => maxFileSizeMB * 1024 * 1024, [maxFileSizeMB]);
+
 	useEffect(() => {
 		return () => {
 			if (progressIntervalRef.current) {
@@ -191,7 +189,7 @@ export function DocumentUploadTab({
 				return [...prev, ...newEntries];
 			});
 		},
-		[t, MAX_FILE_SIZE_BYTES, maxFileSizeMB]
+		[t, maxFileSizeMB]
 	);
 
 	const onDrop = useCallback(

--- a/surfsense_web/components/sources/DocumentUploadTab.tsx
+++ b/surfsense_web/components/sources/DocumentUploadTab.tsx
@@ -143,7 +143,7 @@ export function DocumentUploadTab({
 	const progressIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 	const [folderUpload, setFolderUpload] = useState<FolderUploadData | null>(null);
 	const [isFolderUploading, setIsFolderUploading] = useState(false);
-	const MAX_FILE_SIZE_BYTES = useMemo(() => maxFileSizeMB * 1024 * 1024, [maxFileSizeMB]);
+	const maxFileSizeBytes = useMemo(() => maxFileSizeMB * 1024 * 1024, [maxFileSizeMB]);
 
 	useEffect(() => {
 		return () => {
@@ -168,7 +168,7 @@ export function DocumentUploadTab({
 
 	const addFiles = useCallback(
 		(incoming: File[]) => {
-			const oversized = incoming.filter((f) => f.size > MAX_FILE_SIZE_BYTES);
+			const oversized = incoming.filter((f) => f.size > maxFileSizeBytes);
 			if (oversized.length > 0) {
 				toast.error(t("file_too_large"), {
 					description: t("file_too_large_desc", {
@@ -177,7 +177,7 @@ export function DocumentUploadTab({
 					}),
 				});
 			}
-			const valid = incoming.filter((f) => f.size <= MAX_FILE_SIZE_BYTES);
+			const valid = incoming.filter((f) => f.size <= maxFileSizeBytes);
 			if (valid.length === 0) return;
 
 			setFolderUpload(null);
@@ -189,7 +189,7 @@ export function DocumentUploadTab({
 				return [...prev, ...newEntries];
 			});
 		},
-		[t, maxFileSizeMB]
+		[t, maxFileSizeMB, maxFileSizeBytes]
 	);
 
 	const onDrop = useCallback(
@@ -202,7 +202,7 @@ export function DocumentUploadTab({
 	const { getRootProps, getInputProps, isDragActive } = useDropzone({
 		onDrop,
 		accept: acceptedFileTypes,
-		maxSize: MAX_FILE_SIZE_BYTES,
+		maxSize: maxFileSizeBytes,
 		noClick: isElectron,
 	});
 

--- a/surfsense_web/lib/error-toast.ts
+++ b/surfsense_web/lib/error-toast.ts
@@ -1,6 +1,6 @@
 import { toast } from "sonner";
-import { AbortedError, AppError, AuthenticationError, SURFSENSE_ISSUES_URL } from "./error";
 import { detectEnvironment } from "./env-config";
+import { AbortedError, AppError, AuthenticationError, SURFSENSE_ISSUES_URL } from "./error";
 
 /**
  * Build a GitHub issue URL pre-filled with diagnostic context.


### PR DESCRIPTION
## Summary
Makes the 500MB per-file upload cap configurable via `MAX_FILE_SIZE_MB`
instead of hardcoded, so self-hosted operators can raise it for their
own hardware. Enforced on the backend; the frontend reads the same
value via runtime config so its pre-upload check stays in sync.

## Changes
- `adjust env example to a correct formatation, preventing error from direct copy` — fixes an invalid `ETL_SERVICE` placeholder in `surfsense_backend/.env.example` that broke a direct copy-paste setup.
- `add max file size env providing customizable limitation` — introduces `MAX_FILE_SIZE_MB`, wired through the backend cap and the frontend runtime config.

## Testing
Verified with `MAX_FILE_SIZE_MB` unset (default 500MB) and raised — in
both cases the frontend and backend limits stayed in sync, rejecting
files above the configured cap and accepting files within it end-to-end.
Confirmed the frontend keeps rejecting oversized files even after
raising the limit, until a file at or under the new cap is provided.

## Obs
No UI changes so it`s not out of my codebase knowledge...


<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR makes the 500MB per-file upload limit configurable through a new environment variable `MAX_FILE_SIZE_MB`, allowing self-hosted operators to adjust the cap based on their hardware capabilities. The change propagates the configurable limit through both backend enforcement and frontend pre-upload checks to keep them synchronized. Additionally, it fixes an invalid `ETL_SERVICE` placeholder in the backend environment example file that previously caused setup errors when copied directly.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `docker/.env.example` |
| 2 | `surfsense_backend/.env.example` |
| 3 | `docker/docker-compose.yml` |
| 4 | `docker/docker-compose.dev.yml` |
| 5 | `surfsense_backend/app/routes/documents_routes.py` |
| 6 | `surfsense_web/components/providers/runtime-config.server.tsx` |
| 7 | `surfsense_web/components/providers/runtime-config.tsx` |
| 8 | `surfsense_web/components/sources/DocumentUploadTab.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->