### PR TITLE
feat(model-connections): add LM Studio discovery, model input budgets, and provider-aware errors

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -558,6 +558,9 @@ NOLOGIN_MODE_ENABLED=FALSE
 # -- Redis exposed port (dev/deps-only only; Redis is internal-only in prod) --
 # REDIS_PORT=6379
 
+# -- SearXNG exposed port (dev/deps-only only; internal-only in prod) --
+# SEARXNG_PORT=8888
+
 # -- WhatsApp bridge exposed port (dev/hybrid only; prod keeps it Docker-internal) --
 # WHATSAPP_BRIDGE_PORT=9929
 

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -531,8 +531,8 @@ NOLOGIN_MODE_ENABLED=FALSE
 # searxng service. Works out of the box; nothing here needs setting.
 # Set empty to disable the fallback, or to another base URL to use your own
 # instance (which must have 'json' in search.formats, or requests get a 403).
-# SEARXNG_FALLBACK_URL=http://your-searxng:8080
-# SEARXNG_FALLBACK_TIMEOUT_S=10
+# SEARXNG_URL=http://your-searxng:8080
+# SEARXNG_TIMEOUT_S=10
 # SEARXNG_SECRET=surfsense-searxng-secret
 
 # Stealth hardening levers on the stealth browser tier. Defaults preserve

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -55,8 +55,10 @@ EMBEDDING_MODEL=sentence-transformers/all-MiniLM-L6-v2
 # EMBEDDING_BASE_URL=
 # OLLAMA_EMBEDDING_BASE_URL=
 
-# Context budget for a chat model no source can size -- not in LiteLLM's catalog,
-# no limit set in settings, and nothing reported by discovery.
+# Default max input tokens for a chat model no source can size -- not in
+# LiteLLM's catalog and nothing set in settings. Also caps what a locally
+# discovered model is seeded with, since a model's context length says nothing
+# about how much the host could actually allocate.
 # GEN_AI_MODEL_FALLBACK_MAX_TOKENS=32000
 
 # ------------------------------------------------------------------------------

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -59,7 +59,7 @@ EMBEDDING_MODEL=sentence-transformers/all-MiniLM-L6-v2
 # LiteLLM's catalog and nothing set in settings. Also caps what a locally
 # discovered model is seeded with, since a model's context length says nothing
 # about how much the host could actually allocate.
-# GEN_AI_MODEL_FALLBACK_MAX_TOKENS=32000
+# SURFSENSE_UNKNOWN_MODEL_MAX_INPUT_TOKENS=32000
 
 # ------------------------------------------------------------------------------
 # How You Access SurfSense

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -527,6 +527,14 @@ NOLOGIN_MODE_ENABLED=FALSE
 # CAPTCHA_V3_MIN_SCORE=0.7
 # CAPTCHA_V3_ACTION=verify
 
+# Last-resort fallback for the Google Search scraper, served by the bundled
+# searxng service. Works out of the box; nothing here needs setting.
+# Set empty to disable the fallback, or to another base URL to use your own
+# instance (which must have 'json' in search.formats, or requests get a 403).
+# SEARXNG_FALLBACK_URL=http://your-searxng:8080
+# SEARXNG_FALLBACK_TIMEOUT_S=10
+# SEARXNG_SECRET=surfsense-searxng-secret
+
 # Stealth hardening levers on the stealth browser tier. Defaults preserve
 # current behavior; see surfsense_backend/.env.example for per-flag docs.
 # CRAWL_GEOIP_MATCH_ENABLED=FALSE

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -55,6 +55,10 @@ EMBEDDING_MODEL=sentence-transformers/all-MiniLM-L6-v2
 # EMBEDDING_BASE_URL=
 # OLLAMA_EMBEDDING_BASE_URL=
 
+# Context budget for a chat model no source can size -- not in LiteLLM's catalog,
+# no limit set in settings, and nothing reported by discovery.
+# GEN_AI_MODEL_FALLBACK_MAX_TOKENS=32000
+
 # ------------------------------------------------------------------------------
 # How You Access SurfSense
 # ------------------------------------------------------------------------------

--- a/docker/docker-compose.deps-only.yml
+++ b/docker/docker-compose.deps-only.yml
@@ -80,7 +80,7 @@ services:
       retries: 5
 
   # Google Search scraper fallback. The host-run backend reaches it with
-  # SEARXNG_FALLBACK_URL=http://localhost:8888.
+  # SEARXNG_URL=http://localhost:8888.
   searxng:
     image: searxng/searxng:2026.3.13-3c1f68c59
     ports:

--- a/docker/docker-compose.deps-only.yml
+++ b/docker/docker-compose.deps-only.yml
@@ -79,6 +79,22 @@ services:
       timeout: 5s
       retries: 5
 
+  # Google Search scraper fallback. The host-run backend reaches it with
+  # SEARXNG_FALLBACK_URL=http://localhost:8888.
+  searxng:
+    image: searxng/searxng:2026.3.13-3c1f68c59
+    ports:
+      - "${SEARXNG_PORT:-8888}:8080"
+    volumes:
+      - ./searxng:/etc/searxng
+    environment:
+      - SEARXNG_SECRET=${SEARXNG_SECRET:-surfsense-searxng-secret}
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8080/healthz"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
   # NOTE: zero-cache requires the `zero_publication` Postgres publication to
   # exist before it starts. In this deps-only stack there is no backend
   # container to run migrations, so you must run `uv run alembic upgrade head`

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -127,6 +127,7 @@ services:
       - AUTH_TYPE=${AUTH_TYPE:-LOCAL}
       - NEXT_FRONTEND_URL=${NEXT_FRONTEND_URL:-http://localhost:3000}
       - WHATSAPP_BRIDGE_URL=${WHATSAPP_BRIDGE_URL:-http://whatsapp-bridge:9929}
+      - SEARXNG_FALLBACK_URL=${SEARXNG_FALLBACK_URL:-http://searxng:8080}
       # Daytona Sandbox – uncomment and set credentials to enable cloud code execution
       # - DAYTONA_SANDBOX_ENABLED=TRUE
       # - DAYTONA_API_KEY=${DAYTONA_API_KEY:-}
@@ -184,6 +185,7 @@ services:
       - CELERY_TASK_DEFAULT_QUEUE=surfsense
       - PYTHONPATH=/app
       - FILE_STORAGE_LOCAL_PATH=/app/.local_object_store
+      - SEARXNG_FALLBACK_URL=${SEARXNG_FALLBACK_URL:-http://searxng:8080}
       - SERVICE_ROLE=worker
     depends_on:
       db:

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -76,6 +76,21 @@ services:
       timeout: 5s
       retries: 5
 
+  # Last-resort fallback for the Google Search scraper.
+  searxng:
+    image: searxng/searxng:2026.3.13-3c1f68c59
+    ports:
+      - "${SEARXNG_PORT:-8888}:8080"
+    volumes:
+      - ./searxng:/etc/searxng
+    environment:
+      - SEARXNG_SECRET=${SEARXNG_SECRET:-surfsense-searxng-secret}
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8080/healthz"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
   otel-lgtm:
     image: grafana/otel-lgtm:latest
     ports:

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -76,7 +76,6 @@ services:
       timeout: 5s
       retries: 5
 
-  # Last-resort fallback for the Google Search scraper.
   searxng:
     image: searxng/searxng:2026.3.13-3c1f68c59
     ports:

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -127,7 +127,7 @@ services:
       - AUTH_TYPE=${AUTH_TYPE:-LOCAL}
       - NEXT_FRONTEND_URL=${NEXT_FRONTEND_URL:-http://localhost:3000}
       - WHATSAPP_BRIDGE_URL=${WHATSAPP_BRIDGE_URL:-http://whatsapp-bridge:9929}
-      - SEARXNG_FALLBACK_URL=${SEARXNG_FALLBACK_URL:-http://searxng:8080}
+      - SEARXNG_URL=${SEARXNG_URL:-http://searxng:8080}
       # Daytona Sandbox – uncomment and set credentials to enable cloud code execution
       # - DAYTONA_SANDBOX_ENABLED=TRUE
       # - DAYTONA_API_KEY=${DAYTONA_API_KEY:-}
@@ -185,7 +185,7 @@ services:
       - CELERY_TASK_DEFAULT_QUEUE=surfsense
       - PYTHONPATH=/app
       - FILE_STORAGE_LOCAL_PATH=/app/.local_object_store
-      - SEARXNG_FALLBACK_URL=${SEARXNG_FALLBACK_URL:-http://searxng:8080}
+      - SEARXNG_URL=${SEARXNG_URL:-http://searxng:8080}
       - SERVICE_ROLE=worker
     depends_on:
       db:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -58,7 +58,7 @@ services:
       timeout: 5s
       retries: 5
 
-  # Last-resort fallback for the Google Search scraper (SEARXNG_FALLBACK_URL).
+  # Last-resort fallback for the Google Search scraper (SEARXNG_URL).
   # Nothing depends_on it: if it is down, searches degrade to Google alone.
   searxng:
     image: searxng/searxng:2026.3.13-3c1f68c59
@@ -149,7 +149,7 @@ services:
       NEXT_FRONTEND_URL: ${NEXT_FRONTEND_URL:-${SURFSENSE_PUBLIC_URL:-http://localhost:${LISTEN_HTTP_PORT:-3929}}}
       BACKEND_URL: ${BACKEND_URL:-${SURFSENSE_PUBLIC_URL:-http://localhost:${LISTEN_HTTP_PORT:-3929}}}
       WHATSAPP_BRIDGE_URL: ${WHATSAPP_BRIDGE_URL:-http://whatsapp-bridge:9929}
-      SEARXNG_FALLBACK_URL: ${SEARXNG_FALLBACK_URL:-http://searxng:8080}
+      SEARXNG_URL: ${SEARXNG_URL:-http://searxng:8080}
       # Daytona Sandbox – uncomment and set credentials to enable cloud code execution
       # DAYTONA_SANDBOX_ENABLED: "TRUE"
       # DAYTONA_API_KEY: ${DAYTONA_API_KEY:-}
@@ -210,7 +210,7 @@ services:
       CELERY_TASK_DEFAULT_QUEUE: surfsense
       PYTHONPATH: /app
       FILE_STORAGE_LOCAL_PATH: /app/.local_object_store
-      SEARXNG_FALLBACK_URL: ${SEARXNG_FALLBACK_URL:-http://searxng:8080}
+      SEARXNG_URL: ${SEARXNG_URL:-http://searxng:8080}
       SERVICE_ROLE: worker
     depends_on:
       db:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -149,6 +149,7 @@ services:
       NEXT_FRONTEND_URL: ${NEXT_FRONTEND_URL:-${SURFSENSE_PUBLIC_URL:-http://localhost:${LISTEN_HTTP_PORT:-3929}}}
       BACKEND_URL: ${BACKEND_URL:-${SURFSENSE_PUBLIC_URL:-http://localhost:${LISTEN_HTTP_PORT:-3929}}}
       WHATSAPP_BRIDGE_URL: ${WHATSAPP_BRIDGE_URL:-http://whatsapp-bridge:9929}
+      SEARXNG_FALLBACK_URL: ${SEARXNG_FALLBACK_URL:-http://searxng:8080}
       # Daytona Sandbox – uncomment and set credentials to enable cloud code execution
       # DAYTONA_SANDBOX_ENABLED: "TRUE"
       # DAYTONA_API_KEY: ${DAYTONA_API_KEY:-}
@@ -209,6 +210,7 @@ services:
       CELERY_TASK_DEFAULT_QUEUE: surfsense
       PYTHONPATH: /app
       FILE_STORAGE_LOCAL_PATH: /app/.local_object_store
+      SEARXNG_FALLBACK_URL: ${SEARXNG_FALLBACK_URL:-http://searxng:8080}
       SERVICE_ROLE: worker
     depends_on:
       db:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -58,6 +58,21 @@ services:
       timeout: 5s
       retries: 5
 
+  # Last-resort fallback for the Google Search scraper (SEARXNG_FALLBACK_URL).
+  # Nothing depends_on it: if it is down, searches degrade to Google alone.
+  searxng:
+    image: searxng/searxng:2026.3.13-3c1f68c59
+    volumes:
+      - ./searxng:/etc/searxng
+    environment:
+      SEARXNG_SECRET: ${SEARXNG_SECRET:-surfsense-searxng-secret}
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8080/healthz"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
   # otel-collector:
   #   image: otel/opentelemetry-collector-contrib:0.152.1
   #   profiles:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -58,8 +58,6 @@ services:
       timeout: 5s
       retries: 5
 
-  # Last-resort fallback for the Google Search scraper (SEARXNG_URL).
-  # Nothing depends_on it: if it is down, searches degrade to Google alone.
   searxng:
     image: searxng/searxng:2026.3.13-3c1f68c59
     volumes:

--- a/docker/scripts/install.ps1
+++ b/docker/scripts/install.ps1
@@ -330,6 +330,7 @@ Write-Info "Installation directory: $InstallDir"
 
 New-Item -ItemType Directory -Path "$InstallDir\scripts" -Force | Out-Null
 New-Item -ItemType Directory -Path "$InstallDir\proxy" -Force | Out-Null
+New-Item -ItemType Directory -Path "$InstallDir\searxng" -Force | Out-Null
 
 $Files = @(
     @{ Src = "docker/docker-compose.yml";                Dest = "docker-compose.yml" }
@@ -338,6 +339,8 @@ $Files = @(
     @{ Src = "docker/proxy/Caddyfile";                   Dest = "proxy/Caddyfile" }
     @{ Src = "docker/postgresql.conf";                   Dest = "postgresql.conf" }
     @{ Src = "docker/scripts/migrate-database.ps1";      Dest = "scripts/migrate-database.ps1" }
+    @{ Src = "docker/searxng/settings.yml";              Dest = "searxng/settings.yml" }
+    @{ Src = "docker/searxng/limiter.toml";              Dest = "searxng/limiter.toml" }
 )
 
 foreach ($f in $Files) {

--- a/docker/scripts/install.sh
+++ b/docker/scripts/install.sh
@@ -333,6 +333,7 @@ step "Downloading SurfSense files"
 info "Installation directory: ${INSTALL_DIR}"
 mkdir -p "${INSTALL_DIR}/scripts"
 mkdir -p "${INSTALL_DIR}/proxy"
+mkdir -p "${INSTALL_DIR}/searxng"
 
 FILES=(
     "docker/docker-compose.yml:docker-compose.yml"
@@ -341,6 +342,8 @@ FILES=(
     "docker/proxy/Caddyfile:proxy/Caddyfile"
     "docker/postgresql.conf:postgresql.conf"
     "docker/scripts/migrate-database.sh:scripts/migrate-database.sh"
+    "docker/searxng/settings.yml:searxng/settings.yml"
+    "docker/searxng/limiter.toml:searxng/limiter.toml"
 )
 
 for entry in "${FILES[@]}"; do

--- a/docker/searxng/limiter.toml
+++ b/docker/searxng/limiter.toml
@@ -1,0 +1,5 @@
+[botdetection.ip_limit]
+link_token = false
+
+[botdetection.ip_lists]
+pass_ip = ["0.0.0.0/0"]

--- a/docker/searxng/settings.yml
+++ b/docker/searxng/settings.yml
@@ -1,0 +1,91 @@
+use_default_settings:
+  engines:
+    remove:
+      - ahmia
+      - torch
+      - qwant
+      - qwant news
+      - qwant images
+      - qwant videos
+      - mojeek
+      - mojeek images
+      - mojeek news
+
+server:
+  secret_key: "override-me-via-env"
+  limiter: false
+  image_proxy: false
+  method: "GET"
+  default_http_headers:
+    X-Robots-Tag: "noindex, nofollow"
+
+search:
+  # Dropping 'json' makes every fallback request 403.
+  formats:
+    - html
+    - json
+  default_lang: "auto"
+  autocomplete: ""
+  safe_search: 0
+  ban_time_on_fail: 5
+  max_ban_time_on_fail: 120
+  suspended_times:
+    SearxEngineAccessDenied: 3600
+    SearxEngineCaptcha: 3600
+    SearxEngineTooManyRequests: 600
+    cf_SearxEngineCaptcha: 7200
+    cf_SearxEngineAccessDenied: 3600
+    recaptcha_SearxEngineCaptcha: 7200
+
+ui:
+  static_use_hash: true
+
+outgoing:
+  request_timeout: 12.0
+  max_request_timeout: 20.0
+  pool_connections: 100
+  pool_maxsize: 20
+  enable_http2: true
+  extra_proxy_timeout: 10
+  retries: 1
+  # Uncomment and set your residential proxy URL to route search engine requests through it.
+  # Format: http://<username>:<base64_password>@<hostname>:<port>/
+  #
+  # proxies:
+  #   all://:
+  #     - http://user:pass@proxy-host:port/
+
+engines:
+  # Off on purpose: this instance only runs after Google walled us, and would
+  # query it from the same address.
+  - name: google
+    disabled: true
+  - name: duckduckgo
+    disabled: false
+    weight: 1.1
+    retry_on_http_error: [429, 503]
+  - name: brave
+    disabled: false
+    weight: 1.0
+    retry_on_http_error: [429, 503]
+  - name: bing
+    disabled: false
+    weight: 0.9
+    retry_on_http_error: [429, 503]
+  - name: wikipedia
+    disabled: false
+    weight: 0.8
+  - name: stackoverflow
+    disabled: false
+    weight: 0.7
+  - name: yahoo
+    disabled: false
+    weight: 0.7
+    retry_on_http_error: [429, 503]
+  - name: wikidata
+    disabled: false
+    weight: 0.6
+  - name: currency
+    disabled: false
+  - name: ddg definitions
+    disabled: false

--- a/surfsense_backend/.env.example
+++ b/surfsense_backend/.env.example
@@ -409,6 +409,13 @@ TURNSTILE_SECRET_KEY=
 # Per-fetch budget before giving up under saturation (a cold solve is ~45s).
 # GOOGLE_SEARCH_FETCH_DEADLINE_S=180
 
+# Last-resort fallback once the ladder above is exhausted. Docker Compose sets
+# this to its bundled searxng service; set it by hand only when running the
+# backend outside Docker (dev/deps-only publish SearXNG on 8888). Unset = off.
+# The instance must have 'json' in search.formats, or requests get a 403.
+# SEARXNG_FALLBACK_URL=http://localhost:8888
+# SEARXNG_FALLBACK_TIMEOUT_S=10
+
 # =====================================================================
 # Captcha solving (Phase 3d) — LAST-resort bypass tier (in-house solver seam,
 # app/utils/captcha/solvers.py). Only fires on the stealth browser tier when a

--- a/surfsense_backend/.env.example
+++ b/surfsense_backend/.env.example
@@ -413,8 +413,8 @@ TURNSTILE_SECRET_KEY=
 # this to its bundled searxng service; set it by hand only when running the
 # backend outside Docker (dev/deps-only publish SearXNG on 8888). Unset = off.
 # The instance must have 'json' in search.formats, or requests get a 403.
-# SEARXNG_FALLBACK_URL=http://localhost:8888
-# SEARXNG_FALLBACK_TIMEOUT_S=10
+# SEARXNG_URL=http://localhost:8888
+# SEARXNG_TIMEOUT_S=10
 
 # =====================================================================
 # Captcha solving (Phase 3d) — LAST-resort bypass tier (in-house solver seam,

--- a/surfsense_backend/.env.example
+++ b/surfsense_backend/.env.example
@@ -216,9 +216,12 @@ EMBEDDING_MODEL=sentence-transformers/all-MiniLM-L6-v2
 # EMBEDDING_BASE_URL=http://host.docker.internal:11434
 # OLLAMA_EMBEDDING_BASE_URL=http://host.docker.internal:11434
 
-# Context budget for a chat model no source can size -- not in LiteLLM's catalog,
-# no limit set in settings, and nothing reported by discovery. Raise it when you
-# run a gateway full of models LiteLLM has never heard of.
+# Default max input tokens for a chat model no source can size -- not in
+# LiteLLM's catalog and nothing set in settings. Also caps what a locally
+# discovered model is seeded with, since a model's context length says nothing
+# about how much the host could actually allocate. Raise it when you run a
+# gateway full of models LiteLLM has never heard of, or hosts with memory to
+# spare.
 # GEN_AI_MODEL_FALLBACK_MAX_TOKENS=32000
 
 # Rerankers Config

--- a/surfsense_backend/.env.example
+++ b/surfsense_backend/.env.example
@@ -222,7 +222,7 @@ EMBEDDING_MODEL=sentence-transformers/all-MiniLM-L6-v2
 # about how much the host could actually allocate. Raise it when you run a
 # gateway full of models LiteLLM has never heard of, or hosts with memory to
 # spare.
-# GEN_AI_MODEL_FALLBACK_MAX_TOKENS=32000
+# SURFSENSE_UNKNOWN_MODEL_MAX_INPUT_TOKENS=32000
 
 # Rerankers Config
 RERANKERS_ENABLED=TRUE or FALSE(Default: FALSE)

--- a/surfsense_backend/.env.example
+++ b/surfsense_backend/.env.example
@@ -216,6 +216,11 @@ EMBEDDING_MODEL=sentence-transformers/all-MiniLM-L6-v2
 # EMBEDDING_BASE_URL=http://host.docker.internal:11434
 # OLLAMA_EMBEDDING_BASE_URL=http://host.docker.internal:11434
 
+# Context budget for a chat model no source can size -- not in LiteLLM's catalog,
+# no limit set in settings, and nothing reported by discovery. Raise it when you
+# run a gateway full of models LiteLLM has never heard of.
+# GEN_AI_MODEL_FALLBACK_MAX_TOKENS=32000
+
 # Rerankers Config
 RERANKERS_ENABLED=TRUE or FALSE(Default: FALSE)
 RERANKERS_MODEL_NAME=ms-marco-MiniLM-L-12-v2

--- a/surfsense_backend/app/agents/chat/multi_agent_chat/subagents/builtins/google_search/system_prompt.md
+++ b/surfsense_backend/app/agents/chat/multi_agent_chat/subagents/builtins/google_search/system_prompt.md
@@ -17,6 +17,7 @@ Answer the delegated question from live Google Search data gathered with your ve
 - Scraping a specific results page: pass the full Google Search URL in `queries`.
 - Need more results: raise `max_pages_per_query` to page beyond the first page (cheaper and faster than adding more distinct queries).
 <include snippet="run_reader"/>
+- Provenance: if an item carries `resultsProvider` (e.g. `searxng`), Google was unreachable and these came from a fallback search index — say so in your findings and do not describe them as Google rankings or positions.
 - Handing URLs off for crawling: return the organic result URLs so the supervisor can route them to the web crawling specialist.
 - Comparison requests: pull the current results, compare against prior values already in this conversation's earlier tool results, and report concrete deltas (added, removed, moved up/down).
 </playbook>

--- a/surfsense_backend/app/agents/chat/runtime/llm_config.py
+++ b/surfsense_backend/app/agents/chat/runtime/llm_config.py
@@ -10,7 +10,7 @@ It also provides utilities for creating ChatLiteLLM instances and
 managing prompt configurations.
 """
 
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Iterator
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -27,6 +27,10 @@ from litellm import get_model_info
 
 from app.agents.chat.runtime.prompt_caching import (
     apply_litellm_prompt_caching,
+)
+from app.services.context_admission import (
+    admit_langchain_messages,
+    compute_tool_tokens,
 )
 from app.services.llm_router_service import (
     AUTO_MODE_ID,
@@ -66,6 +70,47 @@ class SanitizedChatLiteLLM(ChatLiteLLM):
     (e.g. ``thinking`` from reasoning models) and normalises bare strings
     in content arrays before forwarding to the underlying provider."""
 
+    def _count_context_tokens(self, messages: list[dict[str, Any]]) -> int | None:
+        from litellm import token_counter
+
+        profile = getattr(self, "profile", None)
+        if not isinstance(profile, dict):
+            return None
+        model_names = profile.get("token_count_models")
+        if not isinstance(model_names, list):
+            model_names = [profile.get("token_count_model")]
+        counts: list[int] = []
+        for model_name in model_names:
+            if not isinstance(model_name, str) or not model_name:
+                continue
+            try:
+                counts.append(token_counter(messages=messages, model=model_name))
+            except Exception:
+                continue
+        return max(counts) if counts else None
+
+    def _admit_messages(
+        self, messages: list[BaseMessage], tools: Any = None
+    ) -> list[BaseMessage]:
+        sanitized = _sanitize_messages(messages)
+        profile = getattr(self, "profile", None)
+        max_input_tokens = (
+            profile.get("max_input_tokens") if isinstance(profile, dict) else None
+        )
+        if (
+            not isinstance(max_input_tokens, int)
+            or isinstance(max_input_tokens, bool)
+            or max_input_tokens <= 0
+        ):
+            return sanitized
+        return admit_langchain_messages(
+            sanitized,
+            sanitize_content=_sanitize_content,
+            count_tokens=self._count_context_tokens,
+            max_input_tokens=max_input_tokens,
+            reserved_tokens=compute_tool_tokens(tools, self._count_context_tokens),
+        )
+
     def _generate(
         self,
         messages: list[BaseMessage],
@@ -74,7 +119,24 @@ class SanitizedChatLiteLLM(ChatLiteLLM):
         **kwargs: Any,
     ) -> ChatResult:
         return super()._generate(
-            _sanitize_messages(messages), stop, run_manager, **kwargs
+            self._admit_messages(messages, kwargs.get("tools")),
+            stop,
+            run_manager,
+            **kwargs,
+        )
+
+    def _stream(
+        self,
+        messages: list[BaseMessage],
+        stop: list[str] | None = None,
+        run_manager: CallbackManagerForLLMRun | None = None,
+        **kwargs: Any,
+    ) -> Iterator[ChatGenerationChunk]:
+        yield from super()._stream(
+            self._admit_messages(messages, kwargs.get("tools")),
+            stop,
+            run_manager,
+            **kwargs,
         )
 
     async def _astream(
@@ -85,7 +147,10 @@ class SanitizedChatLiteLLM(ChatLiteLLM):
         **kwargs: Any,
     ) -> AsyncIterator[ChatGenerationChunk]:
         async for chunk in super()._astream(
-            _sanitize_messages(messages), stop, run_manager, **kwargs
+            self._admit_messages(messages, kwargs.get("tools")),
+            stop,
+            run_manager,
+            **kwargs,
         ):
             yield chunk
 
@@ -98,7 +163,7 @@ class SanitizedChatLiteLLM(ChatLiteLLM):
         **kwargs: Any,
     ) -> ChatResult:
         return await super()._agenerate(
-            _sanitize_messages(messages),
+            self._admit_messages(messages, kwargs.get("tools")),
             stop=stop,
             run_manager=run_manager,
             stream=stream,
@@ -106,20 +171,55 @@ class SanitizedChatLiteLLM(ChatLiteLLM):
         )
 
 
-def _attach_model_profile(llm: ChatLiteLLM, model_string: str) -> None:
-    """Attach a ``profile`` dict to ChatLiteLLM with model context metadata."""
+def resolve_max_input_tokens(
+    model_string: str,
+    persisted_max_input_tokens: int | None = None,
+) -> int:
+    """Resolve the model budget using the Onyx-compatible fallback chain.
+
+    Deliberately ignores how much context a local runtime currently has
+    loaded: LM Studio and Ollama load, unload, and JIT-reload instances at
+    will, so any value we could read here goes stale between requests. A
+    runtime whose loaded context is smaller than this budget rejects the
+    request itself, and that error is classified as MODEL_CONTEXT_LIMIT.
+    """
+    if (
+        isinstance(persisted_max_input_tokens, int)
+        and not isinstance(persisted_max_input_tokens, bool)
+        and persisted_max_input_tokens > 0
+    ):
+        return persisted_max_input_tokens
+
     try:
-        info = get_model_info(model_string)
-        max_input_tokens = info.get("max_input_tokens")
-        if isinstance(max_input_tokens, int) and max_input_tokens > 0:
-            llm.profile = {
-                "max_input_tokens": max_input_tokens,
-                "max_input_tokens_upper": max_input_tokens,
-                "token_count_model": model_string,
-                "token_count_models": [model_string],
-            }
+        catalog_value = get_model_info(model_string).get("max_input_tokens")
+        if (
+            isinstance(catalog_value, int)
+            and not isinstance(catalog_value, bool)
+            and catalog_value > 0
+        ):
+            return catalog_value
     except Exception:
-        return
+        pass
+    return 32_000
+
+
+def _attach_model_profile(
+    llm: ChatLiteLLM,
+    model_string: str,
+    persisted_max_input_tokens: int | None = None,
+) -> int:
+    """Attach normalized context metadata and return the effective limit."""
+    max_input_tokens = resolve_max_input_tokens(
+        model_string,
+        persisted_max_input_tokens=persisted_max_input_tokens,
+    )
+    llm.profile = {
+        "max_input_tokens": max_input_tokens,
+        "max_input_tokens_upper": max_input_tokens,
+        "token_count_model": model_string,
+        "token_count_models": [model_string],
+    }
+    return max_input_tokens
 
 
 @dataclass

--- a/surfsense_backend/app/agents/chat/runtime/llm_config.py
+++ b/surfsense_backend/app/agents/chat/runtime/llm_config.py
@@ -10,7 +10,6 @@ It also provides utilities for creating ChatLiteLLM instances and
 managing prompt configurations.
 """
 
-import os
 from collections.abc import AsyncIterator, Iterator
 from dataclasses import dataclass
 from pathlib import Path
@@ -30,6 +29,7 @@ from app.agents.chat.runtime.prompt_caching import (
     apply_litellm_prompt_caching,
 )
 from app.services.context_admission import (
+    GEN_AI_MODEL_FALLBACK_MAX_TOKENS,
     admit_langchain_messages,
     compute_tool_tokens,
 )
@@ -37,22 +37,6 @@ from app.services.llm_router_service import (
     AUTO_MODE_ID,
     ChatLiteLLMRouter,
     _sanitize_content,
-)
-
-
-def _env_positive_int(name: str, default: int) -> int:
-    try:
-        value = int(os.getenv(name) or default)
-    except ValueError:
-        return default
-    return value if value > 0 else default
-
-
-# Budget for a model no source can size. Env-overridable so a deployment behind
-# a gateway of models LiteLLM has never heard of can raise it in one place
-# instead of editing every model by hand.
-GEN_AI_MODEL_FALLBACK_MAX_TOKENS = _env_positive_int(
-    "GEN_AI_MODEL_FALLBACK_MAX_TOKENS", 32_000
 )
 
 

--- a/surfsense_backend/app/agents/chat/runtime/llm_config.py
+++ b/surfsense_backend/app/agents/chat/runtime/llm_config.py
@@ -10,6 +10,7 @@ It also provides utilities for creating ChatLiteLLM instances and
 managing prompt configurations.
 """
 
+import os
 from collections.abc import AsyncIterator, Iterator
 from dataclasses import dataclass
 from pathlib import Path
@@ -36,6 +37,22 @@ from app.services.llm_router_service import (
     AUTO_MODE_ID,
     ChatLiteLLMRouter,
     _sanitize_content,
+)
+
+
+def _env_positive_int(name: str, default: int) -> int:
+    try:
+        value = int(os.getenv(name) or default)
+    except ValueError:
+        return default
+    return value if value > 0 else default
+
+
+# Budget for a model no source can size. Env-overridable so a deployment behind
+# a gateway of models LiteLLM has never heard of can raise it in one place
+# instead of editing every model by hand.
+GEN_AI_MODEL_FALLBACK_MAX_TOKENS = _env_positive_int(
+    "GEN_AI_MODEL_FALLBACK_MAX_TOKENS", 32_000
 )
 
 
@@ -175,7 +192,7 @@ def resolve_max_input_tokens(
     model_string: str,
     persisted_max_input_tokens: int | None = None,
 ) -> int:
-    """Resolve the model budget using the Onyx-compatible fallback chain.
+    """Resolve the model budget: stored limit, then catalog, then fallback.
 
     Deliberately ignores how much context a local runtime currently has
     loaded: LM Studio and Ollama load, unload, and JIT-reload instances at
@@ -200,7 +217,7 @@ def resolve_max_input_tokens(
             return catalog_value
     except Exception:
         pass
-    return 32_000
+    return GEN_AI_MODEL_FALLBACK_MAX_TOKENS
 
 
 def _attach_model_profile(

--- a/surfsense_backend/app/agents/chat/runtime/llm_config.py
+++ b/surfsense_backend/app/agents/chat/runtime/llm_config.py
@@ -29,7 +29,7 @@ from app.agents.chat.runtime.prompt_caching import (
     apply_litellm_prompt_caching,
 )
 from app.services.context_admission import (
-    GEN_AI_MODEL_FALLBACK_MAX_TOKENS,
+    SURFSENSE_UNKNOWN_MODEL_MAX_INPUT_TOKENS,
     admit_langchain_messages,
     compute_tool_tokens,
 )
@@ -201,7 +201,7 @@ def resolve_max_input_tokens(
             return catalog_value
     except Exception:
         pass
-    return GEN_AI_MODEL_FALLBACK_MAX_TOKENS
+    return SURFSENSE_UNKNOWN_MODEL_MAX_INPUT_TOKENS
 
 
 def _attach_model_profile(

--- a/surfsense_backend/app/agents/chat/shared/middleware/retry_after.py
+++ b/surfsense_backend/app/agents/chat/shared/middleware/retry_after.py
@@ -17,9 +17,11 @@ Behaviour:
   ``litellm.exceptions.RateLimitError.response.headers`` (or any exception
   exposing a similar shape).
 - Sleeps ``max(exponential_backoff, header_delay)`` between retries.
-- Returns ``False`` from ``retry_on`` for ``ContextWindowExceededError`` /
-  ``ContextOverflowError`` so :class:`SurfSenseCompactionMiddleware` (or
-  the LangChain summarization fallback path) handles those instead.
+- Returns ``False`` from ``retry_on`` for context overflow so
+  :class:`SurfSenseCompactionMiddleware` (or the LangChain summarization
+  fallback path) handles it instead, and for the other categories a retry
+  cannot fix (auth, permissions, unknown model, bad request, host out of
+  memory).
 - Emits ``surfsense.retrying`` via ``adispatch_custom_event`` on each retry
   so ``stream_new_chat`` can forward it to clients as an SSE event.
 """
@@ -46,27 +48,36 @@ from langchain_core.callbacks import adispatch_custom_event, dispatch_custom_eve
 from langchain_core.messages import AIMessage
 
 from app.observability import metrics as ot_metrics, otel as ot
+from app.services.llm_error_adapter import LLMErrorCategory, adapt_llm_exception
 
 logger = logging.getLogger(__name__)
 
-# Names of exception classes for which a retry would not help — context
-# overflow needs compaction, auth needs human intervention, etc. Detected
-# by class-name substring so we don't have to import LiteLLM/Anthropic
-# here (which would tie this module to optional deps).
-_NON_RETRYABLE_NAME_HINTS: tuple[str, ...] = (
-    "ContextWindowExceeded",
-    "ContextOverflow",
-    "AuthenticationError",
-    "InvalidRequestError",
-    "PermissionDenied",
-    "InvalidApiKey",
-    "ContextLimit",
+# Categories for which a retry cannot help — context overflow needs
+# compaction, auth needs human intervention, and a host that could not fit the
+# model has already exhausted its own recovery (Ollama's scheduler retries a
+# load-time OOM by shrinking an automatic context and evicting other models
+# before it ever returns the error). Anything unrecognised stays retryable, so
+# a transient failure we cannot classify still gets its attempts.
+_NON_RETRYABLE_CATEGORIES: frozenset[LLMErrorCategory] = frozenset(
+    {
+        LLMErrorCategory.AUTH_FAILED,
+        LLMErrorCategory.PERMISSION_DENIED,
+        LLMErrorCategory.MODEL_NOT_FOUND,
+        LLMErrorCategory.BAD_REQUEST,
+        LLMErrorCategory.CONTEXT_LIMIT,
+        LLMErrorCategory.INSUFFICIENT_MEMORY,
+    }
 )
 
 
 def _is_non_retryable(exc: BaseException) -> bool:
-    name = type(exc).__name__
-    return any(hint in name for hint in _NON_RETRYABLE_NAME_HINTS)
+    """Classify by message and wrapper chain, not just the exception class.
+
+    Local runtimes surface both of the hopeless cases -- out of memory and
+    context overflow -- as a generic provider error whose class name says
+    nothing, so a class-name test retries them until the attempts run out.
+    """
+    return adapt_llm_exception(exc).category in _NON_RETRYABLE_CATEGORIES
 
 
 def _extract_retry_after_seconds(exc: BaseException) -> float | None:

--- a/surfsense_backend/app/automations/services/automation.py
+++ b/surfsense_backend/app/automations/services/automation.py
@@ -171,7 +171,7 @@ class AutomationService:
                 self.auth,
                 "automation_status_changed",
                 {
-                    "automation_id": automation.id,
+                    "automation_id": automation_id,
                     "workspace_id": automation.workspace_id,
                     "next_status": str(data["status"]),
                 },
@@ -182,7 +182,7 @@ class AutomationService:
                 self.auth,
                 "automation_updated",
                 {
-                    "automation_id": automation.id,
+                    "automation_id": automation_id,
                     "workspace_id": automation.workspace_id,
                     "has_definition_change": "definition" in data,
                 },

--- a/surfsense_backend/app/capabilities/google_search/scrape/schemas.py
+++ b/surfsense_backend/app/capabilities/google_search/scrape/schemas.py
@@ -62,5 +62,11 @@ class ScrapeOutput(BaseModel):
 
     @property
     def billable_units(self) -> int:
-        """One fetched SERP page = one billable unit."""
-        return len(self.items)
+        """One fetched Google SERP page = one billable unit.
+
+        Fallback pages (``resultsProvider`` set) cost no proxy render and no
+        captcha solve, so they are not charged at the Google SERP rate.
+        """
+        return sum(
+            1 for item in self.items if not getattr(item, "resultsProvider", None)
+        )

--- a/surfsense_backend/app/proprietary/platforms/google_search/fetch.py
+++ b/surfsense_backend/app/proprietary/platforms/google_search/fetch.py
@@ -548,7 +548,9 @@ async def fetch_serp_html(url: str, *, mobile: bool = False) -> str | None:
         with contextlib.suppress(Exception):
             page = await _render(url, None, mobile=mobile)
             html = page.html_content or ""
-            return html if (page.status == 200 and _has_results(html)) else None
+            if page.status == 200 and _has_results(html):
+                return html
+        logger.warning("[google_search] gave up on %s (unproxied single render)", url)
         return None
 
     deadline = time.monotonic() + _FETCH_DEADLINE_S

--- a/surfsense_backend/app/proprietary/platforms/google_search/scraper.py
+++ b/surfsense_backend/app/proprietary/platforms/google_search/scraper.py
@@ -15,6 +15,7 @@ import logging
 from collections.abc import AsyncIterator
 from typing import Any
 
+from . import searxng
 from .fetch import fetch_serp_html
 from .parsers import parse_ai_mode, parse_serp
 from .query_builder import (
@@ -38,15 +39,24 @@ _PAID_ADS_MAX_TRIES = 3
 
 
 def _search_query_stamp(
-    term: str | None, url: str, page: int, input_model: GoogleSearchScrapeInput
+    term: str | None,
+    url: str | None,
+    page: int,
+    input_model: GoogleSearchScrapeInput,
+    *,
+    domain: str = "google.com",
 ) -> SearchQuery:
-    """The ``searchQuery`` provenance block Apify stamps on every item."""
+    """The ``searchQuery`` provenance block Apify stamps on every item.
+
+    ``domain`` is overridden when a page came from the fallback provider, so an
+    aggregator result never claims to be a google.com SERP.
+    """
     return SearchQuery(
         term=term,
         url=url,
         device="MOBILE" if input_model.mobileResults else "DESKTOP",
         page=page,
-        domain="google.com",
+        domain=domain,
         countryCode=(input_model.countryCode or "US").upper(),
         languageCode=input_model.languageCode or None,
         locationUule=input_model.locationUule,
@@ -54,12 +64,13 @@ def _search_query_stamp(
 
 
 async def _serp_page_flow(
-    url: str, input_model: GoogleSearchScrapeInput
+    url: str, input_model: GoogleSearchScrapeInput, *, term: str | None, page: int
 ) -> SerpItem | None:
-    """Fetch and parse one SERP page into a :class:`SerpItem`.
+    """Fetch and parse one SERP page into a stamped :class:`SerpItem`.
 
     Renders ``url`` through the proxy and parses organic/paid/related/PAA blocks.
-    Returns ``None`` when the page could not be fetched (all IPs walled), so the
+    When every IP is walled the page falls through to the SearXNG fallback
+    (:func:`_searxng_page`); ``None`` means even that yielded nothing, so the
     caller stops paging.
 
     With ``focusOnPaidAds`` we re-render up to :data:`_PAID_ADS_MAX_TRIES` times
@@ -82,7 +93,8 @@ async def _serp_page_flow(
         if input_model.saveHtml:
             item.html = html
         if not input_model.focusOnPaidAds or item.paidResults or item.paidProducts:
-            return item
+            best = item
+            break
         # No ads yet; keep the render with the most organic results as fallback.
         if best is None or len(item.organicResults) > len(best.organicResults):
             best = item
@@ -91,7 +103,31 @@ async def _serp_page_flow(
             attempt,
             tries,
         )
+    if best is None:
+        return await _searxng_page(term, input_model, page=page)
+    best.searchQuery = _search_query_stamp(term, url, page, input_model)
     return best
+
+
+async def _searxng_page(
+    term: str | None, input_model: GoogleSearchScrapeInput, *, page: int
+) -> SerpItem | None:
+    """Last-resort aggregator page when Google walled every IP.
+
+    Skipped when the caller specifically wants ads (an aggregator serves none,
+    so a result here would be a guaranteed miss dressed up as data) or when
+    there is no plain term — a Google URL whose ``q`` we could not read has
+    nothing to re-search.
+    """
+    if input_model.focusOnPaidAds or not term or not searxng.enabled():
+        return None
+    item = await searxng.search_serp(term, input_model, page=page)
+    if item is None:
+        return None
+    item.searchQuery = _search_query_stamp(
+        term, None, page, input_model, domain=searxng.domain()
+    )
+    return item
 
 
 async def _term_flow(
@@ -102,10 +138,9 @@ async def _term_flow(
     pages = input_model.maxPagesPerQuery or 1
     for page in range(1, pages + 1):
         url = build_search_url(term, input_model, page=page)
-        item = await _serp_page_flow(url, input_model)
+        item = await _serp_page_flow(url, input_model, term=term, page=page)
         if item is None:
             return
-        item.searchQuery = _search_query_stamp(term, url, page, input_model)
         yield item.to_output()
         # An empty organic page means we've run past the last result page.
         if not item.organicResults:
@@ -119,10 +154,9 @@ async def _url_flow(
     over the localization inputs). ``maxPagesPerQuery`` paging (rewriting the
     ``start`` parameter) lands with the fetch implementation."""
     term = term_from_url(url)
-    item = await _serp_page_flow(url, input_model)
+    item = await _serp_page_flow(url, input_model, term=term, page=1)
     if item is None:
         return
-    item.searchQuery = _search_query_stamp(term, url, 1, input_model)
     yield item.to_output()
 
 

--- a/surfsense_backend/app/proprietary/platforms/google_search/searxng.py
+++ b/surfsense_backend/app/proprietary/platforms/google_search/searxng.py
@@ -3,7 +3,8 @@
 When Google walls every vetted IP (``fetch_serp_html`` returns ``None`` after
 its pool/deadline budget), this returns the same ``SerpItem`` shape from a
 SearXNG instance's JSON API, so a search yields organic results instead of
-nothing. Off unless ``SEARXNG_FALLBACK_URL`` is set.
+nothing. Keyed on ``SEARXNG_FALLBACK_URL``, which the Docker stack points at
+its bundled ``searxng`` service; unset elsewhere means off.
 
 SearXNG is a metasearch aggregator, not Google: only organic results (title,
 url, snippet) and query suggestions exist. Ads, People-Also-Ask, AI Overview,

--- a/surfsense_backend/app/proprietary/platforms/google_search/searxng.py
+++ b/surfsense_backend/app/proprietary/platforms/google_search/searxng.py
@@ -1,0 +1,142 @@
+"""Last-resort SearXNG fallback for the Google Search scraper.
+
+When Google walls every vetted IP (``fetch_serp_html`` returns ``None`` after
+its pool/deadline budget), this returns the same ``SerpItem`` shape from a
+SearXNG instance's JSON API, so a search yields organic results instead of
+nothing. Off unless ``SEARXNG_FALLBACK_URL`` is set.
+
+SearXNG is a metasearch aggregator, not Google: only organic results (title,
+url, snippet) and query suggestions exist. Ads, People-Also-Ask, AI Overview,
+sitelinks, icons, and result totals are Google-only and stay empty, and every
+item carries ``resultsProvider="searxng"`` so no consumer reports aggregator
+hits as Google rankings.
+
+``ponytail:`` best-effort — any error/timeout returns ``None`` and the caller
+behaves exactly as it does today. The instance must serve JSON
+(``search.formats`` including ``json`` in its ``settings.yml``); a stock
+self-hosted install answers 403 until it does.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+from urllib.parse import urlsplit
+
+import httpx
+
+from .schemas import (
+    GoogleSearchScrapeInput,
+    OrganicResult,
+    RelatedQuery,
+    SerpItem,
+    SuggestedResult,
+)
+
+logger = logging.getLogger(__name__)
+
+PROVIDER = "searxng"
+
+# Read here rather than in app.config to match the sibling fetch seam, which
+# takes its own knobs straight from the environment.
+_HOST = os.getenv("SEARXNG_FALLBACK_URL", "").strip()
+_TIMEOUT_S = float(os.getenv("SEARXNG_FALLBACK_TIMEOUT_S", "10"))
+# A Google SERP page is 10 results; cap the aggregator to the same so a
+# fallback page never looks anomalously large to a caller that is paging.
+_MAX_RESULTS = 10
+
+# ``quickDateRange`` (Google ``tbs=qdr:``) -> SearXNG ``time_range``. Only the
+# plain units map; compound codes like "m6" have no equivalent and are dropped
+# rather than approximated.
+_TIME_RANGE = {"d": "day", "w": "week", "m": "month", "y": "year"}
+
+
+def enabled() -> bool:
+    """True when a fallback instance is configured."""
+    return bool(_HOST)
+
+
+def domain() -> str:
+    """Instance hostname, for the ``searchQuery.domain`` provenance field."""
+    return urlsplit(_HOST).hostname or PROVIDER
+
+
+def _query(term: str, input_model: GoogleSearchScrapeInput) -> str:
+    """The term with only the operators SearXNG actually honors.
+
+    ``site:`` and exact-match quoting are supported across its engines;
+    ``intitle:``/``intext:``/``inurl:``/``filetype:``/``before:``/``after:``
+    are not, and folding them in returns zero results instead of degrading.
+    """
+    query = f'"{term}"' if input_model.forceExactMatch else term
+    if input_model.site:
+        query = f"{query} site:{input_model.site}"
+    return query
+
+
+async def _fetch_json(params: dict[str, Any]) -> dict[str, Any] | None:
+    try:
+        async with httpx.AsyncClient(timeout=_TIMEOUT_S) as client:
+            response = await client.get(f"{_HOST.rstrip('/')}/search", params=params)
+        response.raise_for_status()
+        return response.json()
+    except Exception as e:
+        logger.warning("[google_search][searxng] fallback request failed: %s", e)
+        return None
+
+
+async def search_serp(
+    term: str, input_model: GoogleSearchScrapeInput, *, page: int = 1
+) -> SerpItem | None:
+    """One SearXNG results page as a ``SerpItem``, or ``None`` if unusable."""
+    if not enabled():
+        return None
+
+    params: dict[str, Any] = {
+        "q": _query(term, input_model),
+        "format": "json",
+        "pageno": page,
+        "categories": "general",
+    }
+    if input_model.languageCode:
+        params["language"] = input_model.languageCode
+    time_range = _TIME_RANGE.get((input_model.quickDateRange or "").lower())
+    if time_range:
+        params["time_range"] = time_range
+
+    payload = await _fetch_json(params)
+    if payload is None:
+        return None
+
+    usable = [r for r in (payload.get("results") or []) if r.get("url")][:_MAX_RESULTS]
+    if not usable:
+        logger.info("[google_search][searxng] no results for %r", term)
+        return None
+
+    suggestions = [s for s in (payload.get("suggestions") or []) if s][:_MAX_RESULTS]
+    logger.info(
+        "[google_search][searxng] fallback served %d result(s) for %r page=%d",
+        len(usable),
+        term,
+        page,
+    )
+    return SerpItem(
+        organicResults=[
+            OrganicResult(
+                title=r.get("title"),
+                url=r.get("url"),
+                description=r.get("content"),
+                position=i,
+            )
+            for i, r in enumerate(usable, start=1)
+        ],
+        relatedQueries=[RelatedQuery(title=s) for s in suggestions],
+        suggestedResults=[
+            SuggestedResult(title=s, position=i)
+            for i, s in enumerate(suggestions, start=1)
+        ],
+        # Extra field (SerpItem is extra="allow"), so it flows untouched through
+        # to_output() into REST, MCP, playground, and the chat subagent.
+        resultsProvider=PROVIDER,
+    )

--- a/surfsense_backend/app/proprietary/platforms/google_search/searxng.py
+++ b/surfsense_backend/app/proprietary/platforms/google_search/searxng.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 import logging
 import os
 from typing import Any
-from urllib.parse import urlsplit
 
 import httpx
 
@@ -58,8 +57,9 @@ def enabled() -> bool:
 
 
 def domain() -> str:
-    """Instance hostname, for the ``searchQuery.domain`` provenance field."""
-    return urlsplit(_HOST).hostname or PROVIDER
+    """Provider label for ``searchQuery.domain`` — not the configured host,
+    which is often a private address that should not reach API output."""
+    return PROVIDER
 
 
 def _query(term: str, input_model: GoogleSearchScrapeInput) -> str:

--- a/surfsense_backend/app/proprietary/platforms/google_search/searxng.py
+++ b/surfsense_backend/app/proprietary/platforms/google_search/searxng.py
@@ -3,8 +3,8 @@
 When Google walls every vetted IP (``fetch_serp_html`` returns ``None`` after
 its pool/deadline budget), this returns the same ``SerpItem`` shape from a
 SearXNG instance's JSON API, so a search yields organic results instead of
-nothing. Keyed on ``SEARXNG_FALLBACK_URL``, which the Docker stack points at
-its bundled ``searxng`` service; unset elsewhere means off.
+nothing. Keyed on ``SEARXNG_URL``, which the Docker stack points at its
+bundled ``searxng`` service; unset elsewhere means off.
 
 SearXNG is a metasearch aggregator, not Google: only organic results (title,
 url, snippet) and query suggestions exist. Ads, People-Also-Ask, AI Overview,
@@ -40,8 +40,8 @@ PROVIDER = "searxng"
 
 # Read here rather than in app.config to match the sibling fetch seam, which
 # takes its own knobs straight from the environment.
-_HOST = os.getenv("SEARXNG_FALLBACK_URL", "").strip()
-_TIMEOUT_S = float(os.getenv("SEARXNG_FALLBACK_TIMEOUT_S", "10"))
+_HOST = os.getenv("SEARXNG_URL", "").strip()
+_TIMEOUT_S = float(os.getenv("SEARXNG_TIMEOUT_S", "10"))
 # A Google SERP page is 10 results; cap the aggregator to the same so a
 # fallback page never looks anomalously large to a caller that is paging.
 _MAX_RESULTS = 10

--- a/surfsense_backend/app/proprietary/platforms/google_search/searxng.py
+++ b/surfsense_backend/app/proprietary/platforms/google_search/searxng.py
@@ -79,6 +79,12 @@ async def _fetch_json(params: dict[str, Any]) -> dict[str, Any] | None:
     try:
         async with httpx.AsyncClient(timeout=_TIMEOUT_S) as client:
             response = await client.get(f"{_HOST.rstrip('/')}/search", params=params)
+        if response.status_code == 403:
+            logger.warning(
+                "[google_search][searxng] instance refused the JSON API (403); "
+                "add 'json' to search.formats in its settings.yml"
+            )
+            return None
         response.raise_for_status()
         return response.json()
     except Exception as e:

--- a/surfsense_backend/app/routes/anonymous_chat_routes.py
+++ b/surfsense_backend/app/routes/anonymous_chat_routes.py
@@ -488,13 +488,22 @@ async def stream_anonymous_chat(
             logger.exception("Anonymous chat stream error")
             anon_outcome = "error"
             await TokenQuotaService.anon_release(session_key, ip_key, request_id)
-            _, error_code, _, _, user_message, extra = classify_stream_exception(
+            (
+                _,
+                error_code,
+                _,
+                _,
+                user_message,
+                diagnostic,
+                extra,
+            ) = classify_stream_exception(
                 e,
                 flow_label="chat",
             )
             yield streaming_service.format_error(
                 user_message,
                 error_code=error_code,
+                diagnostic=diagnostic,
                 extra=extra,
             )
             yield streaming_service.format_done()

--- a/surfsense_backend/app/routes/model_connections_routes.py
+++ b/surfsense_backend/app/routes/model_connections_routes.py
@@ -460,7 +460,7 @@ async def preview_connection_models(
     try:
         discovered = await discover_models(draft)
     except ModelDiscoveryError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        raise HTTPException(status_code=400, detail=f"{exc}. Try typing the model id manually.") from exc
     return [_preview_model_read(item) for item in discovered]
 
 

--- a/surfsense_backend/app/routes/model_connections_routes.py
+++ b/surfsense_backend/app/routes/model_connections_routes.py
@@ -461,7 +461,7 @@ async def preview_connection_models(
     try:
         discovered = await discover_models(draft)
     except ModelDiscoveryError as exc:
-        raise HTTPException(status_code=400, detail=f"{exc}. Try typing the model id manually.") from exc
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     return [_preview_model_read(item) for item in discovered]
 
 

--- a/surfsense_backend/app/routes/model_connections_routes.py
+++ b/surfsense_backend/app/routes/model_connections_routes.py
@@ -101,7 +101,17 @@ def _connection_read(
 
 def _apply_model_facts(model: Model, facts: dict) -> None:
     model.supports_chat = facts.get("supports_chat")
-    model.max_input_tokens = facts.get("max_input_tokens")
+    # Write-once, matching Onyx's sync_model_configurations: discovery seeds the
+    # limit for a model we have not seen before but never overwrites a stored
+    # one, so an operator's value survives every rediscovery. Clearing it in
+    # settings re-opens the model to whatever discovery reports next.
+    stored_limit = getattr(model, "max_input_tokens", None)
+    if not (
+        isinstance(stored_limit, int)
+        and not isinstance(stored_limit, bool)
+        and stored_limit > 0
+    ):
+        model.max_input_tokens = facts.get("max_input_tokens")
     model.supports_image_input = facts.get("supports_image_input")
     model.supports_tools = facts.get("supports_tools")
     model.supports_image_generation = facts.get("supports_image_generation")
@@ -609,7 +619,7 @@ async def discover_connection_models(
         else:
             db_model.display_name = item.get("display_name") or db_model.display_name
             _apply_model_facts(db_model, item)
-            db_model.catalog = item.get("metadata") or db_model.catalog
+            db_model.catalog = (item.get("metadata") or {}) or db_model.catalog
     await session.commit()
     conn = await _load_connection(session, connection_id)
     await _default_unset_roles(session, conn, list(conn.models))

--- a/surfsense_backend/app/routes/model_connections_routes.py
+++ b/surfsense_backend/app/routes/model_connections_routes.py
@@ -260,6 +260,7 @@ async def _default_unset_roles(
 async def list_model_providers(auth: AuthContext = Depends(require_session_context)):
     del auth
     local_only = {"ollama_chat", "lm_studio"}
+    hidden = {"openai_compatible_raw"}  # deprecated; superseded by openai_compatible
     return [
         ModelProviderRead(
             provider=provider,
@@ -271,6 +272,7 @@ async def list_model_providers(auth: AuthContext = Depends(require_session_conte
             local_only=provider in local_only,
         )
         for provider, spec in sorted(REGISTRY.items())
+        if provider not in hidden
     ]
 
 

--- a/surfsense_backend/app/routes/model_connections_routes.py
+++ b/surfsense_backend/app/routes/model_connections_routes.py
@@ -101,10 +101,10 @@ def _connection_read(
 
 def _apply_model_facts(model: Model, facts: dict) -> None:
     model.supports_chat = facts.get("supports_chat")
-    # Write-once, matching Onyx's sync_model_configurations: discovery seeds the
-    # limit for a model we have not seen before but never overwrites a stored
-    # one, so an operator's value survives every rediscovery. Clearing it in
-    # settings re-opens the model to whatever discovery reports next.
+    # Write-once: discovery seeds the limit for a model we have not seen before
+    # but never overwrites a stored one, so an operator's value survives every
+    # rediscovery. Clearing it in settings re-opens the model to whatever
+    # discovery reports next.
     stored_limit = getattr(model, "max_input_tokens", None)
     if not (
         isinstance(stored_limit, int)
@@ -619,7 +619,7 @@ async def discover_connection_models(
         else:
             db_model.display_name = item.get("display_name") or db_model.display_name
             _apply_model_facts(db_model, item)
-            db_model.catalog = (item.get("metadata") or {}) or db_model.catalog
+            db_model.catalog = item.get("metadata") or db_model.catalog
     await session.commit()
     conn = await _load_connection(session, connection_id)
     await _default_unset_roles(session, conn, list(conn.models))

--- a/surfsense_backend/app/routes/new_chat_routes.py
+++ b/surfsense_backend/app/routes/new_chat_routes.py
@@ -73,6 +73,7 @@ from app.schemas.new_chat import (
     TokenUsageSummary,
     TurnStatusResponse,
 )
+from app.tasks.chat.streaming.errors.messages import chat_error_message
 from app.tasks.chat.streaming.flows import (
     stream_new_chat,
     stream_resume_chat,
@@ -199,7 +200,7 @@ def _raise_if_thread_busy_for_start(thread_id: int) -> None:
         retry_after_ms = int(status_payload.get("retry_after_ms") or 0)
         detail = {
             "errorCode": "TURN_CANCELLING",
-            "message": "A previous response is still stopping. Please try again in a moment.",
+            "message": chat_error_message("TURN_CANCELLING"),
             "retry_after_ms": retry_after_ms if retry_after_ms > 0 else None,
             "retry_after_at": status_payload.get("retry_after_at"),
         }
@@ -217,7 +218,7 @@ def _raise_if_thread_busy_for_start(thread_id: int) -> None:
         status_code=409,
         detail={
             "errorCode": "THREAD_BUSY",
-            "message": "Another response is still finishing for this thread. Please try again in a moment.",
+            "message": chat_error_message("THREAD_BUSY"),
         },
     )
 
@@ -1864,6 +1865,7 @@ async def cancel_active_turn(
         return CancelActiveTurnResponse(
             status="idle",
             error_code="NO_ACTIVE_TURN",
+            message=chat_error_message("NO_ACTIVE_TURN"),
         )
 
     request_cancel(str(thread_id))
@@ -1880,6 +1882,7 @@ async def cancel_active_turn(
     return CancelActiveTurnResponse(
         status="cancelling",
         error_code="TURN_CANCELLING",
+        message=chat_error_message("TURN_CANCELLING"),
         retry_after_ms=retry_after_ms if retry_after_ms > 0 else None,
         retry_after_at=retry_after_at,
     )

--- a/surfsense_backend/app/routes/workspaces_routes.py
+++ b/surfsense_backend/app/routes/workspaces_routes.py
@@ -236,7 +236,7 @@ async def read_workspaces(
 
 
 @router.get("/workspaces/limits")
-async def read_workspace_limits(_auth: AuthContext = Depends(allow_any_principal)):
+async def read_workspace_limits(_auth: AuthContext = Depends(require_session_context)):
     return {"max_workspaces_per_user": config.MAX_WORKSPACES_PER_USER}
 
 

--- a/surfsense_backend/app/schemas/model_connections.py
+++ b/surfsense_backend/app/schemas/model_connections.py
@@ -97,7 +97,7 @@ class ModelUpdate(BaseModel):
     display_name: str | None = Field(None, max_length=255)
     enabled: bool | None = None
     supports_chat: bool | None = None
-    max_input_tokens: int | None = None
+    max_input_tokens: int | None = Field(None, gt=0)
     supports_image_input: bool | None = None
     supports_tools: bool | None = None
     supports_image_generation: bool | None = None

--- a/surfsense_backend/app/schemas/new_chat.py
+++ b/surfsense_backend/app/schemas/new_chat.py
@@ -463,6 +463,7 @@ class CancelActiveTurnResponse(BaseModel):
 
     status: Literal["cancelling", "idle"]
     error_code: Literal["TURN_CANCELLING", "NO_ACTIVE_TURN"]
+    message: str
     retry_after_ms: int | None = None
     retry_after_at: int | None = None
 

--- a/surfsense_backend/app/services/context_admission.py
+++ b/surfsense_backend/app/services/context_admission.py
@@ -1,0 +1,392 @@
+"""Shared model-context counting, trimming, and admission helpers."""
+
+from __future__ import annotations
+
+import copy
+import json
+from collections.abc import Callable
+from typing import Any
+
+from langchain_core.exceptions import ContextOverflowError
+from langchain_core.messages import (
+    AIMessage,
+    BaseMessage,
+    HumanMessage,
+    SystemMessage,
+    ToolMessage,
+)
+
+TokenCounter = Callable[[list[dict[str, Any]]], int | None]
+
+_TRIM_SUFFIX = (
+    "\n\n<!-- Content trimmed to fit model context window. "
+    "Some documents were omitted. Refine your query or "
+    "reduce top_k for different results. -->"
+)
+
+
+def conservative_token_estimate(messages: list[dict[str, Any]]) -> int:
+    """Estimate tokens conservatively when the selected tokenizer is unavailable."""
+    serialized = json.dumps(messages, ensure_ascii=False, default=str)
+    return max(1, (len(serialized) + 2) // 3)
+
+
+def convert_langchain_messages(
+    messages: list[BaseMessage],
+    sanitize_content: Callable[[Any], Any],
+) -> list[dict[str, Any]]:
+    """Convert LangChain messages to the OpenAI representation used for counting."""
+    result: list[dict[str, Any]] = []
+    for msg in messages:
+        if isinstance(msg, SystemMessage):
+            result.append({"role": "system", "content": msg.content})
+        elif isinstance(msg, HumanMessage):
+            result.append({"role": "user", "content": msg.content})
+        elif isinstance(msg, AIMessage):
+            ai_msg: dict[str, Any] = {"role": "assistant"}
+            sanitized = sanitize_content(msg.content) if msg.content else ""
+            ai_msg["content"] = sanitized if sanitized else ""
+            if msg.tool_calls:
+                ai_msg["tool_calls"] = [
+                    {
+                        "id": tool_call.get("id", ""),
+                        "type": "function",
+                        "function": {
+                            "name": tool_call.get("name", ""),
+                            "arguments": (
+                                tool_call.get("args", "{}")
+                                if isinstance(tool_call.get("args"), str)
+                                else json.dumps(tool_call.get("args", {}))
+                            ),
+                        },
+                    }
+                    for tool_call in msg.tool_calls
+                ]
+            result.append(ai_msg)
+        elif isinstance(msg, ToolMessage):
+            result.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": msg.tool_call_id,
+                    "content": (
+                        msg.content
+                        if isinstance(msg.content, str)
+                        else json.dumps(msg.content)
+                    ),
+                }
+            )
+        else:
+            role = getattr(msg, "type", "user")
+            if role == "human":
+                role = "user"
+            elif role == "ai":
+                role = "assistant"
+            result.append({"role": role, "content": msg.content})
+    return result
+
+
+def _count(
+    messages: list[dict[str, Any]],
+    count_tokens: TokenCounter,
+    *,
+    estimate_on_failure: bool,
+) -> int | None:
+    counted = count_tokens(messages)
+    if counted is not None:
+        return counted
+    return conservative_token_estimate(messages) if estimate_on_failure else None
+
+
+def compute_tool_tokens(tools: Any, count_tokens: TokenCounter) -> int:
+    """Count the tokens a bound tool-schema payload adds to every request.
+
+    ``litellm.token_counter`` is given only ``messages``, so without this the
+    schemas are budgeted as zero and an oversized request passes local
+    admission just to be rejected by the provider, which does charge them.
+    Each schema is counted as a lone user message, so the reservation includes
+    that message's framing overhead per tool -- erring toward reserving
+    slightly too much rather than too little.
+    """
+    if not isinstance(tools, list) or not tools:
+        return 0
+    total = 0
+    for tool in tools:
+        try:
+            serialized = json.dumps(tool, ensure_ascii=False, default=str)
+        except (TypeError, ValueError):
+            continue
+        total += (
+            _count(
+                [{"role": "user", "content": serialized}],
+                count_tokens,
+                estimate_on_failure=True,
+            )
+            or 0
+        )
+    return total
+
+
+def trim_messages_to_fit_context(
+    messages: list[dict[str, Any]],
+    *,
+    count_tokens: TokenCounter,
+    max_input_tokens: int,
+    output_reserve_fraction: float = 0.10,
+    minimum_output_reserve: int = 0,
+    safety_margin_fraction: float = 0.0,
+    reserved_tokens: int = 0,
+    preserve_protected_content: bool = False,
+    estimate_on_count_failure: bool = True,
+) -> tuple[list[dict[str, Any]], int, int]:
+    """Fit messages to a context budget while preserving router compatibility.
+
+    ``reserved_tokens`` covers request parts the token counter never sees --
+    today, the bound tool schemas.
+    """
+    output_reserve = max(
+        minimum_output_reserve,
+        min(int(max_input_tokens * output_reserve_fraction), 16_384),
+    )
+    safety_margin = int(max_input_tokens * safety_margin_fraction)
+    budget = max(
+        0, max_input_tokens - output_reserve - safety_margin - max(0, reserved_tokens)
+    )
+    total_tokens = _count(
+        messages,
+        count_tokens,
+        estimate_on_failure=estimate_on_count_failure,
+    )
+    if total_tokens is None:
+        return messages, 0, budget
+    if total_tokens <= budget:
+        return messages, total_tokens, budget
+
+    trimmed = copy.deepcopy(messages)
+    message_token_map: dict[int, int] = {}
+    candidate_priority: dict[int, int] = {}
+    for index, message in enumerate(trimmed):
+        if message.get("role") == "system":
+            continue
+        role = message.get("role")
+        content = message.get("content", "")
+        if not isinstance(content, str) or len(content) < 500:
+            continue
+        is_document = "<document>" in content or "<mentioned_documents>" in content
+        if role in ("tool", "assistant"):
+            candidate_priority[index] = 0
+        elif role == "user" and is_document:
+            candidate_priority[index] = 1
+        else:
+            continue
+        message_tokens = _count(
+            [message],
+            count_tokens,
+            estimate_on_failure=estimate_on_count_failure,
+        )
+        if message_tokens is not None:
+            message_token_map[index] = message_tokens
+
+    candidates = sorted(
+        message_token_map.items(),
+        key=lambda item: (candidate_priority.get(item[0], 9), -item[1]),
+    )
+    running_total = total_tokens
+    for index, original_message_tokens in candidates:
+        if running_total <= budget:
+            break
+
+        content = trimmed[index]["content"]
+        original_length = len(content)
+        low, high = 200, original_length - 1
+        best = 200
+        while low <= high:
+            midpoint = (low + high) // 2
+            trimmed[index]["content"] = content[:midpoint] + _TRIM_SUFFIX
+            new_message_tokens = _count(
+                [trimmed[index]],
+                count_tokens,
+                estimate_on_failure=estimate_on_count_failure,
+            )
+            if new_message_tokens is None:
+                high = midpoint - 1
+                continue
+            projected_total = (
+                running_total - original_message_tokens + new_message_tokens
+            )
+            if projected_total <= budget:
+                best = midpoint
+                low = midpoint + 1
+            else:
+                high = midpoint - 1
+
+        last_document_end = content[:best].rfind("</document>")
+        if last_document_end > min(200, best // 4):
+            best = last_document_end + len("</document>")
+        trimmed[index]["content"] = content[:best] + _TRIM_SUFFIX
+        new_message_tokens = _count(
+            [trimmed[index]],
+            count_tokens,
+            estimate_on_failure=estimate_on_count_failure,
+        )
+        if new_message_tokens is None:
+            continue
+        running_total = running_total - original_message_tokens + new_message_tokens
+
+    recounted = _count(
+        trimmed,
+        count_tokens,
+        estimate_on_failure=estimate_on_count_failure,
+    )
+    if recounted is not None:
+        running_total = recounted
+    if running_total <= budget:
+        return trimmed, running_total, budget
+    if preserve_protected_content:
+        removable_indices = [
+            index
+            for index, message in enumerate(trimmed)
+            if isinstance(message.get("content"), str)
+            and message["content"]
+            and (
+                message.get("role") in ("tool", "assistant")
+                or (
+                    message.get("role") == "user"
+                    and (
+                        "<document>" in message["content"]
+                        or "<mentioned_documents>" in message["content"]
+                    )
+                )
+            )
+        ]
+        for index in removable_indices:
+            if running_total <= budget:
+                return trimmed, running_total, budget
+            role = trimmed[index].get("role", "message")
+            trimmed[index]["content"] = (
+                f"[content omitted to fit model context window; role={role}]"
+            )
+            recounted = _count(
+                trimmed,
+                count_tokens,
+                estimate_on_failure=estimate_on_count_failure,
+            )
+            if recounted is not None:
+                running_total = recounted
+        for index in removable_indices:
+            if running_total <= budget:
+                return trimmed, running_total, budget
+            trimmed[index]["content"] = ""
+            recounted = _count(
+                trimmed,
+                count_tokens,
+                estimate_on_failure=estimate_on_count_failure,
+            )
+            if recounted is not None:
+                running_total = recounted
+        raise ContextOverflowError(
+            f"Request requires {running_total} input tokens but the model budget is "
+            f"{budget} (max_input_tokens={max_input_tokens}, output_reserve="
+            f"{output_reserve}, safety_margin={safety_margin}, tool_schemas="
+            f"{max(0, reserved_tokens)}); protected system or user content cannot "
+            "be truncated."
+        )
+
+    # Preserve the Auto router's existing aggressive final fallback.
+    fallback_indices = [
+        index
+        for index, message in enumerate(trimmed)
+        if message.get("role") != "system"
+        and isinstance(message.get("content"), str)
+        and message["content"]
+    ]
+    for index in fallback_indices:
+        if running_total <= budget:
+            break
+        role = trimmed[index].get("role", "message")
+        old_tokens = (
+            _count(
+                [trimmed[index]],
+                count_tokens,
+                estimate_on_failure=estimate_on_count_failure,
+            )
+            or 0
+        )
+        trimmed[index]["content"] = (
+            f"[content omitted to fit model context window; role={role}]"
+        )
+        running_total += (
+            _count(
+                [trimmed[index]],
+                count_tokens,
+                estimate_on_failure=estimate_on_count_failure,
+            )
+            or 0
+        ) - old_tokens
+        recounted = _count(
+            trimmed,
+            count_tokens,
+            estimate_on_failure=estimate_on_count_failure,
+        )
+        if recounted is not None:
+            running_total = recounted
+
+    if running_total > budget:
+        for index in fallback_indices:
+            if running_total <= budget:
+                break
+            old_tokens = (
+                _count(
+                    [trimmed[index]],
+                    count_tokens,
+                    estimate_on_failure=estimate_on_count_failure,
+                )
+                or 0
+            )
+            trimmed[index]["content"] = ""
+            running_total += (
+                _count(
+                    [trimmed[index]],
+                    count_tokens,
+                    estimate_on_failure=estimate_on_count_failure,
+                )
+                or 0
+            ) - old_tokens
+            recounted = _count(
+                trimmed,
+                count_tokens,
+                estimate_on_failure=estimate_on_count_failure,
+            )
+            if recounted is not None:
+                running_total = recounted
+
+    return trimmed, running_total, budget
+
+
+def admit_langchain_messages(
+    messages: list[BaseMessage],
+    *,
+    sanitize_content: Callable[[Any], Any],
+    count_tokens: TokenCounter,
+    max_input_tokens: int,
+    reserved_tokens: int = 0,
+) -> list[BaseMessage]:
+    """Admit sanitized LangChain messages without corrupting protected content."""
+    provider_messages = convert_langchain_messages(messages, sanitize_content)
+    admitted, _, _ = trim_messages_to_fit_context(
+        provider_messages,
+        count_tokens=count_tokens,
+        max_input_tokens=max_input_tokens,
+        output_reserve_fraction=0.0,
+        minimum_output_reserve=1_024,
+        safety_margin_fraction=0.05,
+        reserved_tokens=reserved_tokens,
+        preserve_protected_content=True,
+    )
+    if admitted is provider_messages:
+        return messages
+
+    result = [message.model_copy(deep=True) for message in messages]
+    for index, admitted_message in enumerate(admitted):
+        if admitted_message.get("content") != provider_messages[index].get("content"):
+            result[index].content = admitted_message["content"]
+    return result

--- a/surfsense_backend/app/services/context_admission.py
+++ b/surfsense_backend/app/services/context_admission.py
@@ -20,19 +20,11 @@ from langchain_core.messages import (
 TokenCounter = Callable[[list[dict[str, Any]]], int | None]
 
 
-def _env_positive_int(name: str, default: int) -> int:
-    try:
-        value = int(os.getenv(name) or default)
-    except ValueError:
-        return default
-    return value if value > 0 else default
-
-
 # Budget for a model no source can size. Env-overridable so a deployment behind
 # a gateway of models LiteLLM has never heard of can raise it in one place
 # instead of editing every model by hand.
-GEN_AI_MODEL_FALLBACK_MAX_TOKENS = _env_positive_int(
-    "GEN_AI_MODEL_FALLBACK_MAX_TOKENS", 32_000
+SURFSENSE_UNKNOWN_MODEL_MAX_INPUT_TOKENS = int(
+    os.getenv("SURFSENSE_UNKNOWN_MODEL_MAX_INPUT_TOKENS", "32000")
 )
 
 _TRIM_SUFFIX = (

--- a/surfsense_backend/app/services/context_admission.py
+++ b/surfsense_backend/app/services/context_admission.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import copy
 import json
+import os
 from collections.abc import Callable
 from typing import Any
 
@@ -17,6 +18,22 @@ from langchain_core.messages import (
 )
 
 TokenCounter = Callable[[list[dict[str, Any]]], int | None]
+
+
+def _env_positive_int(name: str, default: int) -> int:
+    try:
+        value = int(os.getenv(name) or default)
+    except ValueError:
+        return default
+    return value if value > 0 else default
+
+
+# Budget for a model no source can size. Env-overridable so a deployment behind
+# a gateway of models LiteLLM has never heard of can raise it in one place
+# instead of editing every model by hand.
+GEN_AI_MODEL_FALLBACK_MAX_TOKENS = _env_positive_int(
+    "GEN_AI_MODEL_FALLBACK_MAX_TOKENS", 32_000
+)
 
 _TRIM_SUFFIX = (
     "\n\n<!-- Content trimmed to fit model context window. "

--- a/surfsense_backend/app/services/llm_error_adapter.py
+++ b/surfsense_backend/app/services/llm_error_adapter.py
@@ -45,7 +45,7 @@ _CATEGORY_MESSAGES: dict[LLMErrorCategory, str] = {
     LLMErrorCategory.MODEL_NOT_FOUND: "Model not found. Check your model configuration.",
     LLMErrorCategory.BAD_REQUEST: "LLM rejected the request. Document content may be invalid.",
     LLMErrorCategory.CONTEXT_LIMIT: "Document exceeds the LLM context window even after optimization.",
-    LLMErrorCategory.INSUFFICIENT_MEMORY: "The LLM host ran out of memory loading this model. Lower the model's context limit.",
+    LLMErrorCategory.INSUFFICIENT_MEMORY: "The LLM host ran out of memory loading this model. Free memory on the host or use a smaller model.",
     LLMErrorCategory.RESPONSE_INVALID: "LLM returned an invalid response.",
     LLMErrorCategory.SERVER_ERROR: "LLM internal server error. Will retry on next sync.",
     LLMErrorCategory.UNKNOWN: "Something went wrong when calling the LLM.",

--- a/surfsense_backend/app/services/llm_error_adapter.py
+++ b/surfsense_backend/app/services/llm_error_adapter.py
@@ -19,6 +19,7 @@ class LLMErrorCategory(StrEnum):
     MODEL_NOT_FOUND = "model_not_found"
     BAD_REQUEST = "bad_request"
     CONTEXT_LIMIT = "context_limit"
+    INSUFFICIENT_MEMORY = "insufficient_memory"
     RESPONSE_INVALID = "response_invalid"
     SERVER_ERROR = "server_error"
     UNKNOWN = "unknown"
@@ -44,6 +45,7 @@ _CATEGORY_MESSAGES: dict[LLMErrorCategory, str] = {
     LLMErrorCategory.MODEL_NOT_FOUND: "Model not found. Check your model configuration.",
     LLMErrorCategory.BAD_REQUEST: "LLM rejected the request. Document content may be invalid.",
     LLMErrorCategory.CONTEXT_LIMIT: "Document exceeds the LLM context window even after optimization.",
+    LLMErrorCategory.INSUFFICIENT_MEMORY: "The LLM host ran out of memory loading this model. Lower the model's context limit.",
     LLMErrorCategory.RESPONSE_INVALID: "LLM returned an invalid response.",
     LLMErrorCategory.SERVER_ERROR: "LLM internal server error. Will retry on next sync.",
     LLMErrorCategory.UNKNOWN: "Something went wrong when calling the LLM.",
@@ -95,6 +97,27 @@ _CLASS_NAME_MAP: tuple[tuple[LLMErrorCategory, tuple[str, ...]], ...] = (
         ("BadRequestError", "InvalidRequestError", "UnprocessableEntityError"),
     ),
     (LLMErrorCategory.SERVER_ERROR, ("InternalServerError",)),
+)
+
+# The first block is Ollama's own ``outOfMemorySubstrings`` from ``llm/status.go``:
+# the list they scrape subprocess logs with, so matching it keeps us in step with
+# what the runtime itself calls an OOM. The last two are returned directly rather
+# than logged, so they are absent from that list -- the pre-flight "does not fit"
+# check, which is ``ErrLoadRequiredFull`` on current Ollama and was a formatted
+# "requires more system memory" through v0.9.
+_INSUFFICIENT_MEMORY_HINTS = (
+    "out of memory",
+    "out of device memory",
+    "cudamalloc failed",
+    "hipmalloc failed",
+    "failed to allocate",
+    "allocation failed",
+    "not enough memory",
+    "insufficient memory",
+    "vk_error_out_of_device_memory",
+    "erroroutofmemory",
+    "unable to load full model on gpu",
+    "requires more system memory",
 )
 
 
@@ -199,6 +222,12 @@ def _category_from_provider_payload(
 
 def _category_from_message(raw: str) -> LLMErrorCategory | None:
     lowered = raw.lower()
+    # Checked first: a runtime that fails to reserve the KV cache reports the
+    # requested ``n_ctx`` alongside the allocation failure, which would otherwise
+    # read as a context-limit error and tell the user to shrink a prompt that was
+    # never the problem.
+    if any(hint in lowered for hint in _INSUFFICIENT_MEMORY_HINTS):
+        return LLMErrorCategory.INSUFFICIENT_MEMORY
     if any(
         hint in lowered
         for hint in ("rate limit", "rate-limited", "temporarily rate-limited")

--- a/surfsense_backend/app/services/llm_error_adapter.py
+++ b/surfsense_backend/app/services/llm_error_adapter.py
@@ -99,17 +99,16 @@ _CLASS_NAME_MAP: tuple[tuple[LLMErrorCategory, tuple[str, ...]], ...] = (
 
 
 def _parse_error_payload(message: str) -> dict[str, Any] | None:
-    candidates = [message]
-    first_brace_idx = message.find("{")
-    if first_brace_idx >= 0:
-        candidates.append(message[first_brace_idx:])
-
-    for candidate in candidates:
+    decoder = json.JSONDecoder()
+    candidate_starts = [-1]
+    candidate_starts.extend(index for index, char in enumerate(message) if char == "{")
+    for start in candidate_starts[:21]:
+        candidate = message if start == -1 else message[start:]
         try:
-            parsed = json.loads(candidate)
+            parsed, _ = decoder.raw_decode(candidate)
             if isinstance(parsed, dict):
                 return parsed
-        except Exception:
+        except (TypeError, ValueError):
             continue
     return None
 
@@ -160,6 +159,25 @@ def _category_from_provider_payload(
     status_code: int | None,
     provider_error_type: str | None,
 ) -> LLMErrorCategory | None:
+    normalized_type = (provider_error_type or "").lower()
+    if normalized_type == "rate_limit_error":
+        return LLMErrorCategory.RATE_LIMITED
+    if normalized_type in {
+        "authentication_error",
+        "invalid_api_key",
+        "invalid_api_key_error",
+    }:
+        return LLMErrorCategory.AUTH_FAILED
+    if normalized_type in {"permission_denied", "forbidden"}:
+        return LLMErrorCategory.PERMISSION_DENIED
+    if normalized_type in {"not_found_error", "model_not_found"}:
+        return LLMErrorCategory.MODEL_NOT_FOUND
+    if normalized_type in {
+        "context_length_exceeded",
+        "context_window_exceeded",
+        "exceed_context_size_error",
+    }:
+        return LLMErrorCategory.CONTEXT_LIMIT
     if status_code == 429:
         return LLMErrorCategory.RATE_LIMITED
     if status_code == 401:
@@ -176,22 +194,6 @@ def _category_from_provider_payload(
         return LLMErrorCategory.PROVIDER_UNAVAILABLE
     if status_code is not None and status_code >= 500:
         return LLMErrorCategory.SERVER_ERROR
-
-    normalized_type = (provider_error_type or "").lower()
-    if normalized_type == "rate_limit_error":
-        return LLMErrorCategory.RATE_LIMITED
-    if normalized_type in {
-        "authentication_error",
-        "invalid_api_key",
-        "invalid_api_key_error",
-    }:
-        return LLMErrorCategory.AUTH_FAILED
-    if normalized_type in {"permission_denied", "forbidden"}:
-        return LLMErrorCategory.PERMISSION_DENIED
-    if normalized_type in {"not_found_error", "model_not_found"}:
-        return LLMErrorCategory.MODEL_NOT_FOUND
-    if normalized_type in {"context_length_exceeded", "context_window_exceeded"}:
-        return LLMErrorCategory.CONTEXT_LIMIT
     return None
 
 
@@ -226,30 +228,87 @@ def _category_from_message(raw: str) -> LLMErrorCategory | None:
             "context window",
             "maximum context",
             "too many tokens",
+            "available context size",
+            "n_ctx",
         )
     ):
         return LLMErrorCategory.CONTEXT_LIMIT
     return None
 
 
-def adapt_llm_exception(exc: BaseException) -> LLMErrorAdaptation:
-    raw = str(exc)
-    parsed = _parse_error_payload(raw)
-    status_code = _extract_provider_status_code(parsed)
-    provider_error_type = _extract_provider_error_type(parsed)
+def _exception_chain(exc: BaseException, max_depth: int = 5) -> list[BaseException]:
+    chain: list[BaseException] = []
+    seen: set[int] = set()
+    current: BaseException | None = exc
+    while current is not None and len(chain) < max_depth and id(current) not in seen:
+        chain.append(current)
+        seen.add(id(current))
+        current = current.__cause__ or current.__context__
+    return chain
 
-    category = (
-        _category_from_provider_payload(status_code, provider_error_type)
-        or _category_from_message(raw)
-        or _category_from_class_name(exc)
-        or LLMErrorCategory.UNKNOWN
-    )
+
+def adapt_llm_exception(exc: BaseException) -> LLMErrorAdaptation:
+    entries: list[tuple[BaseException, str, int | None, str | None]] = []
+    for current in _exception_chain(exc):
+        raw = str(current)
+        parsed = _parse_error_payload(raw)
+        entries.append(
+            (
+                current,
+                raw,
+                _extract_provider_status_code(parsed),
+                _extract_provider_error_type(parsed),
+            )
+        )
+
+    category: LLMErrorCategory | None = None
+    matched_status: int | None = None
+    matched_type: str | None = None
+
+    # Provider semantics across the entire wrapper chain must win over generic
+    # HTTP statuses and wrapper class names.
+    for _, _, status_code, provider_error_type in entries:
+        if provider_error_type:
+            semantic = _category_from_provider_payload(None, provider_error_type)
+            if semantic is not None:
+                category = semantic
+                matched_status = status_code
+                matched_type = provider_error_type
+                break
+    if category is None:
+        for _, raw, status_code, provider_error_type in entries:
+            semantic = _category_from_message(raw)
+            if semantic is not None:
+                category = semantic
+                matched_status = status_code
+                matched_type = provider_error_type
+                break
+    if category is None:
+        for _, _, status_code, provider_error_type in entries:
+            status_category = _category_from_provider_payload(
+                status_code, provider_error_type
+            )
+            if status_category is not None:
+                category = status_category
+                matched_status = status_code
+                matched_type = provider_error_type
+                break
+    if category is None:
+        for current, _, status_code, provider_error_type in entries:
+            class_category = _category_from_class_name(current)
+            if class_category is not None:
+                category = class_category
+                matched_status = status_code
+                matched_type = provider_error_type
+                break
+
+    category = category or LLMErrorCategory.UNKNOWN
     return LLMErrorAdaptation(
         category=category,
         retryable=category in _RETRYABLE_CATEGORIES,
         user_message=_CATEGORY_MESSAGES[category],
-        provider_status_code=status_code,
-        provider_error_type=provider_error_type,
+        provider_status_code=matched_status,
+        provider_error_type=matched_type,
     )
 
 

--- a/surfsense_backend/app/services/llm_router_service.py
+++ b/surfsense_backend/app/services/llm_router_service.py
@@ -11,7 +11,6 @@ The router is initialized from global LLM configs and provides both
 synchronous ChatLiteLLM-like interface and async methods.
 """
 
-import copy
 import logging
 import re
 import time
@@ -30,6 +29,10 @@ from litellm.exceptions import (
 )
 from pydantic import Field
 
+from app.services.context_admission import (
+    compute_tool_tokens,
+    trim_messages_to_fit_context,
+)
 from app.services.model_resolver import native_connection_from_config, to_litellm
 from app.utils.perf import get_perf_logger
 
@@ -648,158 +651,23 @@ class ChatLiteLLMRouter(BaseChatModel):
         tokens with ``litellm.token_counter``.
         """
         max_input = self._get_max_input_tokens()
-        output_reserve = min(int(max_input * output_reserve_fraction), 16_384)
-        budget = max_input - output_reserve
-
-        total_tokens = self._count_tokens(messages)
-        if total_tokens is None:
-            return messages
-
-        if total_tokens <= budget:
-            return messages
-
-        perf = get_perf_logger()
-        perf.warning(
-            "[llm_router] context overflow detected: %d tokens > %d budget "
-            "(max_input=%d, reserve=%d). Trimming messages.",
-            total_tokens,
-            budget,
-            max_input,
-            output_reserve,
+        trimmed, final_tokens, budget = trim_messages_to_fit_context(
+            messages,
+            count_tokens=self._count_tokens,
+            max_input_tokens=max_input,
+            output_reserve_fraction=output_reserve_fraction,
+            reserved_tokens=compute_tool_tokens(
+                getattr(self, "_bound_tools", None), self._count_tokens
+            ),
+            estimate_on_count_failure=False,
         )
-
-        trimmed = copy.deepcopy(messages)
-
-        # Per-message token counts for trimmable candidates.
-        # Skip system messages to preserve agent instructions.
-        msg_token_map: dict[int, int] = {}
-        candidate_priority: dict[int, int] = {}
-        for i, msg in enumerate(trimmed):
-            if msg.get("role") == "system":
-                continue
-            role = msg.get("role")
-            content = msg.get("content", "")
-            if not isinstance(content, str) or len(content) < 500:
-                continue
-            # Prefer trimming tool/assistant outputs first.
-            # User messages are only trimmed if they clearly contain injected
-            # document context blobs.
-            is_doc_blob = "<document>" in content or "<mentioned_documents>" in content
-            if role in ("tool", "assistant"):
-                candidate_priority[i] = 0
-            elif role == "user" and is_doc_blob:
-                candidate_priority[i] = 1
-            else:
-                continue
-            token_count = self._count_tokens([msg])
-            if token_count is not None:
-                msg_token_map[i] = token_count
-
-        if not msg_token_map:
-            perf.warning("[llm_router] no trimmable messages found, returning as-is")
-            return trimmed
-
-        # Trim largest messages first
-        candidates = sorted(
-            msg_token_map.items(),
-            key=lambda x: (candidate_priority.get(x[0], 9), -x[1]),
-        )
-        running_total = total_tokens
-
-        trim_suffix = (
-            "\n\n<!-- Content trimmed to fit model context window. "
-            "Some documents were omitted. Refine your query or "
-            "reduce top_k for different results. -->"
-        )
-
-        for idx, orig_msg_tokens in candidates:
-            if running_total <= budget:
-                break
-
-            content = trimmed[idx]["content"]
-            orig_len = len(content)
-
-            # Binary search: find maximum content[:mid] that keeps total ≤ budget.
-            lo, hi = 200, orig_len - 1
-            best = 200
-
-            while lo <= hi:
-                mid = (lo + hi) // 2
-                trimmed[idx]["content"] = content[:mid] + trim_suffix
-                new_msg_tokens = self._count_tokens([trimmed[idx]])
-                if new_msg_tokens is None:
-                    hi = mid - 1
-                    continue
-
-                projected_total = running_total - orig_msg_tokens + new_msg_tokens
-                if projected_total <= budget:
-                    best = mid
-                    lo = mid + 1
-                else:
-                    hi = mid - 1
-
-            # Prefer cutting at a </document> boundary for cleaner output
-            last_doc_end = content[:best].rfind("</document>")
-            if last_doc_end > min(200, best // 4):
-                best = last_doc_end + len("</document>")
-
-            trimmed[idx]["content"] = content[:best] + trim_suffix
-
-            try:
-                new_msg_tokens = self._count_tokens([trimmed[idx]])
-                if new_msg_tokens is None:
-                    continue
-                running_total = running_total - orig_msg_tokens + new_msg_tokens
-            except Exception:
-                pass
-
-        # Hard guarantee: if still over budget, replace remaining large
-        # non-system messages with compact placeholders until we fit.
-        if running_total > budget:
-            fallback_indices: list[int] = []
-            for i, msg in enumerate(trimmed):
-                if msg.get("role") == "system":
-                    continue
-                content = msg.get("content")
-                if isinstance(content, str) and len(content) > 0:
-                    fallback_indices.append(i)
-
-            for idx in fallback_indices:
-                if running_total <= budget:
-                    break
-                role = trimmed[idx].get("role", "message")
-                placeholder = (
-                    f"[content omitted to fit model context window; role={role}]"
-                )
-                old_tokens = self._count_tokens([trimmed[idx]]) or 0
-                trimmed[idx]["content"] = placeholder
-                new_tokens = self._count_tokens([trimmed[idx]]) or 0
-                running_total = running_total - old_tokens + new_tokens
-
-            if running_total > budget:
-                perf.error(
-                    "[llm_router] unable to fit context even after aggressive trimming: "
-                    "tokens=%d budget=%d",
-                    running_total,
-                    budget,
-                )
-                # Final safety net: clear oldest non-system contents.
-                for idx in fallback_indices:
-                    if running_total <= budget:
-                        break
-                    old_tokens = self._count_tokens([trimmed[idx]]) or 0
-                    trimmed[idx]["content"] = ""
-                    new_tokens = self._count_tokens([trimmed[idx]]) or 0
-                    running_total = running_total - old_tokens + new_tokens
-
-        perf.info(
-            "[llm_router] messages trimmed: %d → %d tokens (budget=%d, max_input=%d)",
-            total_tokens,
-            running_total,
-            budget,
-            max_input,
-        )
-
+        if trimmed is not messages:
+            get_perf_logger().info(
+                "[llm_router] messages trimmed to %d tokens (budget=%d, max_input=%d)",
+                final_tokens,
+                budget,
+                max_input,
+            )
         return trimmed
 
     # -----------------------------------------------------------------
@@ -1137,61 +1005,9 @@ class ChatLiteLLMRouter(BaseChatModel):
 
     def _convert_messages(self, messages: list[BaseMessage]) -> list[dict]:
         """Convert LangChain messages to OpenAI format."""
-        from langchain_core.messages import (
-            AIMessage as AIMsg,
-            HumanMessage,
-            SystemMessage,
-            ToolMessage,
-        )
+        from app.services.context_admission import convert_langchain_messages
 
-        result = []
-        for msg in messages:
-            if isinstance(msg, SystemMessage):
-                result.append({"role": "system", "content": msg.content})
-            elif isinstance(msg, HumanMessage):
-                result.append({"role": "user", "content": msg.content})
-            elif isinstance(msg, AIMsg):
-                ai_msg: dict[str, Any] = {"role": "assistant"}
-                has_tool_calls = hasattr(msg, "tool_calls") and msg.tool_calls
-
-                sanitized = _sanitize_content(msg.content) if msg.content else ""
-                ai_msg["content"] = sanitized if sanitized else ""
-
-                if has_tool_calls:
-                    ai_msg["tool_calls"] = [
-                        {
-                            "id": tc.get("id", ""),
-                            "type": "function",
-                            "function": {
-                                "name": tc.get("name", ""),
-                                "arguments": tc.get("args", "{}")
-                                if isinstance(tc.get("args"), str)
-                                else __import__("json").dumps(tc.get("args", {})),
-                            },
-                        }
-                        for tc in msg.tool_calls
-                    ]
-                result.append(ai_msg)
-            elif isinstance(msg, ToolMessage):
-                result.append(
-                    {
-                        "role": "tool",
-                        "tool_call_id": msg.tool_call_id,
-                        "content": msg.content
-                        if isinstance(msg.content, str)
-                        else __import__("json").dumps(msg.content),
-                    }
-                )
-            else:
-                # Fallback for other message types
-                role = getattr(msg, "type", "user")
-                if role == "human":
-                    role = "user"
-                elif role == "ai":
-                    role = "assistant"
-                result.append({"role": role, "content": msg.content})
-
-        return result
+        return convert_langchain_messages(messages, _sanitize_content)
 
     def _convert_response_to_message(
         self, response_message: Any, response: Any = None

--- a/surfsense_backend/app/services/model_connection_service.py
+++ b/surfsense_backend/app/services/model_connection_service.py
@@ -406,7 +406,7 @@ def _lm_studio_native_v1_models(payload: Any) -> list[dict[str, Any]]:
                 "supports_tools": tools,
                 "supports_image_generation": False,
                 "max_input_tokens": _lm_studio_context_length(item, "native v1"),
-                "metadata": item,
+                "metadata": dict(item),
             }
         )
     return results

--- a/surfsense_backend/app/services/model_connection_service.py
+++ b/surfsense_backend/app/services/model_connection_service.py
@@ -93,6 +93,16 @@ def _model_test_error(conn: Connection, model_id: str, exc: Exception) -> Verify
         raw,
     )
 
+    if status_code == 400:
+        if "api key" in normalized:
+            return VerifyResult(
+                "AUTH_FAILED",
+                False,
+                f"Authentication failed. Check your {provider_name} credentials and try again.",
+            )
+        
+
+
     if status_code in (401, 403) or "authentication" in exc_name or "401" in normalized:
         return VerifyResult(
             "AUTH_FAILED",
@@ -114,7 +124,7 @@ def _model_test_error(conn: Connection, model_id: str, exc: Exception) -> Verify
         return VerifyResult(
             "RATE_LIMITED",
             False,
-            f"{provider_name} rate limited the model test. Try again later.",
+            f"{provider_name} rate limited the model test. Try again later or check your provider for possible insufficient quotas or unavailable model.",
         )
 
     if "timeout" in exc_name or "timed out" in normalized:

--- a/surfsense_backend/app/services/model_connection_service.py
+++ b/surfsense_backend/app/services/model_connection_service.py
@@ -347,13 +347,13 @@ def _lm_studio_context_length(item: dict[str, Any], source: str) -> int | None:
 
 
 def _lm_studio_native_v1_models(payload: Any) -> list[dict[str, Any]]:
-    if not isinstance(payload, list):
+    if not isinstance(payload, dict) or not isinstance(payload.get("models"), list):
         raise ModelDiscoveryError(
             "LM Studio native v1 returned an unsupported model-list response."
         )
 
     results: list[dict[str, Any]] = []
-    for item in payload:
+    for item in payload["models"]:
         if not isinstance(item, dict):
             raise ModelDiscoveryError(
                 "LM Studio native v1 returned an invalid model record."

--- a/surfsense_backend/app/services/model_connection_service.py
+++ b/surfsense_backend/app/services/model_connection_service.py
@@ -454,6 +454,14 @@ def _lm_studio_optional_bool(
 
 
 def _lm_studio_context_length(item: dict[str, Any], source: str) -> int | None:
+    """LM Studio's ceiling, uncapped - unlike ``_ollama_seed_budget``.
+
+    A person picks this window when they load the model, so it describes the
+    deployment; Ollama's maximum is auto-sized from free memory, so only that
+    one needs a cap. ``loaded_instances[].config.context_length`` is left
+    unread on purpose: seeding is write-once and a loaded instance vanishes on
+    the next reload.
+    """
     value = item.get("max_context_length")
     if value is None:
         return None

--- a/surfsense_backend/app/services/model_connection_service.py
+++ b/surfsense_backend/app/services/model_connection_service.py
@@ -6,6 +6,7 @@ import contextlib
 import logging
 from dataclasses import dataclass
 from typing import Any
+from urllib.parse import urlsplit, urlunsplit
 
 import anyio
 import httpx
@@ -93,15 +94,12 @@ def _model_test_error(conn: Connection, model_id: str, exc: Exception) -> Verify
         raw,
     )
 
-    if status_code == 400:
-        if "api key" in normalized:
-            return VerifyResult(
-                "AUTH_FAILED",
-                False,
-                f"Authentication failed. Check your {provider_name} credentials and try again.",
-            )
-        
-
+    if status_code == 400 and "api key" in normalized:
+        return VerifyResult(
+            "AUTH_FAILED",
+            False,
+            f"Authentication failed. Check your {provider_name} credentials and try again.",
+        )
 
     if status_code in (401, 403) or "authentication" in exc_name or "401" in normalized:
         return VerifyResult(
@@ -161,7 +159,19 @@ async def verify_connection(conn: Connection) -> VerifyResult:
     if spec.base_url_required and not base_url:
         return VerifyResult("UNREACHABLE", False, "Base URL is required.")
 
-    if spec.transport == Transport.OLLAMA and base_url:
+    if spec.discovery == "lm_studio_models":
+        try:
+            await _discover_lm_studio_models(conn)
+            return VerifyResult("OK", True, "Connection verified.")
+        except ModelDiscoveryError as exc:
+            return VerifyResult("UNREACHABLE", False, str(exc))
+        except httpx.ConnectError as exc:
+            return VerifyResult("UNREACHABLE", False, _docker_hint(base_url, exc))
+        except httpx.TimeoutException as exc:
+            return VerifyResult("UNREACHABLE", False, f"Connection timed out: {exc}")
+        except httpx.HTTPError as exc:
+            return VerifyResult("UNREACHABLE", False, _docker_hint(base_url, exc))
+    elif spec.transport == Transport.OLLAMA and base_url:
         url = f"{base_url.rstrip('/')}/api/version"
     elif spec.discovery in {"openai_models", "openrouter", "requesty"} and base_url:
         url = f"{base_url.rstrip('/')}/models"  # verbatim; user owns the path
@@ -300,6 +310,210 @@ async def _discover_openai_shaped_models(
             }
         )
     return results
+
+
+def _lm_studio_server_root(base_url: str) -> str:
+    parsed = urlsplit(base_url.rstrip("/"))
+    path = parsed.path.rstrip("/")
+    if path == "/v1":
+        path = ""
+    elif path.endswith("/v1"):
+        path = path[:-3]
+    return urlunsplit((parsed.scheme, parsed.netloc, path, "", ""))
+
+
+def _lm_studio_optional_bool(
+    mapping: dict[str, Any], key: str, source: str
+) -> bool | None:
+    if key not in mapping:
+        return None
+    value = mapping[key]
+    if not isinstance(value, bool):
+        raise ModelDiscoveryError(
+            f"LM Studio {source} returned a non-boolean {key} capability."
+        )
+    return value
+
+
+def _lm_studio_context_length(item: dict[str, Any], source: str) -> int | None:
+    value = item.get("max_context_length")
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ModelDiscoveryError(
+            f"LM Studio {source} returned an invalid max_context_length."
+        )
+    return value
+
+
+def _lm_studio_native_v1_models(payload: Any) -> list[dict[str, Any]]:
+    if not isinstance(payload, list):
+        raise ModelDiscoveryError(
+            "LM Studio native v1 returned an unsupported model-list response."
+        )
+
+    results: list[dict[str, Any]] = []
+    for item in payload:
+        if not isinstance(item, dict):
+            raise ModelDiscoveryError(
+                "LM Studio native v1 returned an invalid model record."
+            )
+        model_id = item.get("key")
+        if not isinstance(model_id, str) or not model_id.strip():
+            logger.warning(
+                "Skipping LM Studio native v1 model without a key",
+                extra={"provider": "lm_studio", "discovery_source": "native_v1"},
+            )
+            continue
+        model_id = model_id.strip()
+        if len(model_id) > 255:
+            raise ModelDiscoveryError(
+                "LM Studio native v1 returned a model key longer than 255 characters."
+            )
+
+        model_type = item.get("type")
+        capabilities = item.get("capabilities")
+        capabilities = capabilities if isinstance(capabilities, dict) else {}
+        is_llm = model_type == "llm"
+        is_embedding = model_type == "embedding"
+        vision = _lm_studio_optional_bool(capabilities, "vision", "native v1")
+        tools = _lm_studio_optional_bool(
+            capabilities, "trained_for_tool_use", "native v1"
+        )
+        if vision is not None:
+            supports_image_input = vision
+        elif is_embedding:
+            supports_image_input = False
+        else:
+            supports_image_input = None
+        if not is_llm and not is_embedding:
+            logger.warning(
+                "LM Studio native v1 returned an unknown model type",
+                extra={
+                    "provider": "lm_studio",
+                    "discovery_source": "native_v1",
+                    "model_type": model_type,
+                },
+            )
+
+        results.append(
+            {
+                "model_id": model_id,
+                "display_name": item.get("display_name") or model_id,
+                "source": ModelSource.DISCOVERED,
+                "supports_chat": is_llm,
+                "supports_image_input": supports_image_input,
+                "supports_tools": tools,
+                "supports_image_generation": False,
+                "max_input_tokens": _lm_studio_context_length(item, "native v1"),
+                "metadata": item,
+            }
+        )
+    return results
+
+
+def _lm_studio_native_v0_models(payload: Any) -> list[dict[str, Any]]:
+    if not isinstance(payload, dict) or not isinstance(payload.get("data"), list):
+        raise ModelDiscoveryError(
+            "LM Studio legacy v0 returned an unsupported model-list response."
+        )
+
+    results: list[dict[str, Any]] = []
+    for item in payload["data"]:
+        if not isinstance(item, dict):
+            raise ModelDiscoveryError(
+                "LM Studio legacy v0 returned an invalid model record."
+            )
+        model_id = item.get("id")
+        if not isinstance(model_id, str) or not model_id.strip():
+            logger.warning(
+                "Skipping LM Studio legacy v0 model without an id",
+                extra={"provider": "lm_studio", "discovery_source": "native_v0"},
+            )
+            continue
+        model_id = model_id.strip()
+        if len(model_id) > 255:
+            raise ModelDiscoveryError(
+                "LM Studio legacy v0 returned a model id longer than 255 characters."
+            )
+        model_type = item.get("type")
+        results.append(
+            {
+                "model_id": model_id,
+                "display_name": item.get("name") or model_id,
+                "source": ModelSource.DISCOVERED,
+                "supports_chat": model_type in {"llm", "vlm"},
+                "supports_image_input": model_type == "vlm",
+                "supports_tools": None,
+                "supports_image_generation": False,
+                "max_input_tokens": _lm_studio_context_length(item, "legacy v0"),
+                "metadata": item,
+            }
+        )
+    return results
+
+
+async def _discover_lm_studio_models(conn: Connection) -> list[dict[str, Any]]:
+    base_url = _base_url_or_default(conn)
+    if not base_url:
+        return []
+
+    server_root = _lm_studio_server_root(base_url)
+    native_sources = (
+        ("native_v1", f"{server_root}/api/v1/models", _lm_studio_native_v1_models),
+        ("native_v0", f"{server_root}/api/v0/models", _lm_studio_native_v0_models),
+    )
+
+    async with httpx.AsyncClient(timeout=DISCOVERY_TIMEOUT_SECONDS) as client:
+        for source, url, normalize in native_sources:
+            response = await client.get(url, headers=_auth_headers(conn))
+            if response.status_code in {404, 405}:
+                logger.warning(
+                    "LM Studio model discovery endpoint unavailable; trying fallback",
+                    extra={
+                        "provider": "lm_studio",
+                        "discovery_source": source,
+                        "status_code": response.status_code,
+                    },
+                )
+                continue
+            response.raise_for_status()
+            try:
+                payload = response.json()
+            except ValueError as exc:
+                raise ModelDiscoveryError(
+                    f"LM Studio {source} returned invalid JSON."
+                ) from exc
+            results = normalize(payload)
+            _log_lm_studio_discovery(source, results)
+            return results
+
+    logger.info(
+        "LM Studio native discovery unavailable; using OpenAI-compatible fallback",
+        extra={"provider": "lm_studio", "discovery_source": "openai_compatible"},
+    )
+    results = await _discover_openai_shaped_models(conn, base_url)
+    _log_lm_studio_discovery("openai_compatible", results)
+    return results
+
+
+def _log_lm_studio_discovery(source: str, models: list[dict[str, Any]]) -> None:
+    logger.info(
+        "LM Studio model discovery completed",
+        extra={
+            "provider": "lm_studio",
+            "discovery_source": source,
+            "models_total": len(models),
+            "chat_models": sum(bool(model.get("supports_chat")) for model in models),
+            "vision_models": sum(
+                bool(model.get("supports_image_input")) for model in models
+            ),
+            "embedding_models": sum(
+                (model.get("metadata") or {}).get("type") in {"embedding", "embeddings"}
+                for model in models
+            ),
+        },
+    )
 
 
 async def _discover_anthropic_models(conn: Connection) -> list[dict[str, Any]]:
@@ -470,6 +684,8 @@ async def discover_models(conn: Connection) -> list[dict[str, Any]]:
             results = await _requesty_models(conn)
         elif spec.discovery == "anthropic_models":
             results = await _discover_anthropic_models(conn)
+        elif spec.discovery == "lm_studio_models":
+            results = await _discover_lm_studio_models(conn)
         elif spec.discovery == "openai_models":
             results = await _discover_openai_shaped_models(conn, conn.base_url)
         elif spec.discovery == "bedrock_models":

--- a/surfsense_backend/app/services/model_connection_service.py
+++ b/surfsense_backend/app/services/model_connection_service.py
@@ -141,6 +141,10 @@ def _model_test_error(conn: Connection, model_id: str, exc: Exception) -> Verify
     )
 
 
+def _openai_compatible_404_hint(url: str) -> str:
+    return f"Got 404 from {url}. Check your API Base URL."
+
+
 async def verify_connection(conn: Connection) -> VerifyResult:
     spec = spec_for(conn.provider)
     base_url = _base_url_or_default(conn)
@@ -172,9 +176,9 @@ async def verify_connection(conn: Connection) -> VerifyResult:
             if spec.transport == Transport.OLLAMA and url.endswith("/v1/models"):
                 message = "Ollama native API should not use /v1."
             elif spec.transport == Transport.OPENAI_COMPATIBLE:
-                message = "OpenAI-compatible servers should expose /v1/models."
+                message = _openai_compatible_404_hint(url)
             else:
-                message = "Endpoint returned 404."
+                message = f"Endpoint returned 404 for {url}."
             return VerifyResult("NOT_FOUND", False, message)
         response.raise_for_status()
         return VerifyResult("OK", True, "Connection verified.")
@@ -194,9 +198,10 @@ def _discovery_error_message(conn: Connection, exc: httpx.HTTPError) -> str:
             return "Authentication failed while discovering models."
         if status_code == 404:
             spec = spec_for(conn.provider)
+            attempted = str(exc.request.url)
             if spec.transport == Transport.OPENAI_COMPATIBLE:
-                return "OpenAI-compatible servers should expose /v1/models."
-            return "Model discovery endpoint returned 404."
+                return _openai_compatible_404_hint(attempted)
+            return f"Model discovery endpoint returned 404 for {attempted}."
         return f"Model discovery failed with HTTP {status_code}."
     if isinstance(exc, httpx.TimeoutException):
         return f"Model discovery timed out: {exc}"

--- a/surfsense_backend/app/services/model_connection_service.py
+++ b/surfsense_backend/app/services/model_connection_service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import contextlib
 import logging
+import os
 from dataclasses import dataclass
 from typing import Any
 from urllib.parse import urlsplit, urlunsplit
@@ -23,6 +24,18 @@ logger = logging.getLogger(__name__)
 VERIFY_TIMEOUT_SECONDS = 8.0
 DISCOVERY_TIMEOUT_SECONDS = 15.0
 TEST_TIMEOUT_SECONDS = 30.0
+
+
+def _positive_int(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int) and value > 0:
+        return value
+    if isinstance(value, str):
+        with contextlib.suppress(ValueError):
+            parsed = int(value.strip())
+            return parsed if parsed > 0 else None
+    return None
 
 
 @dataclass(frozen=True)
@@ -302,6 +315,45 @@ def _classify_from_litellm(model_string: str, model_id: str) -> dict[str, Any]:
     }
 
 
+def _ollama_modelfile_num_ctx(parameters: Any) -> int | None:
+    """Read ``num_ctx`` out of Ollama's newline-delimited Modelfile parameters.
+
+    Only present when someone authored it with ``ollama create``, so it is a
+    stated preference -- usually a smaller window chosen to fit the host's
+    memory. It outranks the architecture maximum because a request-level
+    ``num_ctx`` overrides the Modelfile and we always send one: seeding from it
+    is what stops us from quietly allocating more than was asked for.
+    """
+    if not isinstance(parameters, str):
+        return None
+    for line in parameters.splitlines():
+        tokens = line.split(maxsplit=1)
+        if len(tokens) == 2 and tokens[0] == "num_ctx":
+            return _positive_int(tokens[1])
+    return None
+
+
+def _ollama_context_length(metadata: dict) -> int | None:
+    """Resolve how much context an Ollama model can take.
+
+    The Modelfile value wins, then the architecture-keyed value from
+    ``/api/show``. ``details`` is the third source because newer Ollama reports
+    ``context_length`` in ``/api/tags`` while ``/api/show`` does not.
+    """
+    model_info = metadata.get("model_info") or {}
+    architecture = model_info.get("general.architecture") or ""
+    details = metadata.get("details") or {}
+    for candidate in (
+        _ollama_modelfile_num_ctx(metadata.get("parameters")),
+        model_info.get(f"{architecture}.context_length") if architecture else None,
+        details.get("context_length"),
+    ):
+        resolved = _positive_int(candidate)
+        if resolved:
+            return resolved
+    return None
+
+
 def derive_capabilities(
     conn: Connection, model_id: str, metadata: dict | None = None
 ) -> dict[str, Any]:
@@ -311,7 +363,7 @@ def derive_capabilities(
     facts = _classify_from_litellm(model_string, model_id)
     if spec.transport == Transport.OLLAMA:
         caps = set(metadata.get("capabilities") or [])
-        details = metadata.get("details") or {}
+        discovered_context = _ollama_context_length(metadata)
         facts.update(
             {
                 "supports_chat": "embedding" not in caps,
@@ -319,10 +371,12 @@ def derive_capabilities(
                 or facts["supports_image_input"],
                 "supports_tools": "tools" in caps or facts["supports_tools"],
                 "supports_image_generation": False,
-                "max_input_tokens": metadata.get("context_length")
-                or metadata.get("num_ctx")
-                or details.get("context_length")
-                or facts["max_input_tokens"],
+                # Seeded unbounded on purpose. What the host can allocate is not
+                # ours to guess -- Ollama usually runs on another machine, and a
+                # blanket cap would cost a sliding-window model most of its window
+                # to save memory it never wanted. When the KV cache does not fit,
+                # the load fails and MODEL_OUT_OF_MEMORY names the fix.
+                "max_input_tokens": discovered_context or facts["max_input_tokens"],
             }
         )
     return facts
@@ -612,7 +666,18 @@ async def _ollama_tags_then_show(conn: Connection) -> list[dict[str, Any]]:
                     headers=_auth_headers(conn),
                 )
                 show_response.raise_for_status()
-                metadata.update(show_response.json())
+                payload = show_response.json()
+                # Both endpoints return a ``details`` block and they carry
+                # different fields, so merge rather than let the shallow update
+                # drop what only /api/tags reports (context_length on newer
+                # Ollama, embedding_length).
+                details = {
+                    **(metadata.get("details") or {}),
+                    **(payload.get("details") or {}),
+                }
+                metadata.update(payload)
+                if details:
+                    metadata["details"] = details
             results.append(
                 {
                     "model_id": model_id,
@@ -674,8 +739,6 @@ async def _discover_bedrock_models(conn: Connection) -> list[dict[str, Any]]:
         return []
 
     def list_models() -> list[dict[str, Any]]:
-        import os
-
         import boto3
 
         if bearer_token := params.get("aws_bearer_token_bedrock"):

--- a/surfsense_backend/app/services/model_connection_service.py
+++ b/surfsense_backend/app/services/model_connection_service.py
@@ -14,7 +14,7 @@ import httpx
 import litellm
 
 from app.db import Connection, Model, ModelSource
-from app.services.context_admission import GEN_AI_MODEL_FALLBACK_MAX_TOKENS
+from app.services.context_admission import SURFSENSE_UNKNOWN_MODEL_MAX_INPUT_TOKENS
 from app.services.model_resolver import to_litellm
 from app.services.openrouter_model_normalizer import normalize_openrouter_models
 from app.services.provider_registry import Transport, provider_label, spec_for
@@ -374,7 +374,7 @@ def _ollama_seed_budget(metadata: dict) -> int | None:
         return stated
     architecture_max = _ollama_architecture_context_length(metadata)
     if architecture_max:
-        return min(architecture_max, GEN_AI_MODEL_FALLBACK_MAX_TOKENS)
+        return min(architecture_max, SURFSENSE_UNKNOWN_MODEL_MAX_INPUT_TOKENS)
     return None
 
 

--- a/surfsense_backend/app/services/model_connection_service.py
+++ b/surfsense_backend/app/services/model_connection_service.py
@@ -495,7 +495,7 @@ async def _discover_lm_studio_models(conn: Connection) -> list[dict[str, Any]]:
 
     raise ModelDiscoveryError(
         "LM Studio native model discovery is unavailable. "
-        "Upgrade LM Studio to version 0.4 or newer, or enter the model ID manually."
+        "Upgrade LM Studio to version 0.4 or newer."
     )
 
 

--- a/surfsense_backend/app/services/model_connection_service.py
+++ b/surfsense_backend/app/services/model_connection_service.py
@@ -12,7 +12,7 @@ import httpx
 import litellm
 
 from app.db import Connection, Model, ModelSource
-from app.services.model_resolver import ensure_v1, to_litellm
+from app.services.model_resolver import to_litellm
 from app.services.openrouter_model_normalizer import normalize_openrouter_models
 from app.services.provider_registry import Transport, provider_label, spec_for
 from app.services.requesty_model_normalizer import normalize_requesty_models
@@ -149,10 +149,8 @@ async def verify_connection(conn: Connection) -> VerifyResult:
 
     if spec.transport == Transport.OLLAMA and base_url:
         url = f"{base_url.rstrip('/')}/api/version"
-    elif spec.discovery == "openai_models" and base_url:
+    elif spec.discovery in {"openai_models", "openrouter", "requesty"} and base_url:
         url = f"{base_url.rstrip('/')}/models"  # verbatim; user owns the path
-    elif spec.discovery in {"openrouter", "requesty"} and base_url:
-        url = f"{ensure_v1(base_url)}/models"
     elif spec.discovery == "anthropic_models" and base_url:
         url = f"{base_url.rstrip('/')}/models"
     else:
@@ -355,7 +353,7 @@ async def _openrouter_models(conn: Connection) -> list[dict[str, Any]]:
     base_url = _base_url_or_default(conn) or "https://openrouter.ai/api/v1"
     async with httpx.AsyncClient(timeout=DISCOVERY_TIMEOUT_SECONDS) as client:
         response = await client.get(
-            f"{ensure_v1(base_url)}/models", headers=_auth_headers(conn)
+            f"{base_url.rstrip('/')}/models", headers=_auth_headers(conn)
         )
     response.raise_for_status()
     return normalize_openrouter_models(response.json().get("data", []))
@@ -365,7 +363,7 @@ async def _requesty_models(conn: Connection) -> list[dict[str, Any]]:
     base_url = _base_url_or_default(conn) or "https://router.requesty.ai/v1"
     async with httpx.AsyncClient(timeout=DISCOVERY_TIMEOUT_SECONDS) as client:
         response = await client.get(
-            f"{ensure_v1(base_url)}/models", headers=_auth_headers(conn)
+            f"{base_url.rstrip('/')}/models", headers=_auth_headers(conn)
         )
     response.raise_for_status()
     return normalize_requesty_models(response.json().get("data", []))

--- a/surfsense_backend/app/services/model_connection_service.py
+++ b/surfsense_backend/app/services/model_connection_service.py
@@ -469,7 +469,12 @@ async def _discover_lm_studio_models(conn: Connection) -> list[dict[str, Any]]:
             response = await client.get(url, headers=_auth_headers(conn))
             if response.status_code in {404, 405}:
                 logger.warning(
-                    "LM Studio model discovery endpoint unavailable; trying fallback",
+                    (
+                        "LM Studio current discovery endpoint unavailable; "
+                        "trying legacy native fallback"
+                        if source == "native_v1"
+                        else "LM Studio native discovery endpoints unavailable"
+                    ),
                     extra={
                         "provider": "lm_studio",
                         "discovery_source": source,
@@ -488,13 +493,10 @@ async def _discover_lm_studio_models(conn: Connection) -> list[dict[str, Any]]:
             _log_lm_studio_discovery(source, results)
             return results
 
-    logger.info(
-        "LM Studio native discovery unavailable; using OpenAI-compatible fallback",
-        extra={"provider": "lm_studio", "discovery_source": "openai_compatible"},
+    raise ModelDiscoveryError(
+        "LM Studio native model discovery is unavailable. "
+        "Upgrade LM Studio to version 0.4 or newer, or enter the model ID manually."
     )
-    results = await _discover_openai_shaped_models(conn, base_url)
-    _log_lm_studio_discovery("openai_compatible", results)
-    return results
 
 
 def _log_lm_studio_discovery(source: str, models: list[dict[str, Any]]) -> None:

--- a/surfsense_backend/app/services/model_connection_service.py
+++ b/surfsense_backend/app/services/model_connection_service.py
@@ -14,6 +14,7 @@ import httpx
 import litellm
 
 from app.db import Connection, Model, ModelSource
+from app.services.context_admission import GEN_AI_MODEL_FALLBACK_MAX_TOKENS
 from app.services.model_resolver import to_litellm
 from app.services.openrouter_model_normalizer import normalize_openrouter_models
 from app.services.provider_registry import Transport, provider_label, spec_for
@@ -320,9 +321,9 @@ def _ollama_modelfile_num_ctx(parameters: Any) -> int | None:
 
     Only present when someone authored it with ``ollama create``, so it is a
     stated preference -- usually a smaller window chosen to fit the host's
-    memory. It outranks the architecture maximum because a request-level
-    ``num_ctx`` overrides the Modelfile and we always send one: seeding from it
-    is what stops us from quietly allocating more than was asked for.
+    memory. That makes it the one discovered number worth persisting as a
+    budget: the architecture maximum describes the model, this describes the
+    deployment.
     """
     if not isinstance(parameters, str):
         return None
@@ -333,24 +334,47 @@ def _ollama_modelfile_num_ctx(parameters: Any) -> int | None:
     return None
 
 
-def _ollama_context_length(metadata: dict) -> int | None:
-    """Resolve how much context an Ollama model can take.
+def _ollama_architecture_context_length(metadata: dict) -> int | None:
+    """The context length the weights support, keyed by architecture in
+    ``/api/show``.
 
-    The Modelfile value wins, then the architecture-keyed value from
-    ``/api/show``. ``details`` is the third source because newer Ollama reports
-    ``context_length`` in ``/api/tags`` while ``/api/show`` does not.
+    ``details`` is the second source because newer Ollama reports
+    ``context_length`` in ``/api/tags`` while ``/api/show`` does not. This is a
+    property of the model, not of the host: it says nothing about how much the
+    server was able to allocate.
     """
     model_info = metadata.get("model_info") or {}
     architecture = model_info.get("general.architecture") or ""
     details = metadata.get("details") or {}
     for candidate in (
-        _ollama_modelfile_num_ctx(metadata.get("parameters")),
         model_info.get(f"{architecture}.context_length") if architecture else None,
         details.get("context_length"),
     ):
         resolved = _positive_int(candidate)
         if resolved:
             return resolved
+    return None
+
+
+def _ollama_seed_budget(metadata: dict) -> int | None:
+    """Seed ``max_input_tokens`` for a freshly discovered Ollama model.
+
+    A Modelfile ``num_ctx`` is a human's statement about this deployment, so it
+    is taken verbatim. The architecture maximum is not: Ollama sizes the context
+    from free memory at load time, so a 262k-capable model routinely loads at a
+    fraction of that. Seeding it verbatim would budget against a context length
+    the host never allocated. Capping at the generic fallback keeps the case
+    that matters -- a model whose context length is *below* the fallback gets
+    pinned to what it actually supports instead of being over-budgeted -- while
+    leaving the larger number to the settings field, where a big host can opt
+    into it.
+    """
+    stated = _ollama_modelfile_num_ctx(metadata.get("parameters"))
+    if stated:
+        return stated
+    architecture_max = _ollama_architecture_context_length(metadata)
+    if architecture_max:
+        return min(architecture_max, GEN_AI_MODEL_FALLBACK_MAX_TOKENS)
     return None
 
 
@@ -363,7 +387,6 @@ def derive_capabilities(
     facts = _classify_from_litellm(model_string, model_id)
     if spec.transport == Transport.OLLAMA:
         caps = set(metadata.get("capabilities") or [])
-        discovered_context = _ollama_context_length(metadata)
         facts.update(
             {
                 "supports_chat": "embedding" not in caps,
@@ -371,12 +394,8 @@ def derive_capabilities(
                 or facts["supports_image_input"],
                 "supports_tools": "tools" in caps or facts["supports_tools"],
                 "supports_image_generation": False,
-                # Seeded unbounded on purpose. What the host can allocate is not
-                # ours to guess -- Ollama usually runs on another machine, and a
-                # blanket cap would cost a sliding-window model most of its window
-                # to save memory it never wanted. When the KV cache does not fit,
-                # the load fails and MODEL_OUT_OF_MEMORY names the fix.
-                "max_input_tokens": discovered_context or facts["max_input_tokens"],
+                "max_input_tokens": _ollama_seed_budget(metadata)
+                or facts["max_input_tokens"],
             }
         )
     return facts

--- a/surfsense_backend/app/services/model_connection_service.py
+++ b/surfsense_backend/app/services/model_connection_service.py
@@ -149,7 +149,9 @@ async def verify_connection(conn: Connection) -> VerifyResult:
 
     if spec.transport == Transport.OLLAMA and base_url:
         url = f"{base_url.rstrip('/')}/api/version"
-    elif spec.discovery in {"openai_models", "openrouter", "requesty"} and base_url:
+    elif spec.discovery == "openai_models" and base_url:
+        url = f"{base_url.rstrip('/')}/models"  # verbatim; user owns the path
+    elif spec.discovery in {"openrouter", "requesty"} and base_url:
         url = f"{ensure_v1(base_url)}/models"
     elif spec.discovery == "anthropic_models" and base_url:
         url = f"{base_url.rstrip('/')}/models"
@@ -265,7 +267,7 @@ async def _discover_openai_shaped_models(
     if not resolved_base_url:
         return []
 
-    url = f"{ensure_v1(resolved_base_url)}/models"
+    url = f"{resolved_base_url.rstrip('/')}/models"  # verbatim; user owns the path
     async with httpx.AsyncClient(timeout=DISCOVERY_TIMEOUT_SECONDS) as client:
         response = await client.get(url, headers=_auth_headers(conn))
     response.raise_for_status()

--- a/surfsense_backend/app/services/model_connection_service.py
+++ b/surfsense_backend/app/services/model_connection_service.py
@@ -80,6 +80,29 @@ def _docker_hint(url: str | None, exc_or_status: Any) -> str:
     return raw
 
 
+def _provider_detail(raw: str, limit: int = 300) -> str:
+    """Bound provider error text; LiteLLM and gateway bodies can be large."""
+    detail = " ".join(raw.split())
+    return detail if len(detail) <= limit else f"{detail[:limit]}…"
+
+
+def _provider_error(
+    conn: Connection,
+    *,
+    status_code: int,
+    detail: str,
+    model_id: str | None = None,
+) -> VerifyResult:
+    """Report a provider response without misclassifying it as unreachable."""
+    target = f"model '{model_id}'" if model_id else _base_url_or_default(conn)
+    return VerifyResult(
+        "PROVIDER_ERROR",
+        False,
+        f"{provider_label(conn.provider)} returned HTTP {status_code} for "
+        f"{target}. {_provider_detail(detail)}",
+    )
+
+
 def _model_test_error(conn: Connection, model_id: str, exc: Exception) -> VerifyResult:
     provider_name = provider_label(conn.provider)
     raw = str(exc)
@@ -132,6 +155,16 @@ def _model_test_error(conn: Connection, model_id: str, exc: Exception) -> Verify
             f"{provider_name} did not respond in time. Check the endpoint and try again.",
         )
 
+    # LiteLLM can wrap a clean HTTP response in APIConnectionError. A status
+    # code means the provider answered; only its absence is a transport failure.
+    if isinstance(status_code, int) and status_code >= 400:
+        return _provider_error(
+            conn,
+            status_code=status_code,
+            detail=raw,
+            model_id=model_id,
+        )
+
     if "connection" in exc_name or "connect" in normalized:
         return VerifyResult(
             "UNREACHABLE",
@@ -169,6 +202,12 @@ async def verify_connection(conn: Connection) -> VerifyResult:
             return VerifyResult("UNREACHABLE", False, _docker_hint(base_url, exc))
         except httpx.TimeoutException as exc:
             return VerifyResult("UNREACHABLE", False, f"Connection timed out: {exc}")
+        except httpx.HTTPStatusError as exc:
+            return _provider_error(
+                conn,
+                status_code=exc.response.status_code,
+                detail=exc.response.text,
+            )
         except httpx.HTTPError as exc:
             return VerifyResult("UNREACHABLE", False, _docker_hint(base_url, exc))
     elif spec.transport == Transport.OLLAMA and base_url:
@@ -206,6 +245,12 @@ async def verify_connection(conn: Connection) -> VerifyResult:
         return VerifyResult("UNREACHABLE", False, _docker_hint(base_url, exc))
     except httpx.TimeoutException as exc:
         return VerifyResult("UNREACHABLE", False, f"Connection timed out: {exc}")
+    except httpx.HTTPStatusError as exc:
+        return _provider_error(
+            conn,
+            status_code=exc.response.status_code,
+            detail=exc.response.text,
+        )
     except httpx.HTTPError as exc:
         return VerifyResult("UNREACHABLE", False, _docker_hint(base_url, exc))
 
@@ -698,6 +743,13 @@ async def discover_models(conn: Connection) -> list[dict[str, Any]]:
             results = []
     except httpx.HTTPError as exc:
         raise ModelDiscoveryError(_discovery_error_message(conn, exc)) from exc
+
+    if not results and spec.discovery not in {"none", "static"}:
+        raise ModelDiscoveryError(
+            f"No models found at {_base_url_or_default(conn)}. Check that the URL "
+            f"points at your {provider_label(conn.provider)} server and that at "
+            "least one model is available."
+        )
 
     return results
 

--- a/surfsense_backend/app/services/model_resolver.py
+++ b/surfsense_backend/app/services/model_resolver.py
@@ -15,15 +15,6 @@ if TYPE_CHECKING:
 from app.services.provider_registry import spec_for
 
 
-def ensure_v1(base_url: str | None) -> str | None:
-    if not base_url:
-        return None
-    stripped = base_url.rstrip("/")
-    if stripped.endswith("/v1"):
-        return stripped
-    return f"{stripped}/v1"
-
-
 def strip_version_suffix(base_url: str | None) -> str | None:
     """Drop a trailing ``/v1`` segment from a base URL.
 
@@ -109,7 +100,6 @@ def native_connection_from_config(config: Mapping[str, Any]) -> dict[str, Any]:
 
 
 __all__ = [
-    "ensure_v1",
     "native_connection_from_config",
     "strip_version_suffix",
     "to_litellm",

--- a/surfsense_backend/app/services/model_resolver.py
+++ b/surfsense_backend/app/services/model_resolver.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from app.db import Connection
 
-from app.services.provider_registry import Transport, spec_for
+from app.services.provider_registry import spec_for
 
 
 def ensure_v1(base_url: str | None) -> str | None:
@@ -67,13 +67,12 @@ def to_litellm(
     prefix = spec.litellm_prefix or str(provider)
     model_string = f"{prefix}/{model_id}" if prefix else model_id
     if base_url:
-        if spec.transport == Transport.OPENAI_COMPATIBLE:
-            api_base = ensure_v1(base_url)
-        elif provider == "anthropic":
+        if provider == "anthropic":
             # LiteLLM's Anthropic handler appends ``/v1/messages`` to api_base,
             # so a base URL ending in ``/v1`` must be reduced to the API root.
             api_base = strip_version_suffix(base_url)
         else:
+            # Verbatim: the user owns the path (/v1 or custom); LiteLLM appends the route.
             api_base = base_url.rstrip("/")
         kwargs["api_base"] = api_base
 

--- a/surfsense_backend/app/services/new_streaming_service.py
+++ b/surfsense_backend/app/services/new_streaming_service.py
@@ -569,28 +569,31 @@ class VercelStreamingService:
 
     def format_error(
         self,
-        error_text: str,
+        message: str,
         error_code: str | None = None,
+        diagnostic: str | None = None,
         extra: dict[str, object] | None = None,
     ) -> str:
         """
         Format an error message.
 
         Args:
-            error_text: The error message text
+            message: Display-ready error message
             error_code: Optional machine-readable error code for frontend branching
+            diagnostic: Optional raw diagnostic text; clients must not render it
 
         Returns:
             str: SSE formatted error part
 
         Example output:
-            data: {"type":"error","errorText":"Something went wrong","errorCode":"SOME_CODE"}
+            data: {"type":"error","message":"Something went wrong","errorCode":"SOME_CODE"}
         """
-        payload: dict[str, object] = {"type": "error", "errorText": error_text}
+        payload: dict[str, object] = dict(extra or {})
+        payload.update({"type": "error", "message": message})
         if error_code:
             payload["errorCode"] = error_code
-        if extra:
-            payload.update(extra)
+        if diagnostic:
+            payload["diagnostic"] = diagnostic
         return self._format_sse(payload)
 
     # =========================================================================

--- a/surfsense_backend/app/services/provider_registry.py
+++ b/surfsense_backend/app/services/provider_registry.py
@@ -97,6 +97,9 @@ REGISTRY: dict[str, ProviderSpec] = {
         "bearer",
         "OpenAI-compatible provider",
     ),
+    # DEPRECATED: hidden from the catalog; superseded by "openai_compatible"
+    # (now verbatim). Kept so existing connections still resolve. Remove once none
+    # remain (provider='openai_compatible_raw').
     "openai_compatible_raw": ProviderSpec(
         Transport.NATIVE,
         "openai",

--- a/surfsense_backend/app/services/provider_registry.py
+++ b/surfsense_backend/app/services/provider_registry.py
@@ -19,6 +19,7 @@ class Transport(StrEnum):
 
 DiscoveryKind = Literal[
     "ollama",
+    "lm_studio_models",
     "openai_models",
     "anthropic_models",
     "bedrock_models",
@@ -112,7 +113,7 @@ REGISTRY: dict[str, ProviderSpec] = {
     "lm_studio": ProviderSpec(
         Transport.OPENAI_COMPATIBLE,
         "openai",
-        "openai_models",
+        "lm_studio_models",
         "http://host.docker.internal:1234/v1",
         True,
         "bearer",

--- a/surfsense_backend/app/services/streaming/events/error.py
+++ b/surfsense_backend/app/services/streaming/events/error.py
@@ -9,15 +9,17 @@ from ..envelope import format_sse
 
 
 def format_error(
-    error_text: str,
+    message: str,
     *,
     error_code: str | None = None,
+    diagnostic: str | None = None,
     extra: dict[str, Any] | None = None,
     emitter: Emitter | None = None,
 ) -> str:
-    payload: dict[str, Any] = {"type": "error", "errorText": error_text}
+    payload: dict[str, Any] = dict(extra or {})
+    payload.update({"type": "error", "message": message})
     if error_code:
         payload["errorCode"] = error_code
-    if extra:
-        payload.update(extra)
+    if diagnostic:
+        payload["diagnostic"] = diagnostic
     return format_sse(attach_emitted_by(payload, emitter))

--- a/surfsense_backend/app/services/streaming/service.py
+++ b/surfsense_backend/app/services/streaming/service.py
@@ -298,15 +298,17 @@ class StreamingService:
 
     def format_error(
         self,
-        error_text: str,
+        message: str,
         *,
         error_code: str | None = None,
+        diagnostic: str | None = None,
         extra: dict[str, Any] | None = None,
         emitter: Emitter | None = None,
     ) -> str:
         return error.format_error(
-            error_text,
+            message,
             error_code=error_code,
+            diagnostic=diagnostic,
             extra=extra,
             emitter=emitter,
         )

--- a/surfsense_backend/app/tasks/chat/streaming/errors/classifier.py
+++ b/surfsense_backend/app/tasks/chat/streaming/errors/classifier.py
@@ -197,6 +197,19 @@ def _classify_provider_exception(
             extra,
         )
 
+    # Ahead of the unavailable group on purpose: a local runtime reports OOM as a
+    # 5xx, which would land there and advise retrying a load that cannot succeed
+    # until the operator lowers the limit.
+    if adapted.category is LLMErrorCategory.INSUFFICIENT_MEMORY:
+        return (
+            "model_out_of_memory",
+            "MODEL_OUT_OF_MEMORY",
+            "warn",
+            True,
+            chat_error_message("MODEL_OUT_OF_MEMORY"),
+            _provider_error_extra(adapted),
+        )
+
     if adapted.category in {
         LLMErrorCategory.TIMEOUT,
         LLMErrorCategory.PROVIDER_UNAVAILABLE,

--- a/surfsense_backend/app/tasks/chat/streaming/errors/classifier.py
+++ b/surfsense_backend/app/tasks/chat/streaming/errors/classifier.py
@@ -13,6 +13,7 @@ from app.agents.chat.multi_agent_chat.main_agent.middleware.busy_mutex import (
 )
 from app.agents.chat.runtime.errors import BusyError
 from app.services.llm_error_adapter import LLMErrorCategory, adapt_llm_exception
+from app.tasks.chat.streaming.errors.messages import chat_error_message
 
 TURN_CANCELLING_INITIAL_DELAY_MS = 200
 TURN_CANCELLING_BACKOFF_FACTOR = 2
@@ -158,7 +159,7 @@ def _classify_provider_exception(
             "RATE_LIMITED",
             "warn",
             True,
-            "This model is temporarily rate-limited. Please try again in a few seconds or switch models.",
+            chat_error_message("RATE_LIMITED"),
             _provider_error_extra(adapted),
         )
 
@@ -171,7 +172,7 @@ def _classify_provider_exception(
             "MODEL_AUTH_FAILED",
             "warn",
             True,
-            "This model's API key is invalid or expired. Switch models, or update the API key.",
+            chat_error_message("MODEL_AUTH_FAILED"),
             _provider_error_extra(adapted),
         )
 
@@ -181,25 +182,19 @@ def _classify_provider_exception(
             "MODEL_NOT_FOUND",
             "warn",
             True,
-            "The selected model is unavailable or no longer exists. Switch to another model and try again.",
+            chat_error_message("MODEL_NOT_FOUND"),
             _provider_error_extra(adapted),
         )
 
     if adapted.category is LLMErrorCategory.CONTEXT_LIMIT:
-        message = (
-            "This request is too large for the selected model. Raise the context "
-            "in LM Studio, or lower this model's context limit in settings."
-            if adapted.provider_error_type == "exceed_context_size_error"
-            else "This request is too large for the selected model. Reduce the "
-            "input or increase its configured context limit."
-        )
+        extra = _provider_error_extra(adapted)
         return (
             "model_context_limit",
             "MODEL_CONTEXT_LIMIT",
             "warn",
             True,
-            message,
-            _provider_error_extra(adapted),
+            chat_error_message("MODEL_CONTEXT_LIMIT", details=extra),
+            extra,
         )
 
     if adapted.category in {
@@ -214,7 +209,7 @@ def _classify_provider_exception(
             "MODEL_PROVIDER_UNAVAILABLE",
             "warn",
             True,
-            "The selected model provider is temporarily unavailable. Please try again or switch models.",
+            chat_error_message("MODEL_PROVIDER_UNAVAILABLE"),
             _provider_error_extra(adapted),
         )
 
@@ -226,9 +221,15 @@ def classify_stream_exception(
     *,
     flow_label: str,
 ) -> tuple[
-    str, str, Literal["info", "warn", "error"], bool, str, dict[str, Any] | None
+    str,
+    str,
+    Literal["info", "warn", "error"],
+    bool,
+    str,
+    str,
+    dict[str, Any] | None,
 ]:
-    """Return kind, code, severity, expected flag, message, and optional extra dict."""
+    """Return classification, safe message, diagnostic, and optional metadata."""
     raw = str(exc)
     if isinstance(exc, BusyError) or "Thread is busy with another request" in raw:
         busy_thread_id = str(exc.request_id) if isinstance(exc, BusyError) else None
@@ -242,7 +243,8 @@ def classify_stream_exception(
                 "TURN_CANCELLING",
                 "info",
                 True,
-                "A previous response is still stopping. Please try again in a moment.",
+                chat_error_message("TURN_CANCELLING"),
+                raw,
                 {
                     "retry_after_ms": retry_after_ms,
                     "retry_after_at": retry_after_at,
@@ -253,19 +255,22 @@ def classify_stream_exception(
             "THREAD_BUSY",
             "warn",
             True,
-            "Another response is still finishing for this thread. Please try again in a moment.",
+            chat_error_message("THREAD_BUSY"),
+            raw,
             None,
         )
 
     provider_classification = _classify_provider_exception(exc)
     if provider_classification is not None:
-        return provider_classification
+        kind, code, severity, expected, message, extra = provider_classification
+        return kind, code, severity, expected, message, raw, extra
 
     return (
         "server_error",
         "SERVER_ERROR",
         "error",
         False,
+        chat_error_message("SERVER_ERROR"),
         f"Error during {flow_label}: {raw}",
         None,
     )

--- a/surfsense_backend/app/tasks/chat/streaming/errors/classifier.py
+++ b/surfsense_backend/app/tasks/chat/streaming/errors/classifier.py
@@ -186,12 +186,19 @@ def _classify_provider_exception(
         )
 
     if adapted.category is LLMErrorCategory.CONTEXT_LIMIT:
+        message = (
+            "This request is too large for the selected model. Raise the context "
+            "in LM Studio, or lower this model's context limit in settings."
+            if adapted.provider_error_type == "exceed_context_size_error"
+            else "This request is too large for the selected model. Reduce the "
+            "input or increase its configured context limit."
+        )
         return (
             "model_context_limit",
             "MODEL_CONTEXT_LIMIT",
             "warn",
             True,
-            "This request is too large for the selected model. Try a model with a larger context window or reduce the input.",
+            message,
             _provider_error_extra(adapted),
         )
 

--- a/surfsense_backend/app/tasks/chat/streaming/errors/emitter.py
+++ b/surfsense_backend/app/tasks/chat/streaming/errors/emitter.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any, Literal
 
 from .classifier import log_chat_stream_error
+from .messages import chat_error_message
 
 
 def emit_stream_terminal_error(
@@ -15,13 +16,17 @@ def emit_stream_terminal_error(
     thread_id: int,
     workspace_id: int,
     user_id: str | None,
-    message: str,
     error_kind: str = "server_error",
     error_code: str = "SERVER_ERROR",
     severity: Literal["info", "warn", "error"] = "error",
     is_expected: bool = False,
+    diagnostic: str | None = None,
     extra: dict[str, Any] | None = None,
 ) -> str:
+    message = chat_error_message(error_code, details=extra)
+    log_extra = dict(extra or {})
+    if diagnostic:
+        log_extra["diagnostic"] = diagnostic
     log_chat_stream_error(
         flow=flow,
         error_kind=error_kind,
@@ -33,6 +38,11 @@ def emit_stream_terminal_error(
         workspace_id=workspace_id,
         user_id=user_id,
         message=message,
+        extra=log_extra or None,
+    )
+    return streaming_service.format_error(
+        message,
+        error_code=error_code,
+        diagnostic=diagnostic,
         extra=extra,
     )
-    return streaming_service.format_error(message, error_code=error_code, extra=extra)

--- a/surfsense_backend/app/tasks/chat/streaming/errors/messages.py
+++ b/surfsense_backend/app/tasks/chat/streaming/errors/messages.py
@@ -24,6 +24,11 @@ CHAT_ERROR_MESSAGES: dict[str, str] = {
         "The selected model is unavailable or no longer exists. Switch to "
         "another model and try again."
     ),
+    "MODEL_OUT_OF_MEMORY": (
+        "The model host does not have enough memory to run this model at its "
+        "configured context limit. Lower this model's context limit in "
+        "settings, or switch models."
+    ),
     "MODEL_PROVIDER_UNAVAILABLE": (
         "The selected model provider is temporarily unavailable. Please try "
         "again or switch models."
@@ -36,9 +41,7 @@ CHAT_ERROR_MESSAGES: dict[str, str] = {
         "This model is temporarily rate-limited. Please try again in a few "
         "seconds or switch models."
     ),
-    "SERVER_ERROR": (
-        "We couldn't complete this response right now. Please try again."
-    ),
+    "SERVER_ERROR": ("We couldn't complete this response right now. Please try again."),
     "THREAD_BUSY": (
         "Another response is still finishing for this thread. Please try again "
         "in a moment."

--- a/surfsense_backend/app/tasks/chat/streaming/errors/messages.py
+++ b/surfsense_backend/app/tasks/chat/streaming/errors/messages.py
@@ -13,8 +13,8 @@ CHAT_ERROR_MESSAGES: dict[str, str] = {
         "the API key."
     ),
     "MODEL_CONTEXT_LIMIT": (
-        "This request is too large for the selected model. Reduce the input or "
-        "increase its configured context limit."
+        "This request is too large for the selected model. Ask for less at once, "
+        "or lower this model's max input tokens in settings so we send less."
     ),
     "MODEL_DOES_NOT_SUPPORT_IMAGE_INPUT": (
         "The selected model does not support image input. Switch to a "
@@ -25,9 +25,8 @@ CHAT_ERROR_MESSAGES: dict[str, str] = {
         "another model and try again."
     ),
     "MODEL_OUT_OF_MEMORY": (
-        "The model host does not have enough memory to run this model at its "
-        "configured context limit. Lower this model's context limit in "
-        "settings, or switch models."
+        "The computer running this model doesn't have enough memory to load it. "
+        "Close anything else using the GPU, or switch to a smaller model."
     ),
     "MODEL_PROVIDER_UNAVAILABLE": (
         "The selected model provider is temporarily unavailable. Please try "
@@ -55,8 +54,8 @@ CHAT_ERROR_MESSAGES: dict[str, str] = {
 }
 
 _LM_STUDIO_CONTEXT_MESSAGE = (
-    "This request is too large for the selected model. Raise the context in "
-    "LM Studio, or lower this model's context limit in settings."
+    "This request is too large for the selected model. Raise the context length "
+    "in LM Studio, or lower this model's max input tokens in settings."
 )
 
 

--- a/surfsense_backend/app/tasks/chat/streaming/errors/messages.py
+++ b/surfsense_backend/app/tasks/chat/streaming/errors/messages.py
@@ -1,0 +1,76 @@
+"""Canonical user-facing messages for backend-owned chat error codes."""
+
+from __future__ import annotations
+
+from typing import Any
+
+CHAT_ERROR_MESSAGES: dict[str, str] = {
+    "MESSAGE_PERSIST_FAILED": (
+        "We couldn't save this message. Please try again in a moment."
+    ),
+    "MODEL_AUTH_FAILED": (
+        "This model's API key is invalid or expired. Switch models, or update "
+        "the API key."
+    ),
+    "MODEL_CONTEXT_LIMIT": (
+        "This request is too large for the selected model. Reduce the input or "
+        "increase its configured context limit."
+    ),
+    "MODEL_DOES_NOT_SUPPORT_IMAGE_INPUT": (
+        "The selected model does not support image input. Switch to a "
+        "vision-capable model or remove the image attachment and try again."
+    ),
+    "MODEL_NOT_FOUND": (
+        "The selected model is unavailable or no longer exists. Switch to "
+        "another model and try again."
+    ),
+    "MODEL_PROVIDER_UNAVAILABLE": (
+        "The selected model provider is temporarily unavailable. Please try "
+        "again or switch models."
+    ),
+    "NO_ACTIVE_TURN": "There is no active response to stop.",
+    "PREMIUM_QUOTA_EXHAUSTED": (
+        "Buy more credits to continue with this model, or switch to a free model."
+    ),
+    "RATE_LIMITED": (
+        "This model is temporarily rate-limited. Please try again in a few "
+        "seconds or switch models."
+    ),
+    "SERVER_ERROR": (
+        "We couldn't complete this response right now. Please try again."
+    ),
+    "THREAD_BUSY": (
+        "Another response is still finishing for this thread. Please try again "
+        "in a moment."
+    ),
+    "TOOL_EXECUTION_ERROR": (
+        "A tool failed while processing your request. Please try again."
+    ),
+    "TURN_CANCELLING": (
+        "A previous response is still stopping. Please try again in a moment."
+    ),
+}
+
+_LM_STUDIO_CONTEXT_MESSAGE = (
+    "This request is too large for the selected model. Raise the context in "
+    "LM Studio, or lower this model's context limit in settings."
+)
+
+
+def chat_error_message(
+    error_code: str,
+    *,
+    details: dict[str, Any] | None = None,
+) -> str:
+    """Return safe display copy for a backend-owned chat error code."""
+    if (
+        error_code == "MODEL_CONTEXT_LIMIT"
+        and details
+        and details.get("provider_error_type") == "exceed_context_size_error"
+    ):
+        return _LM_STUDIO_CONTEXT_MESSAGE
+    try:
+        return CHAT_ERROR_MESSAGES[error_code]
+    except KeyError as exc:
+        raise ValueError(f"No user-facing message registered for {error_code}") from exc
+

--- a/surfsense_backend/app/tasks/chat/streaming/errors/messages.py
+++ b/surfsense_backend/app/tasks/chat/streaming/errors/messages.py
@@ -73,4 +73,3 @@ def chat_error_message(
         return CHAT_ERROR_MESSAGES[error_code]
     except KeyError as exc:
         raise ValueError(f"No user-facing message registered for {error_code}") from exc
-

--- a/surfsense_backend/app/tasks/chat/streaming/flows/new_chat/auto_pin.py
+++ b/surfsense_backend/app/tasks/chat/streaming/flows/new_chat/auto_pin.py
@@ -33,12 +33,12 @@ class AutoPinResult:
     """Outcome of ``resolve_initial_auto_pin``.
 
     ``llm_config_id`` is set when ``error`` is ``None``; ``error`` carries the
-    classified user-facing message plus error code/kind so the orchestrator can
-    emit one terminal-error SSE frame.
+    code, kind, and diagnostic so the orchestrator can emit one canonical
+    terminal-error SSE frame.
     """
 
     llm_config_id: int | None
-    error: tuple[str, str, Literal["user_error", "server_error"]] | None
+    error: tuple[str, Literal["user_error", "server_error"], str] | None
 
 
 async def resolve_initial_auto_pin(
@@ -94,5 +94,5 @@ async def resolve_initial_auto_pin(
         if is_vision_failure:
             ot.add_event("quota.denied", {"quota.code": error_code})
         return AutoPinResult(
-            llm_config_id=None, error=(str(pin_error), error_code, error_kind)
+            llm_config_id=None, error=(error_code, error_kind, str(pin_error))
         )

--- a/surfsense_backend/app/tasks/chat/streaming/flows/new_chat/llm_capability.py
+++ b/surfsense_backend/app/tasks/chat/streaming/flows/new_chat/llm_capability.py
@@ -23,8 +23,8 @@ def check_image_input_capability(
     *,
     user_image_data_urls: list[str] | None,
     agent_config: AgentConfig | None,
-) -> tuple[str, str] | None:
-    """Return ``(user_message, error_code)`` when the gate trips, else ``None``.
+) -> str | None:
+    """Return the error code when the gate trips, otherwise ``None``.
 
     The caller emits one terminal-error SSE frame on a non-``None`` return.
     """
@@ -47,14 +47,5 @@ def check_image_input_capability(
     ):
         return None
 
-    model_label = agent_config.config_name or agent_config.model_name or "model"
     ot.add_event("quota.denied", {"quota.code": "MODEL_DOES_NOT_SUPPORT_IMAGE_INPUT"})
-    return (
-        (
-            f"The selected model ({model_label}) does not support "
-            "image input. Switch to a vision-capable model "
-            "(e.g. GPT-4o, Claude, Gemini) or remove the image "
-            "attachment and try again."
-        ),
-        "MODEL_DOES_NOT_SUPPORT_IMAGE_INPUT",
-    )
+    return "MODEL_DOES_NOT_SUPPORT_IMAGE_INPUT"

--- a/surfsense_backend/app/tasks/chat/streaming/flows/new_chat/orchestrator.py
+++ b/surfsense_backend/app/tasks/chat/streaming/flows/new_chat/orchestrator.py
@@ -228,9 +228,11 @@ async def stream_new_chat(
             requested_llm_config_id=requested_llm_config_id,
         )
         if pin_result.error is not None:
-            message, error_code, error_kind = pin_result.error
+            error_code, error_kind, diagnostic = pin_result.error
             yield emit_stream_error(
-                message=message, error_kind=error_kind, error_code=error_code
+                error_kind=error_kind,
+                error_code=error_code,
+                diagnostic=diagnostic,
             )
             yield streaming_service.format_done()
             return
@@ -241,9 +243,9 @@ async def stream_new_chat(
         )
         if llm_load_error:
             yield emit_stream_error(
-                message=llm_load_error,
                 error_kind="server_error",
                 error_code="SERVER_ERROR",
+                diagnostic=llm_load_error,
             )
             yield streaming_service.format_done()
             return
@@ -257,11 +259,9 @@ async def stream_new_chat(
             user_image_data_urls=user_image_data_urls, agent_config=agent_config
         )
         if capability_error is not None:
-            message, error_code = capability_error
             yield emit_stream_error(
-                message=message,
                 error_kind="user_error",
-                error_code=error_code,
+                error_code=capability_error,
             )
             yield streaming_service.format_done()
             return
@@ -285,11 +285,11 @@ async def stream_new_chat(
                         force_repin_free=True,
                     )
                     if pin_fallback.error is not None:
-                        message, error_code, error_kind = pin_fallback.error
+                        error_code, error_kind, diagnostic = pin_fallback.error
                         yield emit_stream_error(
-                            message=message,
                             error_kind=error_kind,
                             error_code=error_code,
+                            diagnostic=diagnostic,
                         )
                         yield streaming_service.format_done()
                         return
@@ -308,9 +308,9 @@ async def stream_new_chat(
                     )
                     if llm_load_error:
                         yield emit_stream_error(
-                            message=llm_load_error,
                             error_kind="server_error",
                             error_code="SERVER_ERROR",
+                            diagnostic=llm_load_error,
                         )
                         yield streaming_service.format_done()
                         return
@@ -342,10 +342,6 @@ async def stream_new_chat(
                     )
                 else:
                     yield emit_stream_error(
-                        message=(
-                            "Buy more credits to continue with this model, or "
-                            "switch to a free model"
-                        ),
                         error_kind="premium_quota_exhausted",
                         error_code="PREMIUM_QUOTA_EXHAUSTED",
                         severity="info",
@@ -360,9 +356,9 @@ async def stream_new_chat(
 
         if not llm:
             yield emit_stream_error(
-                message="Failed to create LLM instance",
                 error_kind="server_error",
                 error_code="SERVER_ERROR",
+                diagnostic="Failed to create LLM instance",
             )
             yield streaming_service.format_done()
             return
@@ -525,7 +521,6 @@ async def stream_new_chat(
         )
         if user_message_id is None:
             yield emit_stream_error(
-                message="We couldn't save your message. Please try again in a moment.",
                 error_kind="server_error",
                 error_code="MESSAGE_PERSIST_FAILED",
             )
@@ -562,9 +557,6 @@ async def stream_new_chat(
             # void. The user row is already persisted so the legacy
             # ghost-thread gate isn't reopened.
             yield emit_stream_error(
-                message=(
-                    "We couldn't initialize the assistant message. Please try again."
-                ),
                 error_kind="server_error",
                 error_code="MESSAGE_PERSIST_FAILED",
             )

--- a/surfsense_backend/app/tasks/chat/streaming/flows/resume_chat/orchestrator.py
+++ b/surfsense_backend/app/tasks/chat/streaming/flows/resume_chat/orchestrator.py
@@ -196,9 +196,9 @@ async def stream_resume_chat(
             )
         except ValueError as pin_error:
             yield emit_stream_error(
-                message=str(pin_error),
                 error_kind="server_error",
                 error_code="SERVER_ERROR",
+                diagnostic=str(pin_error),
             )
             yield streaming_service.format_done()
             return
@@ -208,9 +208,9 @@ async def stream_resume_chat(
         )
         if llm_load_error:
             yield emit_stream_error(
-                message=llm_load_error,
                 error_kind="server_error",
                 error_code="SERVER_ERROR",
+                diagnostic=llm_load_error,
             )
             yield streaming_service.format_done()
             return
@@ -245,9 +245,9 @@ async def stream_resume_chat(
                         )
                     except ValueError as pin_error:
                         yield emit_stream_error(
-                            message=str(pin_error),
                             error_kind="server_error",
                             error_code="SERVER_ERROR",
+                            diagnostic=str(pin_error),
                         )
                         yield streaming_service.format_done()
                         return
@@ -258,9 +258,9 @@ async def stream_resume_chat(
                     )
                     if llm_load_error:
                         yield emit_stream_error(
-                            message=llm_load_error,
                             error_kind="server_error",
                             error_code="SERVER_ERROR",
+                            diagnostic=llm_load_error,
                         )
                         yield streaming_service.format_done()
                         return
@@ -290,10 +290,6 @@ async def stream_resume_chat(
                     )
                 else:
                     yield emit_stream_error(
-                        message=(
-                            "Buy more credits to continue with this model, or "
-                            "switch to a free model"
-                        ),
                         error_kind="premium_quota_exhausted",
                         error_code="PREMIUM_QUOTA_EXHAUSTED",
                         severity="info",
@@ -308,9 +304,9 @@ async def stream_resume_chat(
 
         if not llm:
             yield emit_stream_error(
-                message="Failed to create LLM instance",
                 error_kind="server_error",
                 error_code="SERVER_ERROR",
+                diagnostic="Failed to create LLM instance",
             )
             yield streaming_service.format_done()
             return
@@ -423,9 +419,6 @@ async def stream_resume_chat(
         )
         if assistant_message_id is None:
             yield emit_stream_error(
-                message=(
-                    "We couldn't initialize the assistant message. Please try again."
-                ),
                 error_kind="server_error",
                 error_code="MESSAGE_PERSIST_FAILED",
             )

--- a/surfsense_backend/app/tasks/chat/streaming/flows/shared/llm_bundle.py
+++ b/surfsense_backend/app/tasks/chat/streaming/flows/shared/llm_bundle.py
@@ -95,24 +95,24 @@ def _positive_int(value: Any) -> int | None:
 def _build_profiled_llm(
     *,
     model_string: str,
-    provider: str,
     litellm_kwargs: dict[str, Any],
     persisted_max_input_tokens: int | None,
 ) -> SanitizedChatLiteLLM:
+    """Build the LLM with a trim budget but no allocation request.
+
+    ``max_input_tokens`` is a ceiling on what we send, never a size we ask a
+    runtime to reserve. Ollama sizes itself from available memory unless the
+    operator says otherwise, and it can only shrink the context to survive a
+    load-time OOM while that sizing is automatic -- a ``num_ctx`` we invented
+    would take that away. An operator who does want a fixed size sets it on the
+    connection, and ``to_litellm`` passes it through untouched.
+    """
     effective = resolve_max_input_tokens(
         model_string,
         persisted_max_input_tokens=persisted_max_input_tokens,
     )
-    resolved_kwargs = dict(litellm_kwargs)
-    if provider == "ollama_chat":
-        # Explicit operator configuration from Connection.extra wins. Otherwise
-        # send the effective budget, so the size Ollama allocates and the size we
-        # trim to cannot disagree -- sending nothing would leave Ollama on its own
-        # 4k default while we budget the fallback, truncating the system prompt
-        # without saying so.
-        resolved_kwargs.setdefault("num_ctx", effective)
     llm = SanitizedChatLiteLLM(
-        model=model_string, **{**resolved_kwargs, "streaming": True}
+        model=model_string, **{**litellm_kwargs, "streaming": True}
     )
     _attach_model_profile(
         llm,
@@ -168,7 +168,6 @@ async def load_llm_bundle(
         return (
             _build_profiled_llm(
                 model_string=model_string,
-                provider=provider,
                 litellm_kwargs=litellm_kwargs,
                 persisted_max_input_tokens=_positive_int(
                     getattr(model, "max_input_tokens", None)
@@ -219,7 +218,6 @@ async def load_llm_bundle(
     return (
         _build_profiled_llm(
             model_string=model_string,
-            provider=provider,
             litellm_kwargs=litellm_kwargs,
             persisted_max_input_tokens=_positive_int(
                 global_model.get("max_input_tokens")

--- a/surfsense_backend/app/tasks/chat/streaming/flows/shared/llm_bundle.py
+++ b/surfsense_backend/app/tasks/chat/streaming/flows/shared/llm_bundle.py
@@ -105,7 +105,11 @@ def _build_profiled_llm(
     )
     resolved_kwargs = dict(litellm_kwargs)
     if provider == "ollama_chat":
-        # Explicit operator configuration from Connection.extra wins.
+        # Explicit operator configuration from Connection.extra wins. Otherwise
+        # send the effective budget, so the size Ollama allocates and the size we
+        # trim to cannot disagree -- sending nothing would leave Ollama on its own
+        # 4k default while we budget the fallback, truncating the system prompt
+        # without saying so.
         resolved_kwargs.setdefault("num_ctx", effective)
     llm = SanitizedChatLiteLLM(
         model=model_string, **{**resolved_kwargs, "streaming": True}

--- a/surfsense_backend/app/tasks/chat/streaming/flows/shared/llm_bundle.py
+++ b/surfsense_backend/app/tasks/chat/streaming/flows/shared/llm_bundle.py
@@ -19,6 +19,8 @@ from sqlalchemy.orm import selectinload
 from app.agents.chat.runtime.llm_config import (
     AgentConfig,
     SanitizedChatLiteLLM,
+    _attach_model_profile,
+    resolve_max_input_tokens,
 )
 from app.config import config
 from app.db import Model, Workspace
@@ -84,6 +86,38 @@ async def _load_db_model(
     return model
 
 
+def _positive_int(value: Any) -> int | None:
+    if isinstance(value, int) and not isinstance(value, bool) and value > 0:
+        return value
+    return None
+
+
+def _build_profiled_llm(
+    *,
+    model_string: str,
+    provider: str,
+    litellm_kwargs: dict[str, Any],
+    persisted_max_input_tokens: int | None,
+) -> SanitizedChatLiteLLM:
+    effective = resolve_max_input_tokens(
+        model_string,
+        persisted_max_input_tokens=persisted_max_input_tokens,
+    )
+    resolved_kwargs = dict(litellm_kwargs)
+    if provider == "ollama_chat":
+        # Explicit operator configuration from Connection.extra wins.
+        resolved_kwargs.setdefault("num_ctx", effective)
+    llm = SanitizedChatLiteLLM(
+        model=model_string, **{**resolved_kwargs, "streaming": True}
+    )
+    _attach_model_profile(
+        llm,
+        model_string,
+        persisted_max_input_tokens=effective,
+    )
+    return llm
+
+
 async def load_llm_bundle(
     session: AsyncSession,
     *,
@@ -128,8 +162,13 @@ async def load_llm_bundle(
             billing_tier="free",
         )
         return (
-            SanitizedChatLiteLLM(
-                model=model_string, **{**litellm_kwargs, "streaming": True}
+            _build_profiled_llm(
+                model_string=model_string,
+                provider=provider,
+                litellm_kwargs=litellm_kwargs,
+                persisted_max_input_tokens=_positive_int(
+                    getattr(model, "max_input_tokens", None)
+                ),
             ),
             agent_config,
             None,
@@ -174,8 +213,13 @@ async def load_llm_bundle(
         billing_tier=str(global_model.get("billing_tier", "free")).lower(),
     )
     return (
-        SanitizedChatLiteLLM(
-            model=model_string, **{**litellm_kwargs, "streaming": True}
+        _build_profiled_llm(
+            model_string=model_string,
+            provider=provider,
+            litellm_kwargs=litellm_kwargs,
+            persisted_max_input_tokens=_positive_int(
+                global_model.get("max_input_tokens")
+            ),
         ),
         agent_config,
         None,

--- a/surfsense_backend/app/tasks/chat/streaming/flows/shared/terminal_error.py
+++ b/surfsense_backend/app/tasks/chat/streaming/flows/shared/terminal_error.py
@@ -54,7 +54,8 @@ def handle_terminal_exception(
         error_code,
         severity,
         is_expected,
-        user_message,
+        _user_message,
+        diagnostic,
         error_extra,
     ) = classify_stream_exception(exc, flow_label=flow_label)
     chat_outcome = error_code or error_kind or "error"
@@ -89,11 +90,11 @@ def handle_terminal_exception(
             thread_id=chat_id,
             workspace_id=workspace_id,
             user_id=user_id,
-            message=user_message,
             error_kind=error_kind,
             error_code=error_code,
             severity=severity,
             is_expected=is_expected,
+            diagnostic=diagnostic,
             extra=error_extra,
         )
         yield from iter_final_frames(streaming_service)

--- a/surfsense_backend/tests/unit/agents/new_chat/test_retry_after.py
+++ b/surfsense_backend/tests/unit/agents/new_chat/test_retry_after.py
@@ -63,6 +63,28 @@ class TestIsNonRetryable:
     def test_generic_exception_is_retryable(self) -> None:
         assert _is_non_retryable(RuntimeError("transient")) is False
 
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "llama runner process has terminated: cudaMalloc failed: out of memory",
+            "model requires more system memory (10.9 GiB) than is available",
+        ],
+    )
+    def test_host_out_of_memory_is_not_retried(self, message: str) -> None:
+        """Ollama surfaces an OOM as a generic API error, so a class-name test
+        retried it -- after the scheduler had already shrunk the context and
+        evicted other models to try to make it fit."""
+        cls = type("APIError", (Exception,), {})
+        assert _is_non_retryable(cls(message)) is True
+
+    def test_context_overflow_without_a_telling_class_name(self) -> None:
+        cls = type("APIError", (Exception,), {})
+        exc = cls(
+            "the prompt is longer than the context length currently available "
+            "to the model"
+        )
+        assert _is_non_retryable(exc) is True
+
 
 class TestDelayCalculation:
     def test_takes_max_of_backoff_and_header(self) -> None:

--- a/surfsense_backend/tests/unit/platforms/google_search/test_searxng_fallback.py
+++ b/surfsense_backend/tests/unit/platforms/google_search/test_searxng_fallback.py
@@ -5,6 +5,8 @@ aggregator's HTTP call is stubbed, so this exercises the real wiring: when the
 fallback fires, what it maps, and the cases where it must stay silent.
 """
 
+import logging
+
 import pytest
 
 from app.proprietary.platforms.google_search import (
@@ -116,6 +118,30 @@ async def test_no_fallback_for_url_without_readable_query(walled_google, searxng
         GoogleSearchScrapeInput(queries="https://www.google.com/search")
     )
     assert items == []
+
+
+async def test_json_api_disabled_names_the_fix(monkeypatch, caplog):
+    """A stock instance 403s ``format=json``; the log has to name the knob."""
+
+    class _Response:
+        status_code = 403
+
+    class _Client:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        async def get(self, url, params=None):
+            return _Response()
+
+    monkeypatch.setattr(searxng, "_HOST", "https://searx.example")
+    monkeypatch.setattr(searxng.httpx, "AsyncClient", lambda **kw: _Client())
+
+    with caplog.at_level(logging.WARNING, logger=searxng.logger.name):
+        assert await searxng._fetch_json({"q": "x"}) is None
+    assert "search.formats" in caplog.text
 
 
 async def test_google_success_is_unstamped_and_untouched(monkeypatch, searxng_up):

--- a/surfsense_backend/tests/unit/platforms/google_search/test_searxng_fallback.py
+++ b/surfsense_backend/tests/unit/platforms/google_search/test_searxng_fallback.py
@@ -63,7 +63,8 @@ async def test_fallback_serves_organic_results(walled_google, searxng_up):
     assert item["resultsTotal"] is None
     # Provenance survives to_output() so no consumer can mistake this for Google.
     assert item["resultsProvider"] == "searxng"
-    assert item["searchQuery"]["domain"] == "searx.example"
+    # The provider label, not the configured host.
+    assert item["searchQuery"]["domain"] == "searxng"
     assert item["searchQuery"]["term"] == "apple pie"
 
 

--- a/surfsense_backend/tests/unit/platforms/google_search/test_searxng_fallback.py
+++ b/surfsense_backend/tests/unit/platforms/google_search/test_searxng_fallback.py
@@ -1,0 +1,134 @@
+"""Offline checks for the SearXNG last-resort fallback.
+
+Google is stubbed as fully walled (``fetch_serp_html`` -> ``None``) and the
+aggregator's HTTP call is stubbed, so this exercises the real wiring: when the
+fallback fires, what it maps, and the cases where it must stay silent.
+"""
+
+import pytest
+
+from app.proprietary.platforms.google_search import (
+    GoogleSearchScrapeInput,
+    scraper,
+    searxng,
+)
+
+pytestmark = pytest.mark.unit
+
+_PAYLOAD = {
+    "results": [
+        {
+            "title": "Pie Guide",
+            "url": "https://pies.example/guide",
+            "content": "How to bake.",
+        },
+        {"title": "No URL here", "content": "dropped"},
+    ],
+    "suggestions": ["easy pie"],
+}
+
+
+@pytest.fixture
+def walled_google(monkeypatch):
+    async def _none(url, *, mobile=False):
+        return None
+
+    monkeypatch.setattr(scraper, "fetch_serp_html", _none)
+
+
+@pytest.fixture
+def searxng_up(monkeypatch):
+    async def _payload(params):
+        return _PAYLOAD
+
+    monkeypatch.setattr(searxng, "_HOST", "https://searx.example")
+    monkeypatch.setattr(searxng, "_fetch_json", _payload)
+
+
+async def test_fallback_serves_organic_results(walled_google, searxng_up):
+    items = await scraper.scrape_serps(GoogleSearchScrapeInput(queries="apple pie"))
+
+    assert len(items) == 1
+    item = items[0]
+    # URL-less entries are dropped, and positions stay 1-based and contiguous.
+    assert [(r["position"], r["url"]) for r in item["organicResults"]] == [
+        (1, "https://pies.example/guide")
+    ]
+    assert item["organicResults"][0]["description"] == "How to bake."
+    assert item["suggestedResults"][0]["title"] == "easy pie"
+    # Google-only blocks stay empty rather than being faked.
+    assert item["paidResults"] == []
+    assert item["peopleAlsoAsk"] == []
+    assert item["aiOverview"] is None
+    assert item["resultsTotal"] is None
+    # Provenance survives to_output() so no consumer can mistake this for Google.
+    assert item["resultsProvider"] == "searxng"
+    assert item["searchQuery"]["domain"] == "searx.example"
+    assert item["searchQuery"]["term"] == "apple pie"
+
+
+async def test_fallback_query_folds_only_supported_operators(
+    walled_google, monkeypatch
+):
+    seen: dict = {}
+
+    async def _capture(params):
+        seen.update(params)
+        return _PAYLOAD
+
+    monkeypatch.setattr(searxng, "_HOST", "https://searx.example")
+    monkeypatch.setattr(searxng, "_fetch_json", _capture)
+
+    await scraper.scrape_serps(
+        GoogleSearchScrapeInput(
+            queries="apple pie",
+            site="pies.example",
+            forceExactMatch=True,
+            wordsInTitle=["easy"],
+            fileTypes=["pdf"],
+            languageCode="en",
+            quickDateRange="w",
+        )
+    )
+    # site: and exact-match survive; intitle:/filetype: would zero out the
+    # aggregator's engines, so they are dropped.
+    assert seen["q"] == '"apple pie" site:pies.example'
+    assert seen["language"] == "en"
+    assert seen["time_range"] == "week"
+
+
+async def test_no_fallback_when_disabled(walled_google, monkeypatch):
+    monkeypatch.setattr(searxng, "_HOST", "")
+    assert await scraper.scrape_serps(GoogleSearchScrapeInput(queries="q")) == []
+
+
+async def test_no_fallback_when_ads_requested(walled_google, searxng_up):
+    items = await scraper.scrape_serps(
+        GoogleSearchScrapeInput(queries="car insurance", focusOnPaidAds=True)
+    )
+    assert items == []
+
+
+async def test_no_fallback_for_url_without_readable_query(walled_google, searxng_up):
+    # A Google URL whose ``q`` cannot be read has no term to re-search.
+    items = await scraper.scrape_serps(
+        GoogleSearchScrapeInput(queries="https://www.google.com/search")
+    )
+    assert items == []
+
+
+async def test_google_success_is_unstamped_and_untouched(monkeypatch, searxng_up):
+    async def _html(url, *, mobile=False):
+        return (
+            '<html><body><div id="rso">'
+            '<div class="tF2Cxc"><a href="https://x.example/a"><h3>Organic</h3></a>'
+            "</div></div></body></html>"
+        )
+
+    monkeypatch.setattr(scraper, "fetch_serp_html", _html)
+
+    items = await scraper.scrape_serps(GoogleSearchScrapeInput(queries="apple pie"))
+    assert len(items) == 1
+    assert items[0]["searchQuery"]["domain"] == "google.com"
+    assert items[0]["searchQuery"]["url"].startswith("https://www.google.com/search")
+    assert "resultsProvider" not in items[0]

--- a/surfsense_backend/tests/unit/services/test_context_admission.py
+++ b/surfsense_backend/tests/unit/services/test_context_admission.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+from langchain_core.exceptions import ContextOverflowError
+
+from app.services.context_admission import (
+    compute_tool_tokens,
+    trim_messages_to_fit_context,
+)
+from app.services.llm_router_service import ChatLiteLLMRouter
+
+pytestmark = pytest.mark.unit
+
+
+def _count(messages: list[dict]) -> int:
+    return len(json.dumps(messages)) // 4
+
+
+def test_under_budget_messages_are_not_copied_or_changed() -> None:
+    messages = [{"role": "user", "content": "hello"}]
+
+    admitted, _, _ = trim_messages_to_fit_context(
+        messages,
+        count_tokens=_count,
+        max_input_tokens=4_096,
+    )
+
+    assert admitted is messages
+
+
+def test_protected_content_overflow_raises_instead_of_deleting_user_text() -> None:
+    messages = [
+        {"role": "system", "content": "S" * 2_000},
+        {"role": "user", "content": "U" * 2_000},
+    ]
+
+    with pytest.raises(ContextOverflowError, match="cannot be truncated"):
+        trim_messages_to_fit_context(
+            messages,
+            count_tokens=_count,
+            max_input_tokens=600,
+            output_reserve_fraction=0,
+            preserve_protected_content=True,
+        )
+
+    assert messages[1]["content"] == "U" * 2_000
+
+
+def test_protected_mode_can_omit_small_tool_outputs_before_failing() -> None:
+    messages = [
+        {"role": "system", "content": "system"},
+        *[{"role": "tool", "content": "T" * 400} for _ in range(8)],
+    ]
+
+    admitted, final_tokens, budget = trim_messages_to_fit_context(
+        messages,
+        count_tokens=_count,
+        max_input_tokens=600,
+        output_reserve_fraction=0,
+        preserve_protected_content=True,
+    )
+
+    assert final_tokens <= budget
+    assert any(message["content"] != "T" * 400 for message in admitted[1:])
+
+
+def test_router_mode_keeps_aggressive_fallback_for_unprotected_messages() -> None:
+    messages = [
+        {"role": "system", "content": "system"},
+        {"role": "assistant", "content": "A" * 4_000},
+    ]
+
+    admitted, final_tokens, budget = trim_messages_to_fit_context(
+        messages,
+        count_tokens=_count,
+        max_input_tokens=600,
+        output_reserve_fraction=0,
+    )
+
+    assert admitted[0] == messages[0]
+    assert admitted[1]["content"] != messages[1]["content"]
+    assert final_tokens <= budget
+
+
+def test_router_method_preserves_shared_aggressive_trimming(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    router = ChatLiteLLMRouter.model_construct()
+    monkeypatch.setattr(ChatLiteLLMRouter, "_get_max_input_tokens", lambda _self: 600)
+    monkeypatch.setattr(
+        ChatLiteLLMRouter, "_count_tokens", lambda _self, messages: _count(messages)
+    )
+    messages = [
+        {"role": "system", "content": "system"},
+        {"role": "tool", "content": "T" * 4_000},
+    ]
+
+    admitted = router._trim_messages_to_fit_context(messages, output_reserve_fraction=0)
+
+    assert admitted[0] == messages[0]
+    assert admitted[1]["content"] != messages[1]["content"]
+    assert _count(admitted) <= 600
+
+
+_TOOL_SCHEMA = {
+    "type": "function",
+    "function": {
+        "name": "search_knowledge_base",
+        "description": "D" * 1_200,
+        "parameters": {"type": "object", "properties": {}},
+    },
+}
+
+
+def test_bound_tool_schemas_shrink_the_budget() -> None:
+    """The provider charges for tool schemas, so admission must too -- otherwise
+    a request passes locally and is rejected over the wire."""
+    messages = [{"role": "user", "content": "hi"}]
+
+    _, _, budget_without_tools = trim_messages_to_fit_context(
+        messages,
+        count_tokens=_count,
+        max_input_tokens=8_960,
+        output_reserve_fraction=0,
+    )
+    _, _, budget_with_tools = trim_messages_to_fit_context(
+        messages,
+        count_tokens=_count,
+        max_input_tokens=8_960,
+        output_reserve_fraction=0,
+        reserved_tokens=compute_tool_tokens([_TOOL_SCHEMA] * 4, _count),
+    )
+
+    reserved = compute_tool_tokens([_TOOL_SCHEMA] * 4, _count)
+    assert reserved > 0
+    assert budget_without_tools - budget_with_tools == reserved
+
+
+def test_compute_tool_tokens_ignores_absent_or_unserializable_tools() -> None:
+    assert compute_tool_tokens(None, _count) == 0
+    assert compute_tool_tokens([], _count) == 0
+    # default=str keeps an exotic schema from raising; it just gets counted.
+    assert compute_tool_tokens([{"fn": object()}], _count) > 0
+
+
+def test_router_method_reserves_tokens_for_its_bound_tools(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    router = ChatLiteLLMRouter.model_construct()
+    object.__setattr__(router, "_bound_tools", [_TOOL_SCHEMA])
+    monkeypatch.setattr(ChatLiteLLMRouter, "_get_max_input_tokens", lambda _self: 1_200)
+    monkeypatch.setattr(
+        ChatLiteLLMRouter, "_count_tokens", lambda _self, messages: _count(messages)
+    )
+    messages = [{"role": "tool", "content": "T" * 3_000}]
+
+    admitted = router._trim_messages_to_fit_context(messages, output_reserve_fraction=0)
+
+    assert _count(admitted) <= 1_200 - compute_tool_tokens([_TOOL_SCHEMA], _count)
+
+
+def test_router_method_preserves_passthrough_when_all_tokenizers_fail(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    router = ChatLiteLLMRouter.model_construct()
+    monkeypatch.setattr(ChatLiteLLMRouter, "_get_max_input_tokens", lambda _self: 600)
+    monkeypatch.setattr(
+        ChatLiteLLMRouter, "_count_tokens", lambda _self, _messages: None
+    )
+    messages = [{"role": "tool", "content": "T" * 4_000}]
+
+    admitted = router._trim_messages_to_fit_context(messages)
+
+    assert admitted is messages

--- a/surfsense_backend/tests/unit/services/test_lm_studio_discovery.py
+++ b/surfsense_backend/tests/unit/services/test_lm_studio_discovery.py
@@ -48,24 +48,26 @@ async def test_lm_studio_uses_native_v1_capabilities(monkeypatch) -> None:
         {
             native_url: (
                 200,
-                [
-                    {
-                        "type": "llm",
-                        "key": "google/gemma-4-e4b",
-                        "display_name": "Gemma 4 E4B",
-                        "max_context_length": 131072,
-                        "capabilities": {
-                            "vision": True,
-                            "trained_for_tool_use": True,
+                {
+                    "models": [
+                        {
+                            "type": "llm",
+                            "key": "google/gemma-4-e4b",
+                            "display_name": "Gemma 4 E4B",
+                            "max_context_length": 131072,
+                            "capabilities": {
+                                "vision": True,
+                                "trained_for_tool_use": True,
+                            },
                         },
-                    },
-                    {
-                        "type": "embedding",
-                        "key": "text-embedding-nomic-embed-text-v1.5",
-                        "display_name": "Nomic Embed",
-                        "max_context_length": 2048,
-                    },
-                ],
+                        {
+                            "type": "embedding",
+                            "key": "text-embedding-nomic-embed-text-v1.5",
+                            "display_name": "Nomic Embed",
+                            "max_context_length": 2048,
+                        },
+                    ]
+                },
             )
         },
     )
@@ -100,7 +102,7 @@ async def test_lm_studio_uses_native_v1_capabilities(monkeypatch) -> None:
 @pytest.mark.asyncio
 async def test_lm_studio_sends_token_to_native_discovery(monkeypatch) -> None:
     native_url = "https://lm.example.com/team/api/v1/models"
-    requests = _mock_responses(monkeypatch, {native_url: (200, [])})
+    requests = _mock_responses(monkeypatch, {native_url: (200, {"models": []})})
 
     await discover_models(
         _connection(

--- a/surfsense_backend/tests/unit/services/test_lm_studio_discovery.py
+++ b/surfsense_backend/tests/unit/services/test_lm_studio_discovery.py
@@ -1,0 +1,207 @@
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+from app.services.model_connection_service import ModelDiscoveryError, discover_models
+
+
+def _connection(**overrides):
+    values = {
+        "provider": "lm_studio",
+        "base_url": "http://host.docker.internal:1234/v1",
+        "api_key": None,
+        "extra": {},
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+def _mock_responses(monkeypatch, responses):
+    requests: list[tuple[str, dict[str, str]]] = []
+
+    class FakeAsyncClient:
+        def __init__(self, **_kwargs) -> None:
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args) -> None:
+            pass
+
+        async def get(self, url: str, **kwargs) -> httpx.Response:
+            requests.append((url, kwargs.get("headers") or {}))
+            status, payload = responses[url]
+            request = httpx.Request("GET", url)
+            return httpx.Response(status, request=request, json=payload)
+
+    monkeypatch.setattr(httpx, "AsyncClient", FakeAsyncClient)
+    return requests
+
+
+@pytest.mark.asyncio
+async def test_lm_studio_uses_native_v1_capabilities(monkeypatch) -> None:
+    native_url = "http://host.docker.internal:1234/api/v1/models"
+    requests = _mock_responses(
+        monkeypatch,
+        {
+            native_url: (
+                200,
+                [
+                    {
+                        "type": "llm",
+                        "key": "google/gemma-4-e4b",
+                        "display_name": "Gemma 4 E4B",
+                        "max_context_length": 131072,
+                        "capabilities": {
+                            "vision": True,
+                            "trained_for_tool_use": True,
+                        },
+                    },
+                    {
+                        "type": "embedding",
+                        "key": "text-embedding-nomic-embed-text-v1.5",
+                        "display_name": "Nomic Embed",
+                        "max_context_length": 2048,
+                    },
+                ],
+            )
+        },
+    )
+
+    models = await discover_models(_connection())
+
+    assert requests == [(native_url, {})]
+    assert models[0] == {
+        "model_id": "google/gemma-4-e4b",
+        "display_name": "Gemma 4 E4B",
+        "source": "DISCOVERED",
+        "supports_chat": True,
+        "supports_image_input": True,
+        "supports_tools": True,
+        "supports_image_generation": False,
+        "max_input_tokens": 131072,
+        "metadata": {
+            "type": "llm",
+            "key": "google/gemma-4-e4b",
+            "display_name": "Gemma 4 E4B",
+            "max_context_length": 131072,
+            "capabilities": {
+                "vision": True,
+                "trained_for_tool_use": True,
+            },
+        },
+    }
+    assert models[1]["supports_chat"] is False
+    assert models[1]["supports_image_input"] is False
+
+
+@pytest.mark.asyncio
+async def test_lm_studio_sends_token_to_native_discovery(monkeypatch) -> None:
+    native_url = "https://lm.example.com/team/api/v1/models"
+    requests = _mock_responses(monkeypatch, {native_url: (200, [])})
+
+    await discover_models(
+        _connection(
+            base_url="https://lm.example.com/team/v1/",
+            api_key="lm-secret",
+        )
+    )
+
+    assert requests == [(native_url, {"Authorization": "Bearer lm-secret"})]
+
+
+@pytest.mark.asyncio
+async def test_lm_studio_falls_back_to_legacy_v0_only_when_v1_is_absent(
+    monkeypatch,
+) -> None:
+    v1_url = "http://host.docker.internal:1234/api/v1/models"
+    v0_url = "http://host.docker.internal:1234/api/v0/models"
+    requests = _mock_responses(
+        monkeypatch,
+        {
+            v1_url: (404, {"error": "not found"}),
+            v0_url: (
+                200,
+                {
+                    "object": "list",
+                    "data": [
+                        {
+                            "id": "qwen2-vl-7b-instruct",
+                            "type": "vlm",
+                            "max_context_length": 32768,
+                        }
+                    ],
+                },
+            ),
+        },
+    )
+
+    models = await discover_models(_connection())
+
+    assert [url for url, _headers in requests] == [v1_url, v0_url]
+    assert models[0]["supports_chat"] is True
+    assert models[0]["supports_image_input"] is True
+
+
+@pytest.mark.asyncio
+async def test_lm_studio_falls_back_to_openai_models_after_native_apis(
+    monkeypatch,
+) -> None:
+    root = "http://host.docker.internal:1234"
+    requests = _mock_responses(
+        monkeypatch,
+        {
+            f"{root}/api/v1/models": (404, {"error": "not found"}),
+            f"{root}/api/v0/models": (405, {"error": "method not allowed"}),
+            f"{root}/v1/models": (
+                200,
+                {"data": [{"id": "legacy-local-model"}]},
+            ),
+        },
+    )
+
+    models = await discover_models(_connection())
+
+    assert [url for url, _headers in requests] == [
+        f"{root}/api/v1/models",
+        f"{root}/api/v0/models",
+        f"{root}/v1/models",
+    ]
+    assert models[0]["model_id"] == "legacy-local-model"
+
+
+@pytest.mark.asyncio
+async def test_lm_studio_does_not_hide_native_server_errors(monkeypatch) -> None:
+    native_url = "http://host.docker.internal:1234/api/v1/models"
+    requests = _mock_responses(
+        monkeypatch,
+        {native_url: (500, {"error": "server failed"})},
+    )
+
+    with pytest.raises(
+        ModelDiscoveryError, match="Model discovery failed with HTTP 500"
+    ):
+        await discover_models(_connection())
+
+    assert requests == [(native_url, {})]
+
+
+@pytest.mark.asyncio
+async def test_lm_studio_rejects_malformed_success_without_fallback(
+    monkeypatch,
+) -> None:
+    native_url = "http://host.docker.internal:1234/api/v1/models"
+    requests = _mock_responses(
+        monkeypatch,
+        {native_url: (200, {"unexpected": "shape"})},
+    )
+
+    with pytest.raises(
+        ModelDiscoveryError,
+        match="LM Studio native v1 returned an unsupported model-list response",
+    ):
+        await discover_models(_connection())
+
+    assert requests == [(native_url, {})]

--- a/surfsense_backend/tests/unit/services/test_lm_studio_discovery.py
+++ b/surfsense_backend/tests/unit/services/test_lm_studio_discovery.py
@@ -55,6 +55,9 @@ async def test_lm_studio_uses_native_v1_capabilities(monkeypatch) -> None:
                             "key": "google/gemma-4-e4b",
                             "display_name": "Gemma 4 E4B",
                             "max_context_length": 131072,
+                            "loaded_instances": [
+                                {"id": "instance-1", "config": {"context_length": 8192}}
+                            ],
                             "capabilities": {
                                 "vision": True,
                                 "trained_for_tool_use": True,
@@ -89,6 +92,9 @@ async def test_lm_studio_uses_native_v1_capabilities(monkeypatch) -> None:
             "key": "google/gemma-4-e4b",
             "display_name": "Gemma 4 E4B",
             "max_context_length": 131072,
+            "loaded_instances": [
+                {"id": "instance-1", "config": {"context_length": 8192}}
+            ],
             "capabilities": {
                 "vision": True,
                 "trained_for_tool_use": True,
@@ -97,6 +103,37 @@ async def test_lm_studio_uses_native_v1_capabilities(monkeypatch) -> None:
     }
     assert models[1]["supports_chat"] is False
     assert models[1]["supports_image_input"] is False
+
+
+@pytest.mark.asyncio
+async def test_lm_studio_budget_tracks_max_not_loaded_context(monkeypatch) -> None:
+    """Discovery reports the model's maximum, not whatever a currently loaded
+    instance happens to use — the latter changes without a rediscovery."""
+    native_url = "http://host.docker.internal:1234/api/v1/models"
+    _mock_responses(
+        monkeypatch,
+        {
+            native_url: (
+                200,
+                {
+                    "models": [
+                        {
+                            "type": "llm",
+                            "key": "model",
+                            "max_context_length": 32768,
+                            "loaded_instances": [
+                                {"id": "one", "config": {"context_length": 8192}}
+                            ],
+                        }
+                    ]
+                },
+            )
+        },
+    )
+
+    models = await discover_models(_connection())
+
+    assert models[0]["max_input_tokens"] == 32768
 
 
 @pytest.mark.asyncio

--- a/surfsense_backend/tests/unit/services/test_lm_studio_discovery.py
+++ b/surfsense_backend/tests/unit/services/test_lm_studio_discovery.py
@@ -148,7 +148,7 @@ async def test_lm_studio_falls_back_to_legacy_v0_only_when_v1_is_absent(
 
 
 @pytest.mark.asyncio
-async def test_lm_studio_falls_back_to_openai_models_after_native_apis(
+async def test_lm_studio_rejects_when_native_apis_are_unavailable(
     monkeypatch,
 ) -> None:
     root = "http://host.docker.internal:1234"
@@ -157,21 +157,19 @@ async def test_lm_studio_falls_back_to_openai_models_after_native_apis(
         {
             f"{root}/api/v1/models": (404, {"error": "not found"}),
             f"{root}/api/v0/models": (405, {"error": "method not allowed"}),
-            f"{root}/v1/models": (
-                200,
-                {"data": [{"id": "legacy-local-model"}]},
-            ),
         },
     )
 
-    models = await discover_models(_connection())
+    with pytest.raises(
+        ModelDiscoveryError,
+        match=r"Upgrade LM Studio to version 0\.4 or newer",
+    ):
+        await discover_models(_connection())
 
     assert [url for url, _headers in requests] == [
         f"{root}/api/v1/models",
         f"{root}/api/v0/models",
-        f"{root}/v1/models",
     ]
-    assert models[0]["model_id"] == "legacy-local-model"
 
 
 @pytest.mark.asyncio

--- a/surfsense_backend/tests/unit/services/test_lm_studio_discovery.py
+++ b/surfsense_backend/tests/unit/services/test_lm_studio_discovery.py
@@ -139,7 +139,12 @@ async def test_lm_studio_budget_tracks_max_not_loaded_context(monkeypatch) -> No
 @pytest.mark.asyncio
 async def test_lm_studio_sends_token_to_native_discovery(monkeypatch) -> None:
     native_url = "https://lm.example.com/team/api/v1/models"
-    requests = _mock_responses(monkeypatch, {native_url: (200, {"models": []})})
+    # One model, because an empty catalog is itself a discovery failure and
+    # would raise before the header assertion below.
+    requests = _mock_responses(
+        monkeypatch,
+        {native_url: (200, {"models": [{"type": "llm", "key": "model"}]})},
+    )
 
     await discover_models(
         _connection(

--- a/surfsense_backend/tests/unit/services/test_model_connections.py
+++ b/surfsense_backend/tests/unit/services/test_model_connections.py
@@ -64,6 +64,36 @@ def test_openai_compatible_resolver_uses_explicit_api_base() -> None:
     assert ensure_v1("http://example.com/v1") == "http://example.com/v1"
 
 
+def test_openai_compatible_resolver_uses_base_url_verbatim() -> None:
+    # A bare host is NOT rewritten to append ``/v1``.
+    _model, kwargs = to_litellm(
+        {
+            "provider": "openai_compatible",
+            "base_url": "https://api.example.com",
+            "api_key": "ex-key",
+            "extra": {},
+        },
+        "some-model",
+    )
+
+    assert kwargs["api_base"] == "https://api.example.com"
+
+
+def test_openai_compatible_resolver_preserves_custom_path() -> None:
+    # Custom (non-/v1) paths survive verbatim, covering the old ``_raw`` case.
+    _model, kwargs = to_litellm(
+        {
+            "provider": "openai_compatible",
+            "base_url": "https://ark.cn-beijing.volces.com/api/v3/",
+            "api_key": "ark-key",
+            "extra": {},
+        },
+        "ep-20260101000000-test",
+    )
+
+    assert kwargs["api_base"] == "https://ark.cn-beijing.volces.com/api/v3"
+
+
 def test_lm_studio_resolver_supplies_dummy_api_key_when_empty() -> None:
     model, kwargs = to_litellm(
         {

--- a/surfsense_backend/tests/unit/services/test_model_connections.py
+++ b/surfsense_backend/tests/unit/services/test_model_connections.py
@@ -5,12 +5,13 @@ import pytest
 
 from app.routes.model_connections_routes import _apply_model_facts
 from app.services import model_connection_service
+from app.services.context_admission import GEN_AI_MODEL_FALLBACK_MAX_TOKENS
 from app.services.global_model_catalog import materialize_global_model_catalog
 from app.services.model_connection_service import (
     ModelDiscoveryError,
     _discovery_error_message,
     _model_test_error,
-    _ollama_context_length,
+    _ollama_seed_budget,
     derive_capabilities,
     discover_models,
     verify_connection,
@@ -54,29 +55,31 @@ def _ollama_conn() -> SimpleNamespace:
     )
 
 
-def test_ollama_context_length_prefers_modelfile_num_ctx() -> None:
-    """A Modelfile ``num_ctx`` is the size Ollama will actually run at, so it
-    outranks the architecture maximum -- budgeting 262k against it would
-    overflow every turn."""
+def test_ollama_seed_budget_takes_modelfile_num_ctx_verbatim() -> None:
+    """A Modelfile ``num_ctx`` is a human's statement about this deployment --
+    the size Ollama will actually run at -- so it is the one discovered number
+    trusted above the generic fallback."""
     assert (
-        _ollama_context_length(
+        _ollama_seed_budget(
             {
-                "parameters": "top_p 0.95\nnum_ctx 8192\ntemperature 1",
+                "parameters": "top_p 0.95\nnum_ctx 64000\ntemperature 1",
                 "model_info": {
                     "general.architecture": "gemma4",
                     "gemma4.context_length": 262_144,
                 },
             }
         )
-        == 8_192
+        == 64_000
     )
 
 
-def test_ollama_context_length_reads_architecture_keyed_value() -> None:
-    """The shape /api/show actually returns: the context length is keyed by
-    architecture, which is why reading ``details`` alone found nothing."""
+def test_ollama_seed_budget_caps_the_architecture_maximum() -> None:
+    """The architecture maximum describes the weights, not the host. Ollama
+    sizes the context from free memory at load time, so a 262k-capable model
+    routinely runs in a far smaller window; budgeting the maximum would
+    overflow every turn."""
     assert (
-        _ollama_context_length(
+        _ollama_seed_budget(
             {
                 "parameters": "top_p 0.95\ntemperature 1",
                 "model_info": {
@@ -86,49 +89,28 @@ def test_ollama_context_length_reads_architecture_keyed_value() -> None:
                 "details": {"family": "gemma4", "quantization_level": "Q4_K_M"},
             }
         )
-        == 262_144
+        == GEN_AI_MODEL_FALLBACK_MAX_TOKENS
     )
 
 
-def test_ollama_context_length_falls_back_to_tags_details() -> None:
-    """Newer Ollama reports context_length in /api/tags ``details``; that is the
-    only source left when /api/show fails."""
-    assert _ollama_context_length({"details": {"context_length": 131_072}}) == 131_072
+def test_ollama_seed_budget_pins_a_window_under_the_fallback() -> None:
+    """The direction the cap must not lose: newer Ollama reports context_length
+    in /api/tags ``details``, and a model whose window is smaller than the
+    generic fallback would otherwise be over-budgeted at 32k."""
+    assert _ollama_seed_budget({"details": {"context_length": 4_096}}) == 4_096
 
 
-def test_ollama_context_length_returns_none_when_unreported() -> None:
-    assert _ollama_context_length({}) is None
-    assert _ollama_context_length({"details": {"context_length": 0}}) is None
-
-
-def test_derive_capabilities_seeds_the_full_architecture_context() -> None:
-    """Seeded unbounded: how much the Ollama host can allocate is not ours to
-    guess, and capping would cost a sliding-window model most of its window."""
-    facts = derive_capabilities(
-        _ollama_conn(),
-        "gemma4:12b",
-        {
-            "capabilities": ["completion", "tools", "vision"],
-            "model_info": {
-                "general.architecture": "gemma4",
-                "gemma4.context_length": 262_144,
-            },
-        },
-    )
-
-    assert facts["max_input_tokens"] == 262_144
-    assert facts["supports_tools"] is True
-    assert facts["supports_image_input"] is True
+def test_ollama_seed_budget_returns_none_when_unreported() -> None:
+    assert _ollama_seed_budget({}) is None
+    assert _ollama_seed_budget({"details": {"context_length": 0}}) is None
 
 
 def test_derive_capabilities_seeds_a_small_window_verbatim() -> None:
-    """The case the dead lookups broke: a model whose real window is under the
-    generic fallback used to be budgeted at 32k and silently truncated."""
     facts = derive_capabilities(
         _ollama_conn(),
         "llama2:7b",
         {
-            "capabilities": ["completion"],
+            "capabilities": ["completion", "tools", "vision"],
             "model_info": {
                 "general.architecture": "llama",
                 "llama.context_length": 4_096,
@@ -137,6 +119,8 @@ def test_derive_capabilities_seeds_a_small_window_verbatim() -> None:
     )
 
     assert facts["max_input_tokens"] == 4_096
+    assert facts["supports_tools"] is True
+    assert facts["supports_image_input"] is True
 
 
 @pytest.mark.asyncio
@@ -197,7 +181,9 @@ async def test_ollama_discovery_merges_details_from_both_endpoints(
     assert details["context_length"] == 262_144
     assert details["embedding_length"] == 3_840
     assert details["quantization_level"] == "Q4_K_M"
-    assert results[0]["max_input_tokens"] == 262_144
+    # The reported maximum survives in the metadata the UI reads, while the
+    # seeded budget stays at the fallback the host is likely to have allocated.
+    assert results[0]["max_input_tokens"] == GEN_AI_MODEL_FALLBACK_MAX_TOKENS
 
 
 def test_anthropic_resolver_strips_trailing_v1_from_api_base() -> None:

--- a/surfsense_backend/tests/unit/services/test_model_connections.py
+++ b/surfsense_backend/tests/unit/services/test_model_connections.py
@@ -2,9 +2,37 @@ from types import SimpleNamespace
 
 import httpx
 
+from app.routes.model_connections_routes import _apply_model_facts
 from app.services.global_model_catalog import materialize_global_model_catalog
 from app.services.model_connection_service import _discovery_error_message
 from app.services.model_resolver import strip_version_suffix, to_litellm
+
+
+def _facts(max_input_tokens: int | None) -> dict:
+    return {
+        "supports_chat": True,
+        "max_input_tokens": max_input_tokens,
+        "supports_image_input": False,
+        "supports_tools": True,
+        "supports_image_generation": False,
+    }
+
+
+def test_rediscovery_preserves_stored_context_limit() -> None:
+    """A stored limit is written once: rediscovery must not clobber it."""
+    model = SimpleNamespace(catalog={}, max_input_tokens=8_192)
+
+    _apply_model_facts(model, _facts(131_072))
+
+    assert model.max_input_tokens == 8_192
+
+
+def test_discovery_seeds_context_limit_when_unset() -> None:
+    model = SimpleNamespace(catalog={}, max_input_tokens=None)
+
+    _apply_model_facts(model, _facts(131_072))
+
+    assert model.max_input_tokens == 131_072
 
 
 def test_anthropic_resolver_strips_trailing_v1_from_api_base() -> None:

--- a/surfsense_backend/tests/unit/services/test_model_connections.py
+++ b/surfsense_backend/tests/unit/services/test_model_connections.py
@@ -1,10 +1,18 @@
 from types import SimpleNamespace
 
 import httpx
+import pytest
 
 from app.routes.model_connections_routes import _apply_model_facts
+from app.services import model_connection_service
 from app.services.global_model_catalog import materialize_global_model_catalog
-from app.services.model_connection_service import _discovery_error_message
+from app.services.model_connection_service import (
+    ModelDiscoveryError,
+    _discovery_error_message,
+    _model_test_error,
+    discover_models,
+    verify_connection,
+)
 from app.services.model_resolver import strip_version_suffix, to_litellm
 
 
@@ -229,3 +237,149 @@ def test_discovery_404_message_points_at_base_url_and_echoes_url() -> None:
 
     assert "http://host.docker.internal:1234/models" in message
     assert "API Base URL" in message
+
+
+def test_model_test_error_reports_http_response_as_provider_error() -> None:
+    class APIConnectionError(Exception):
+        status_code = 415
+
+    conn = SimpleNamespace(
+        provider="ollama_chat",
+        base_url="http://host.docker.internal:11434",
+    )
+
+    result = _model_test_error(
+        conn,
+        "gemma4:12b",
+        APIConnectionError("Unsupported Media Type"),
+    )
+
+    assert result.status == "PROVIDER_ERROR"
+    assert result.ok is False
+    assert "HTTP 415" in result.message
+    assert "Unsupported Media Type" in result.message
+
+
+def test_model_test_error_keeps_statusless_connection_failure_unreachable() -> None:
+    class APIConnectionError(Exception):
+        pass
+
+    conn = SimpleNamespace(
+        provider="ollama_chat",
+        base_url="http://host.docker.internal:11434",
+    )
+
+    result = _model_test_error(
+        conn,
+        "gemma4:12b",
+        APIConnectionError("Connection refused"),
+    )
+
+    assert result.status == "UNREACHABLE"
+    assert result.ok is False
+
+
+@pytest.mark.asyncio
+async def test_verify_connection_reports_http_response_as_provider_error(
+    monkeypatch,
+) -> None:
+    class FakeAsyncClient:
+        def __init__(self, **_kwargs) -> None:
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args) -> None:
+            pass
+
+        async def get(self, url: str, **_kwargs) -> httpx.Response:
+            request = httpx.Request("GET", url)
+            return httpx.Response(
+                500,
+                request=request,
+                text="Provider failed",
+            )
+
+    monkeypatch.setattr(httpx, "AsyncClient", FakeAsyncClient)
+    conn = SimpleNamespace(
+        provider="openai_compatible",
+        base_url="https://models.example.com/v1",
+        api_key="test-key",
+    )
+
+    result = await verify_connection(conn)
+
+    assert result.status == "PROVIDER_ERROR"
+    assert result.ok is False
+    assert "HTTP 500" in result.message
+    assert "Provider failed" in result.message
+
+
+@pytest.mark.asyncio
+async def test_verify_lm_studio_reports_http_response_as_provider_error(
+    monkeypatch,
+) -> None:
+    request = httpx.Request(
+        "GET",
+        "http://host.docker.internal:1234/api/v1/models",
+    )
+    response = httpx.Response(503, request=request, text="Server unavailable")
+
+    async def failed_discovery(_conn) -> list[dict]:
+        raise httpx.HTTPStatusError(
+            "503",
+            request=request,
+            response=response,
+        )
+
+    monkeypatch.setattr(
+        model_connection_service,
+        "_discover_lm_studio_models",
+        failed_discovery,
+    )
+    conn = SimpleNamespace(
+        provider="lm_studio",
+        base_url="http://host.docker.internal:1234/v1",
+        api_key=None,
+    )
+
+    result = await verify_connection(conn)
+
+    assert result.status == "PROVIDER_ERROR"
+    assert result.ok is False
+    assert "HTTP 503" in result.message
+    assert "Server unavailable" in result.message
+
+
+@pytest.mark.asyncio
+async def test_discover_models_rejects_empty_discoverable_provider(
+    monkeypatch,
+) -> None:
+    async def empty_ollama_models(_conn) -> list[dict]:
+        return []
+
+    monkeypatch.setattr(
+        model_connection_service,
+        "_ollama_tags_then_show",
+        empty_ollama_models,
+    )
+    conn = SimpleNamespace(
+        provider="ollama_chat",
+        base_url="http://host.docker.internal:11434",
+    )
+
+    with pytest.raises(ModelDiscoveryError, match="No models found at"):
+        await discover_models(conn)
+
+
+@pytest.mark.asyncio
+async def test_discover_models_allows_empty_static_provider(monkeypatch) -> None:
+    monkeypatch.setattr(
+        model_connection_service,
+        "_litellm_static_models",
+        lambda _conn: [],
+    )
+    conn = SimpleNamespace(provider="azure", base_url=None)
+
+    assert await discover_models(conn) == []

--- a/surfsense_backend/tests/unit/services/test_model_connections.py
+++ b/surfsense_backend/tests/unit/services/test_model_connections.py
@@ -1,5 +1,5 @@
 from app.services.global_model_catalog import materialize_global_model_catalog
-from app.services.model_resolver import ensure_v1, strip_version_suffix, to_litellm
+from app.services.model_resolver import strip_version_suffix, to_litellm
 
 
 def test_anthropic_resolver_strips_trailing_v1_from_api_base() -> None:
@@ -61,7 +61,6 @@ def test_openai_compatible_resolver_uses_explicit_api_base() -> None:
     assert model == "openai/qwen/qwen3"
     assert kwargs["api_base"] == "http://host.docker.internal:1234/v1"
     assert kwargs["api_key"] == "local-key"
-    assert ensure_v1("http://example.com/v1") == "http://example.com/v1"
 
 
 def test_openai_compatible_resolver_uses_base_url_verbatim() -> None:

--- a/surfsense_backend/tests/unit/services/test_model_connections.py
+++ b/surfsense_backend/tests/unit/services/test_model_connections.py
@@ -1,4 +1,9 @@
+from types import SimpleNamespace
+
+import httpx
+
 from app.services.global_model_catalog import materialize_global_model_catalog
+from app.services.model_connection_service import _discovery_error_message
 from app.services.model_resolver import strip_version_suffix, to_litellm
 
 
@@ -181,3 +186,18 @@ def test_global_materialization_preserves_tier_and_keeps_key_server_side() -> No
         for connection in connections
     ]
     assert "sk-" not in repr(public_connections)
+
+
+def test_discovery_404_message_points_at_base_url_and_echoes_url() -> None:
+    request = httpx.Request("GET", "http://host.docker.internal:1234/models")
+    exc = httpx.HTTPStatusError(
+        "404", request=request, response=httpx.Response(404, request=request)
+    )
+    conn = SimpleNamespace(
+        provider="openai_compatible", base_url="http://host.docker.internal:1234"
+    )
+
+    message = _discovery_error_message(conn, exc)
+
+    assert "http://host.docker.internal:1234/models" in message
+    assert "API Base URL" in message

--- a/surfsense_backend/tests/unit/services/test_model_connections.py
+++ b/surfsense_backend/tests/unit/services/test_model_connections.py
@@ -5,7 +5,7 @@ import pytest
 
 from app.routes.model_connections_routes import _apply_model_facts
 from app.services import model_connection_service
-from app.services.context_admission import GEN_AI_MODEL_FALLBACK_MAX_TOKENS
+from app.services.context_admission import SURFSENSE_UNKNOWN_MODEL_MAX_INPUT_TOKENS
 from app.services.global_model_catalog import materialize_global_model_catalog
 from app.services.model_connection_service import (
     ModelDiscoveryError,
@@ -89,7 +89,7 @@ def test_ollama_seed_budget_caps_the_architecture_maximum() -> None:
                 "details": {"family": "gemma4", "quantization_level": "Q4_K_M"},
             }
         )
-        == GEN_AI_MODEL_FALLBACK_MAX_TOKENS
+        == SURFSENSE_UNKNOWN_MODEL_MAX_INPUT_TOKENS
     )
 
 
@@ -183,7 +183,10 @@ async def test_ollama_discovery_merges_details_from_both_endpoints(
     assert details["quantization_level"] == "Q4_K_M"
     # The reported maximum survives in the metadata the UI reads, while the
     # seeded budget stays at the fallback the host is likely to have allocated.
-    assert results[0]["max_input_tokens"] == GEN_AI_MODEL_FALLBACK_MAX_TOKENS
+    assert (
+        results[0]["max_input_tokens"]
+        == SURFSENSE_UNKNOWN_MODEL_MAX_INPUT_TOKENS
+    )
 
 
 def test_anthropic_resolver_strips_trailing_v1_from_api_base() -> None:

--- a/surfsense_backend/tests/unit/services/test_model_connections.py
+++ b/surfsense_backend/tests/unit/services/test_model_connections.py
@@ -10,6 +10,8 @@ from app.services.model_connection_service import (
     ModelDiscoveryError,
     _discovery_error_message,
     _model_test_error,
+    _ollama_context_length,
+    derive_capabilities,
     discover_models,
     verify_connection,
 )
@@ -41,6 +43,161 @@ def test_discovery_seeds_context_limit_when_unset() -> None:
     _apply_model_facts(model, _facts(131_072))
 
     assert model.max_input_tokens == 131_072
+
+
+def _ollama_conn() -> SimpleNamespace:
+    return SimpleNamespace(
+        provider="ollama_chat",
+        base_url="http://host.docker.internal:11434",
+        api_key=None,
+        extra={},
+    )
+
+
+def test_ollama_context_length_prefers_modelfile_num_ctx() -> None:
+    """A Modelfile ``num_ctx`` is the size Ollama will actually run at, so it
+    outranks the architecture maximum -- budgeting 262k against it would
+    overflow every turn."""
+    assert (
+        _ollama_context_length(
+            {
+                "parameters": "top_p 0.95\nnum_ctx 8192\ntemperature 1",
+                "model_info": {
+                    "general.architecture": "gemma4",
+                    "gemma4.context_length": 262_144,
+                },
+            }
+        )
+        == 8_192
+    )
+
+
+def test_ollama_context_length_reads_architecture_keyed_value() -> None:
+    """The shape /api/show actually returns: the context length is keyed by
+    architecture, which is why reading ``details`` alone found nothing."""
+    assert (
+        _ollama_context_length(
+            {
+                "parameters": "top_p 0.95\ntemperature 1",
+                "model_info": {
+                    "general.architecture": "gemma4",
+                    "gemma4.context_length": 262_144,
+                },
+                "details": {"family": "gemma4", "quantization_level": "Q4_K_M"},
+            }
+        )
+        == 262_144
+    )
+
+
+def test_ollama_context_length_falls_back_to_tags_details() -> None:
+    """Newer Ollama reports context_length in /api/tags ``details``; that is the
+    only source left when /api/show fails."""
+    assert _ollama_context_length({"details": {"context_length": 131_072}}) == 131_072
+
+
+def test_ollama_context_length_returns_none_when_unreported() -> None:
+    assert _ollama_context_length({}) is None
+    assert _ollama_context_length({"details": {"context_length": 0}}) is None
+
+
+def test_derive_capabilities_seeds_the_full_architecture_context() -> None:
+    """Seeded unbounded: how much the Ollama host can allocate is not ours to
+    guess, and capping would cost a sliding-window model most of its window."""
+    facts = derive_capabilities(
+        _ollama_conn(),
+        "gemma4:12b",
+        {
+            "capabilities": ["completion", "tools", "vision"],
+            "model_info": {
+                "general.architecture": "gemma4",
+                "gemma4.context_length": 262_144,
+            },
+        },
+    )
+
+    assert facts["max_input_tokens"] == 262_144
+    assert facts["supports_tools"] is True
+    assert facts["supports_image_input"] is True
+
+
+def test_derive_capabilities_seeds_a_small_window_verbatim() -> None:
+    """The case the dead lookups broke: a model whose real window is under the
+    generic fallback used to be budgeted at 32k and silently truncated."""
+    facts = derive_capabilities(
+        _ollama_conn(),
+        "llama2:7b",
+        {
+            "capabilities": ["completion"],
+            "model_info": {
+                "general.architecture": "llama",
+                "llama.context_length": 4_096,
+            },
+        },
+    )
+
+    assert facts["max_input_tokens"] == 4_096
+
+
+@pytest.mark.asyncio
+async def test_ollama_discovery_merges_details_from_both_endpoints(
+    monkeypatch,
+) -> None:
+    """/api/tags and /api/show both return ``details`` with different fields. A
+    shallow update would drop the context_length only /api/tags reports."""
+
+    class FakeAsyncClient:
+        def __init__(self, **_kwargs) -> None:
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args) -> None:
+            pass
+
+        async def get(self, url: str, **_kwargs) -> httpx.Response:
+            return httpx.Response(
+                200,
+                request=httpx.Request("GET", url),
+                json={
+                    "models": [
+                        {
+                            "model": "gemma4:12b",
+                            "name": "gemma4:12b",
+                            "details": {
+                                "family": "gemma4",
+                                "context_length": 262_144,
+                                "embedding_length": 3_840,
+                            },
+                        }
+                    ]
+                },
+            )
+
+        async def post(self, url: str, **_kwargs) -> httpx.Response:
+            return httpx.Response(
+                200,
+                request=httpx.Request("POST", url),
+                json={
+                    "details": {
+                        "family": "gemma4",
+                        "quantization_level": "Q4_K_M",
+                    },
+                    "model_info": {"general.architecture": "gemma4"},
+                    "capabilities": ["completion"],
+                },
+            )
+
+    monkeypatch.setattr(httpx, "AsyncClient", FakeAsyncClient)
+
+    results = await model_connection_service._ollama_tags_then_show(_ollama_conn())
+
+    details = results[0]["metadata"]["details"]
+    assert details["context_length"] == 262_144
+    assert details["embedding_length"] == 3_840
+    assert details["quantization_level"] == "Q4_K_M"
+    assert results[0]["max_input_tokens"] == 262_144
 
 
 def test_anthropic_resolver_strips_trailing_v1_from_api_base() -> None:

--- a/surfsense_backend/tests/unit/tasks/chat/streaming/test_error_classifier.py
+++ b/surfsense_backend/tests/unit/tasks/chat/streaming/test_error_classifier.py
@@ -42,6 +42,60 @@ def test_adapter_preserves_rate_limit_classification() -> None:
     assert adapted.retryable is True
 
 
+def test_adapter_prioritizes_lm_studio_context_type_over_http_400() -> None:
+    exc = RuntimeError(
+        '{"code":400,"type":"exceed_context_size_error",'
+        '"n_prompt_tokens":14684,"n_ctx":8192}'
+    )
+
+    adapted = adapt_llm_exception(exc)
+
+    assert adapted.category is LLMErrorCategory.CONTEXT_LIMIT
+    assert adapted.retryable is False
+    assert adapted.provider_status_code == 400
+    assert adapted.provider_error_type == "exceed_context_size_error"
+
+
+def test_adapter_finds_context_overflow_in_wrapped_cause() -> None:
+    cause = RuntimeError(
+        'LM Studio error: {"code":400,"type":"exceed_context_size_error"} trailing'
+    )
+    exc = _exception_named("MidStreamFallbackError", "provider unavailable")
+    exc.__cause__ = cause
+
+    adapted = adapt_llm_exception(exc)
+
+    assert adapted.category is LLMErrorCategory.CONTEXT_LIMIT
+    assert adapted.retryable is False
+    assert adapted.provider_status_code == 400
+
+
+def test_adapter_keeps_unrelated_http_400_as_bad_request() -> None:
+    adapted = adapt_llm_exception(RuntimeError('{"code":400,"type":"invalid_request"}'))
+
+    assert adapted.category is LLMErrorCategory.BAD_REQUEST
+
+
+def test_stream_classifier_maps_context_limit_to_stable_code() -> None:
+    exc = RuntimeError('{"code":400,"type":"exceed_context_size_error","n_ctx":8192}')
+
+    kind, code, severity, expected, message, extra = classify_stream_exception(
+        exc,
+        flow_label="chat",
+    )
+
+    assert kind == "model_context_limit"
+    assert code == "MODEL_CONTEXT_LIMIT"
+    assert severity == "warn"
+    assert expected is True
+    assert "too large" in message
+    assert extra == {
+        "provider_error_category": "context_limit",
+        "provider_status_code": 400,
+        "provider_error_type": "exceed_context_size_error",
+    }
+
+
 def test_stream_classifier_maps_model_auth_to_stable_code() -> None:
     exc = RuntimeError(
         'litellm.AuthenticationError: OpenrouterException - {"error":{"message":"User not found.","code":401}}'

--- a/surfsense_backend/tests/unit/tasks/chat/streaming/test_error_classifier.py
+++ b/surfsense_backend/tests/unit/tasks/chat/streaming/test_error_classifier.py
@@ -70,6 +70,40 @@ def test_adapter_finds_context_overflow_in_wrapped_cause() -> None:
     assert adapted.provider_status_code == 400
 
 
+def test_adapter_classifies_runtime_out_of_memory() -> None:
+    exc = RuntimeError(
+        "llama runner process has terminated: "
+        "ggml_backend_cuda_buffer_type_alloc_buffer: allocating 4096.00 MiB "
+        "on device 0: cudaMalloc failed: out of memory"
+    )
+
+    adapted = adapt_llm_exception(exc)
+
+    assert adapted.category is LLMErrorCategory.INSUFFICIENT_MEMORY
+    # Retrying reloads the same model at the same size and fails the same way.
+    assert adapted.retryable is False
+
+
+def test_adapter_classifies_preflight_does_not_fit() -> None:
+    """Ollama's ``ErrLoadRequiredFull``, raised before any allocation."""
+    adapted = adapt_llm_exception(RuntimeError("unable to load full model on GPU"))
+
+    assert adapted.category is LLMErrorCategory.INSUFFICIENT_MEMORY
+
+
+def test_adapter_prefers_memory_over_context_when_both_appear() -> None:
+    """The ordering guard: a failed KV cache reservation names the ``n_ctx`` it
+    could not fit, and ``n_ctx`` is also a context-limit hint. Reading it as a
+    context limit would tell the user to shrink a prompt that never ran."""
+    exc = RuntimeError(
+        "llama_init_from_model: failed to allocate KV cache for n_ctx = 262144"
+    )
+
+    adapted = adapt_llm_exception(exc)
+
+    assert adapted.category is LLMErrorCategory.INSUFFICIENT_MEMORY
+
+
 def test_adapter_keeps_unrelated_http_400_as_bad_request() -> None:
     adapted = adapt_llm_exception(RuntimeError('{"code":400,"type":"invalid_request"}'))
 
@@ -121,6 +155,28 @@ def test_stream_classifier_maps_model_auth_to_stable_code() -> None:
         "provider_error_category": "auth_failed",
         "provider_status_code": 401,
     }
+
+
+def test_stream_classifier_maps_out_of_memory_to_stable_code() -> None:
+    """A local runtime reports OOM as a 5xx, which lands in the unavailable
+    group unless this classifies ahead of it -- and that group's copy tells the
+    user to retry a load that cannot succeed until the limit comes down."""
+    exc = RuntimeError(
+        'litellm.APIError: OllamaException - {"error":"model requires more '
+        'system memory (14.2 GiB) than is available (7.8 GiB)"}'
+    )
+
+    kind, code, severity, expected, message, diagnostic, extra = (
+        classify_stream_exception(exc, flow_label="chat")
+    )
+
+    assert kind == "model_out_of_memory"
+    assert code == "MODEL_OUT_OF_MEMORY"
+    assert severity == "warn"
+    assert expected is True
+    assert "context limit" in message
+    assert diagnostic == str(exc)
+    assert extra["provider_error_category"] == "insufficient_memory"
 
 
 def test_stream_classifier_keeps_unknown_errors_generic() -> None:

--- a/surfsense_backend/tests/unit/tasks/chat/streaming/test_error_classifier.py
+++ b/surfsense_backend/tests/unit/tasks/chat/streaming/test_error_classifier.py
@@ -79,9 +79,11 @@ def test_adapter_keeps_unrelated_http_400_as_bad_request() -> None:
 def test_stream_classifier_maps_context_limit_to_stable_code() -> None:
     exc = RuntimeError('{"code":400,"type":"exceed_context_size_error","n_ctx":8192}')
 
-    kind, code, severity, expected, message, extra = classify_stream_exception(
-        exc,
-        flow_label="chat",
+    kind, code, severity, expected, message, diagnostic, extra = (
+        classify_stream_exception(
+            exc,
+            flow_label="chat",
+        )
     )
 
     assert kind == "model_context_limit"
@@ -89,6 +91,7 @@ def test_stream_classifier_maps_context_limit_to_stable_code() -> None:
     assert severity == "warn"
     assert expected is True
     assert "too large" in message
+    assert diagnostic == str(exc)
     assert extra == {
         "provider_error_category": "context_limit",
         "provider_status_code": 400,
@@ -101,9 +104,11 @@ def test_stream_classifier_maps_model_auth_to_stable_code() -> None:
         'litellm.AuthenticationError: OpenrouterException - {"error":{"message":"User not found.","code":401}}'
     )
 
-    kind, code, severity, expected, message, extra = classify_stream_exception(
-        exc,
-        flow_label="chat",
+    kind, code, severity, expected, message, diagnostic, extra = (
+        classify_stream_exception(
+            exc,
+            flow_label="chat",
+        )
     )
 
     assert kind == "model_auth_failed"
@@ -111,6 +116,7 @@ def test_stream_classifier_maps_model_auth_to_stable_code() -> None:
     assert severity == "warn"
     assert expected is True
     assert "API key" in message
+    assert diagnostic == str(exc)
     assert extra == {
         "provider_error_category": "auth_failed",
         "provider_status_code": 401,
@@ -120,14 +126,17 @@ def test_stream_classifier_maps_model_auth_to_stable_code() -> None:
 def test_stream_classifier_keeps_unknown_errors_generic() -> None:
     exc = RuntimeError("database exploded")
 
-    kind, code, severity, expected, message, extra = classify_stream_exception(
-        exc,
-        flow_label="chat",
+    kind, code, severity, expected, message, diagnostic, extra = (
+        classify_stream_exception(
+            exc,
+            flow_label="chat",
+        )
     )
 
     assert kind == "server_error"
     assert code == "SERVER_ERROR"
     assert severity == "error"
     assert expected is False
-    assert message == "Error during chat: database exploded"
+    assert message == "We couldn't complete this response right now. Please try again."
+    assert diagnostic == "Error during chat: database exploded"
     assert extra is None

--- a/surfsense_backend/tests/unit/tasks/chat/streaming/test_error_classifier.py
+++ b/surfsense_backend/tests/unit/tasks/chat/streaming/test_error_classifier.py
@@ -160,7 +160,7 @@ def test_stream_classifier_maps_model_auth_to_stable_code() -> None:
 def test_stream_classifier_maps_out_of_memory_to_stable_code() -> None:
     """A local runtime reports OOM as a 5xx, which lands in the unavailable
     group unless this classifies ahead of it -- and that group's copy tells the
-    user to retry a load that cannot succeed until the limit comes down."""
+    user to retry a load that cannot succeed until memory is freed."""
     exc = RuntimeError(
         'litellm.APIError: OllamaException - {"error":"model requires more '
         'system memory (14.2 GiB) than is available (7.8 GiB)"}'
@@ -174,7 +174,9 @@ def test_stream_classifier_maps_out_of_memory_to_stable_code() -> None:
     assert code == "MODEL_OUT_OF_MEMORY"
     assert severity == "warn"
     assert expected is True
-    assert "context limit" in message
+    # Names a lever that works: our budget does not size the host's allocation,
+    # so telling the user to lower it would not free a byte.
+    assert "smaller model" in message
     assert diagnostic == str(exc)
     assert extra["provider_error_category"] == "insufficient_memory"
 

--- a/surfsense_backend/tests/unit/tasks/chat/streaming/test_error_contract.py
+++ b/surfsense_backend/tests/unit/tasks/chat/streaming/test_error_contract.py
@@ -20,6 +20,7 @@ def test_every_backend_chat_error_has_display_copy() -> None:
         "MODEL_CONTEXT_LIMIT",
         "MODEL_DOES_NOT_SUPPORT_IMAGE_INPUT",
         "MODEL_NOT_FOUND",
+        "MODEL_OUT_OF_MEMORY",
         "MODEL_PROVIDER_UNAVAILABLE",
         "NO_ACTIVE_TURN",
         "PREMIUM_QUOTA_EXHAUSTED",
@@ -68,4 +69,3 @@ def test_error_wire_separates_display_message_from_diagnostic() -> None:
 def test_unknown_backend_chat_error_cannot_be_emitted_silently() -> None:
     with pytest.raises(ValueError, match="No user-facing message registered"):
         chat_error_message("TYPO_ERROR_CODE")
-

--- a/surfsense_backend/tests/unit/tasks/chat/streaming/test_error_contract.py
+++ b/surfsense_backend/tests/unit/tasks/chat/streaming/test_error_contract.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from app.services.streaming.events.error import format_error
+from app.tasks.chat.streaming.errors.messages import (
+    CHAT_ERROR_MESSAGES,
+    chat_error_message,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_every_backend_chat_error_has_display_copy() -> None:
+    expected_codes = {
+        "MESSAGE_PERSIST_FAILED",
+        "MODEL_AUTH_FAILED",
+        "MODEL_CONTEXT_LIMIT",
+        "MODEL_DOES_NOT_SUPPORT_IMAGE_INPUT",
+        "MODEL_NOT_FOUND",
+        "MODEL_PROVIDER_UNAVAILABLE",
+        "NO_ACTIVE_TURN",
+        "PREMIUM_QUOTA_EXHAUSTED",
+        "RATE_LIMITED",
+        "SERVER_ERROR",
+        "THREAD_BUSY",
+        "TOOL_EXECUTION_ERROR",
+        "TURN_CANCELLING",
+    }
+
+    assert set(CHAT_ERROR_MESSAGES) == expected_codes
+    assert all(chat_error_message(code).strip() for code in expected_codes)
+
+
+def test_lm_studio_context_error_uses_actionable_variant() -> None:
+    message = chat_error_message(
+        "MODEL_CONTEXT_LIMIT",
+        details={"provider_error_type": "exceed_context_size_error"},
+    )
+
+    assert "LM Studio" in message
+
+
+def test_error_wire_separates_display_message_from_diagnostic() -> None:
+    frame = format_error(
+        chat_error_message("SERVER_ERROR"),
+        error_code="SERVER_ERROR",
+        diagnostic="RuntimeError: database exploded",
+        extra={
+            "message": "unsafe override",
+            "errorCode": "WRONG_CODE",
+            "diagnostic": "unsafe diagnostic",
+        },
+    )
+    payload = json.loads(frame.removeprefix("data: ").strip())
+
+    assert payload == {
+        "type": "error",
+        "message": chat_error_message("SERVER_ERROR"),
+        "errorCode": "SERVER_ERROR",
+        "diagnostic": "RuntimeError: database exploded",
+    }
+    assert "errorText" not in payload
+
+
+def test_unknown_backend_chat_error_cannot_be_emitted_silently() -> None:
+    with pytest.raises(ValueError, match="No user-facing message registered"):
+        chat_error_message("TYPO_ERROR_CODE")
+

--- a/surfsense_backend/tests/unit/tasks/chat/streaming/test_llm_bundle.py
+++ b/surfsense_backend/tests/unit/tasks/chat/streaming/test_llm_bundle.py
@@ -185,9 +185,11 @@ async def test_load_llm_bundle_enables_streaming_for_db_models(
     ]
 
 
-async def test_load_llm_bundle_injects_ollama_num_ctx_without_overriding_explicit(
+async def test_load_llm_bundle_passes_through_operator_configured_num_ctx(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """The one number allowed to cross into an allocation request: a size an
+    operator set on the connection."""
     connection = SimpleNamespace(
         provider="ollama_chat",
         api_key=None,
@@ -225,9 +227,13 @@ async def test_load_llm_bundle_injects_ollama_num_ctx_without_overriding_explici
     assert _CapturedChatLiteLLM.calls[-1]["num_ctx"] == 12_288
 
 
-async def test_load_llm_bundle_injects_effective_ollama_num_ctx(
+async def test_load_llm_bundle_never_invents_an_ollama_num_ctx(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """The budget caps what we send; it must not become a size Ollama is asked
+    to reserve. Ollama can only shrink the context to survive a load-time OOM
+    while that sizing stays automatic, and an invented ``num_ctx`` removes it.
+    """
     connection = SimpleNamespace(
         provider="ollama_chat",
         api_key=None,
@@ -256,9 +262,13 @@ async def test_load_llm_bundle_injects_effective_ollama_num_ctx(
         ),
     )
 
-    await llm_bundle.load_llm_bundle(object(), config_id=9, workspace_id=42)
+    llm, _, error = await llm_bundle.load_llm_bundle(
+        object(), config_id=9, workspace_id=42
+    )
 
-    assert _CapturedChatLiteLLM.calls[-1]["num_ctx"] == 24_576
+    assert error is None
+    assert llm.profile["max_input_tokens"] == 24_576
+    assert "num_ctx" not in _CapturedChatLiteLLM.calls[-1]
 
 
 async def test_load_llm_bundle_ignores_stale_lm_studio_loaded_context(

--- a/surfsense_backend/tests/unit/tasks/chat/streaming/test_llm_bundle.py
+++ b/surfsense_backend/tests/unit/tasks/chat/streaming/test_llm_bundle.py
@@ -12,7 +12,11 @@ from types import SimpleNamespace
 from typing import Any
 
 import pytest
+from langchain_core.messages import AIMessage
+from langchain_litellm import ChatLiteLLM
+from litellm import get_optional_params
 
+import app.agents.chat.runtime.llm_config as llm_config
 import app.tasks.chat.streaming.flows.shared.llm_bundle as llm_bundle
 
 pytestmark = pytest.mark.unit
@@ -24,6 +28,87 @@ class _CapturedChatLiteLLM:
     def __init__(self, **kwargs: Any) -> None:
         self.kwargs = kwargs
         self.__class__.calls.append(kwargs)
+
+
+def test_context_resolution_prefers_persisted_then_catalog_then_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        llm_config, "get_model_info", lambda _model: {"max_input_tokens": 65_536}
+    )
+
+    assert llm_config.resolve_max_input_tokens("model", 8_192) == 8_192
+    assert llm_config.resolve_max_input_tokens("model") == 65_536
+
+    monkeypatch.setattr(llm_config, "get_model_info", lambda _model: {})
+    assert llm_config.resolve_max_input_tokens("model", 0) == 32_000
+    assert llm_config.resolve_max_input_tokens("model", True) == 32_000
+
+
+def test_litellm_preserves_ollama_num_ctx_as_provider_parameter() -> None:
+    params = get_optional_params(
+        model="qwen3:8b",
+        custom_llm_provider="ollama_chat",
+        num_ctx=8_192,
+    )
+
+    assert params["num_ctx"] == 8_192
+
+
+async def test_sanitized_llm_admits_all_sync_and_async_generation_paths(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    llm = llm_config.SanitizedChatLiteLLM(model="openai/test", api_key="test")
+    llm.profile = {
+        "max_input_tokens": 4_096,
+        "token_count_models": ["openai/test"],
+    }
+    monkeypatch.setattr(
+        llm_config.SanitizedChatLiteLLM,
+        "_count_context_tokens",
+        lambda _self, _messages: 1,
+    )
+    captured: list[list[Any]] = []
+
+    def fake_generate(_self: Any, messages: list[Any], *_args: Any, **_kwargs: Any):
+        captured.append(messages)
+        return "generated"
+
+    def fake_stream(_self: Any, messages: list[Any], *_args: Any, **_kwargs: Any):
+        captured.append(messages)
+        yield "streamed"
+
+    async def fake_agenerate(
+        _self: Any, messages: list[Any], *_args: Any, **_kwargs: Any
+    ):
+        captured.append(messages)
+        return "agenerated"
+
+    async def fake_astream(
+        _self: Any, messages: list[Any], *_args: Any, **_kwargs: Any
+    ):
+        captured.append(messages)
+        yield "astreamed"
+
+    monkeypatch.setattr(ChatLiteLLM, "_generate", fake_generate)
+    monkeypatch.setattr(ChatLiteLLM, "_stream", fake_stream)
+    monkeypatch.setattr(ChatLiteLLM, "_agenerate", fake_agenerate)
+    monkeypatch.setattr(ChatLiteLLM, "_astream", fake_astream)
+    messages = [
+        AIMessage(
+            content=[
+                {"type": "thinking", "thinking": "private"},
+                {"type": "text", "text": "answer"},
+            ]
+        )
+    ]
+
+    assert llm._generate(messages) == "generated"
+    assert list(llm._stream(messages)) == ["streamed"]
+    assert await llm._agenerate(messages) == "agenerated"
+    assert [chunk async for chunk in llm._astream(messages)] == ["astreamed"]
+    assert len(captured) == 4
+    assert all(call[0].content == "answer" for call in captured)
 
 
 @pytest.fixture(autouse=True)
@@ -61,6 +146,8 @@ async def test_load_llm_bundle_enables_streaming_for_db_models(
         model_id="gpt-4o-mini",
         display_name="GPT 4o Mini",
         connection=connection,
+        max_input_tokens=16_384,
+        catalog={},
     )
 
     async def _fake_db_model(_session: Any, *, model_id: int, workspace: Any) -> Any:
@@ -87,6 +174,7 @@ async def test_load_llm_bundle_enables_streaming_for_db_models(
     assert error is None
     assert llm is not None
     assert agent_config is not None
+    assert llm.profile["max_input_tokens"] == 16_384
     assert _CapturedChatLiteLLM.calls == [
         {
             "model": "openai/gpt-4o-mini",
@@ -95,6 +183,124 @@ async def test_load_llm_bundle_enables_streaming_for_db_models(
             "streaming": True,
         }
     ]
+
+
+async def test_load_llm_bundle_injects_ollama_num_ctx_without_overriding_explicit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    connection = SimpleNamespace(
+        provider="ollama_chat",
+        api_key=None,
+        base_url="http://ollama:11434",
+        extra={"litellm_params": {"num_ctx": 12_288}},
+    )
+    model = SimpleNamespace(
+        id=8,
+        model_id="qwen3:8b",
+        display_name="Qwen 3 8B",
+        connection=connection,
+        max_input_tokens=32_000,
+        catalog={},
+    )
+
+    async def _fake_db_model(_session: Any, *, model_id: int, workspace: Any) -> Any:
+        return model
+
+    monkeypatch.setattr(llm_bundle, "_load_db_model", _fake_db_model)
+    monkeypatch.setattr(
+        llm_bundle,
+        "to_litellm",
+        lambda _conn, _model_id: (
+            "ollama_chat/qwen3:8b",
+            {"api_base": "http://ollama:11434", "num_ctx": 12_288},
+        ),
+    )
+
+    llm, _, error = await llm_bundle.load_llm_bundle(
+        object(), config_id=8, workspace_id=42
+    )
+
+    assert error is None
+    assert llm.profile["max_input_tokens"] == 32_000
+    assert _CapturedChatLiteLLM.calls[-1]["num_ctx"] == 12_288
+
+
+async def test_load_llm_bundle_injects_effective_ollama_num_ctx(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    connection = SimpleNamespace(
+        provider="ollama_chat",
+        api_key=None,
+        base_url="http://ollama:11434",
+        extra={},
+    )
+    model = SimpleNamespace(
+        id=9,
+        model_id="qwen3:8b",
+        display_name="Qwen 3 8B",
+        connection=connection,
+        max_input_tokens=24_576,
+        catalog={},
+    )
+
+    async def _fake_db_model(_session: Any, *, model_id: int, workspace: Any) -> Any:
+        return model
+
+    monkeypatch.setattr(llm_bundle, "_load_db_model", _fake_db_model)
+    monkeypatch.setattr(
+        llm_bundle,
+        "to_litellm",
+        lambda _conn, _model_id: (
+            "ollama_chat/qwen3:8b",
+            {"api_base": "http://ollama:11434"},
+        ),
+    )
+
+    await llm_bundle.load_llm_bundle(object(), config_id=9, workspace_id=42)
+
+    assert _CapturedChatLiteLLM.calls[-1]["num_ctx"] == 24_576
+
+
+async def test_load_llm_bundle_ignores_stale_lm_studio_loaded_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A loaded-context snapshot goes stale as soon as LM Studio reloads the
+    model, so it must never clamp the configured budget."""
+    connection = SimpleNamespace(
+        provider="lm_studio",
+        api_key=None,
+        base_url="http://lm-studio:1234/v1",
+        extra={},
+    )
+    model = SimpleNamespace(
+        id=10,
+        model_id="google/gemma",
+        display_name="Gemma",
+        connection=connection,
+        max_input_tokens=262_144,
+        catalog={"loaded_context_length": 8_192},
+    )
+
+    async def _fake_db_model(_session: Any, *, model_id: int, workspace: Any) -> Any:
+        return model
+
+    monkeypatch.setattr(llm_bundle, "_load_db_model", _fake_db_model)
+    monkeypatch.setattr(
+        llm_bundle,
+        "to_litellm",
+        lambda _conn, _model_id: (
+            "openai/google/gemma",
+            {"api_base": "http://lm-studio:1234/v1"},
+        ),
+    )
+
+    llm, _, error = await llm_bundle.load_llm_bundle(
+        object(), config_id=10, workspace_id=42
+    )
+
+    assert error is None
+    assert llm.profile["max_input_tokens"] == 262_144
+    assert "num_ctx" not in _CapturedChatLiteLLM.calls[-1]
 
 
 async def test_load_llm_bundle_enables_streaming_for_global_models(

--- a/surfsense_web/app/global-error.tsx
+++ b/surfsense_web/app/global-error.tsx
@@ -4,6 +4,7 @@ import "./globals.css";
 import posthog from "posthog-js";
 import { useEffect, useMemo } from "react";
 import { Button } from "@/components/ui/button";
+import { detectEnvironment } from "@/lib/env-config";
 
 const ISSUES_URL = "https://github.com/MODSetter/SurfSense/issues/new";
 
@@ -19,6 +20,7 @@ function buildBasicIssueUrl(error: Error & { digest?: string }) {
 		"",
 		`- **Error:** ${error.message}`,
 		...(error.digest ? [`- **Digest:** \`${error.digest}\``] : []),
+		`- **Environment:** ${detectEnvironment()}`,
 		`- **Timestamp:** ${new Date().toISOString()}`,
 		`- **Page:** \`${typeof window !== "undefined" ? window.location.pathname : "unknown"}\``,
 		`- **User Agent:** \`${typeof navigator !== "undefined" ? navigator.userAgent : "unknown"}\``,

--- a/surfsense_web/atoms/model-connections/model-connections-mutation.atoms.ts
+++ b/surfsense_web/atoms/model-connections/model-connections-mutation.atoms.ts
@@ -130,9 +130,7 @@ export const discoverConnectionModelsMutationAtom = atomWithMutation((get) => {
 		mutationKey: ["model-connections", "discover"],
 		mutationFn: (id: number) => modelConnectionsApiService.discoverModels(id),
 		onSuccess: (models: ModelRead[]) => {
-			toast.success(
-				models.length ? `${models.length} models discovered` : "No models found for this connection"
-			);
+			toast.success(`${models.length} models discovered`);
 			invalidateModelConnections(workspaceId);
 		},
 		onError: (error: Error) => toast.error(error.message || "Failed to discover models"),

--- a/surfsense_web/components/free-chat/anonymous-chat.tsx
+++ b/surfsense_web/components/free-chat/anonymous-chat.tsx
@@ -5,6 +5,8 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import type { AnonModel, AnonQuotaResponse } from "@/contracts/types/anonymous-chat.types";
 import { anonymousChatApiService } from "@/lib/apis/anonymous-chat-api.service";
+import { classifyChatError } from "@/lib/chat/chat-error-classifier";
+import { toHttpResponseError } from "@/lib/chat/chat-request-errors";
 import { readSSEStream } from "@/lib/chat/streaming-state";
 import { buildBackendUrl } from "@/lib/env-config";
 import { trackAnonymousChatMessageSent } from "@/lib/posthog/events";
@@ -107,13 +109,7 @@ export function AnonymousChat({ model }: AnonymousChatProps) {
 					setMessages((prev) => prev.filter((m) => m.id !== assistantId));
 					return;
 				}
-				const body = await response.text().catch(() => "");
-				const errorCode = response.status === 409 ? "THREAD_BUSY" : "SERVER_ERROR";
-				const message =
-					errorCode === "THREAD_BUSY"
-						? "A previous response is still stopping. Please try again in a moment."
-						: `Stream error: ${response.status}`;
-				throw Object.assign(new Error(body || message), { errorCode });
+				throw await toHttpResponseError(response);
 			}
 
 			for await (const event of readSSEStream(response)) {
@@ -124,12 +120,10 @@ export function AnonymousChat({ model }: AnonymousChatProps) {
 						prev.map((m) => (m.id === assistantId ? { ...m, content: m.content + event.delta } : m))
 					);
 				} else if (event.type === "error") {
-					const message =
-						event.errorCode === "THREAD_BUSY"
-							? "A previous response is still stopping. Please try again in a moment."
-							: event.errorText;
 					setMessages((prev) =>
-						prev.map((m) => (m.id === assistantId ? { ...m, content: m.content || message } : m))
+						prev.map((m) =>
+							m.id === assistantId ? { ...m, content: m.content || event.message } : m
+						)
 					);
 				} else if ("type" in event && event.type === "data-token-usage") {
 					// After streaming completes, refresh quota
@@ -139,12 +133,9 @@ export function AnonymousChat({ model }: AnonymousChatProps) {
 		} catch (err) {
 			if (err instanceof DOMException && err.name === "AbortError") return;
 			console.error("Chat stream error:", err);
+			const userMessage = classifyChatError({ error: err, flow: "new" }).userMessage;
 			setMessages((prev) =>
-				prev.map((m) =>
-					m.id === assistantId && !m.content
-						? { ...m, content: "An error occurred. Please try again." }
-						: m
-				)
+				prev.map((m) => (m.id === assistantId && !m.content ? { ...m, content: userMessage } : m))
 			);
 		} finally {
 			setIsStreaming(false);

--- a/surfsense_web/components/free-chat/free-chat-page.tsx
+++ b/surfsense_web/components/free-chat/free-chat-page.tsx
@@ -18,6 +18,7 @@ import {
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { useAnonymousMode } from "@/contexts/anonymous-mode";
 import { TimelineDataUI } from "@/features/chat-messages/timeline";
+import { preferBackendMessage } from "@/lib/chat/chat-error-classifier";
 import {
 	addStepSeparator,
 	addToolCall,
@@ -63,19 +64,34 @@ function normalizeFreeChatErrorMessage(error: unknown): string {
 		return "A previous response is still stopping. Please try again in a moment.";
 	}
 	if (code === "MODEL_AUTH_FAILED") {
-		return "This model’s API key is invalid or expired. Switch models, or update the API key.";
+		return preferBackendMessage(
+			error.message,
+			"This model’s API key is invalid or expired. Switch models, or update the API key."
+		);
 	}
 	if (code === "MODEL_NOT_FOUND") {
-		return "This model is unavailable or no longer exists. Please switch models.";
+		return preferBackendMessage(
+			error.message,
+			"This model is unavailable or no longer exists. Please switch models."
+		);
 	}
 	if (code === "MODEL_CONTEXT_LIMIT") {
-		return "This request is too large for the selected model. Reduce the input or switch models.";
+		return preferBackendMessage(
+			error.message,
+			"This request is too large for the selected model. Reduce the input or switch models."
+		);
 	}
 	if (code === "MODEL_PROVIDER_UNAVAILABLE") {
-		return "The selected model provider is temporarily unavailable. Please try again or switch models.";
+		return preferBackendMessage(
+			error.message,
+			"The selected model provider is temporarily unavailable. Please try again or switch models."
+		);
 	}
 	if (code === "RATE_LIMITED") {
-		return "This model is temporarily rate-limited. Please try again in a few seconds or switch models.";
+		return preferBackendMessage(
+			error.message,
+			"This model is temporarily rate-limited. Please try again in a few seconds or switch models."
+		);
 	}
 	return error.message || "An unexpected error occurred";
 }

--- a/surfsense_web/components/free-chat/free-chat-page.tsx
+++ b/surfsense_web/components/free-chat/free-chat-page.tsx
@@ -18,7 +18,7 @@ import {
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { useAnonymousMode } from "@/contexts/anonymous-mode";
 import { TimelineDataUI } from "@/features/chat-messages/timeline";
-import { preferBackendMessage } from "@/lib/chat/chat-error-classifier";
+import { classifyChatError, GENERIC_CHAT_ERROR_MESSAGE } from "@/lib/chat/chat-error-classifier";
 import {
 	addStepSeparator,
 	addToolCall,
@@ -58,47 +58,12 @@ function parseCaptchaError(status: number, body: string): string | null {
 }
 
 function normalizeFreeChatErrorMessage(error: unknown): string {
-	if (!(error instanceof Error)) return "An unexpected error occurred";
-	const code = (error as Error & { errorCode?: string }).errorCode;
-	if (code === "THREAD_BUSY") {
-		return "A previous response is still stopping. Please try again in a moment.";
-	}
-	if (code === "MODEL_AUTH_FAILED") {
-		return preferBackendMessage(
-			error.message,
-			"This model’s API key is invalid or expired. Switch models, or update the API key."
-		);
-	}
-	if (code === "MODEL_NOT_FOUND") {
-		return preferBackendMessage(
-			error.message,
-			"This model is unavailable or no longer exists. Please switch models."
-		);
-	}
-	if (code === "MODEL_CONTEXT_LIMIT") {
-		return preferBackendMessage(
-			error.message,
-			"This request is too large for the selected model. Reduce the input or switch models."
-		);
-	}
-	if (code === "MODEL_PROVIDER_UNAVAILABLE") {
-		return preferBackendMessage(
-			error.message,
-			"The selected model provider is temporarily unavailable. Please try again or switch models."
-		);
-	}
-	if (code === "RATE_LIMITED") {
-		return preferBackendMessage(
-			error.message,
-			"This model is temporarily rate-limited. Please try again in a few seconds or switch models."
-		);
-	}
-	return error.message || "An unexpected error occurred";
+	return classifyChatError({ error, flow: "new" }).userMessage;
 }
 
 function toFreeChatHttpError(status: number, body: string): Error & { errorCode?: string } {
 	let errorCode: string | undefined;
-	let message = body || `Server error: ${status}`;
+	let message = GENERIC_CHAT_ERROR_MESSAGE;
 	try {
 		const parsed = JSON.parse(body) as Record<string, unknown>;
 		const detail =
@@ -113,7 +78,6 @@ function toFreeChatHttpError(status: number, body: string): Error & { errorCode?
 		message =
 			(typeof detail?.message === "string" ? detail.message : undefined) ??
 			(typeof parsed.message === "string" ? parsed.message : undefined) ??
-			(typeof parsed.detail === "string" ? parsed.detail : undefined) ??
 			message;
 	} catch {
 		// non-json response
@@ -326,8 +290,9 @@ export function FreeChatPage() {
 							break;
 
 						case "error":
-							throw Object.assign(new Error(parsed.errorText || "Server error"), {
+							throw Object.assign(new Error(parsed.message), {
 								errorCode: parsed.errorCode,
+								diagnostic: parsed.diagnostic,
 							});
 					}
 				}

--- a/surfsense_web/components/settings/model-connections/connection-settings-dialog.tsx
+++ b/surfsense_web/components/settings/model-connections/connection-settings-dialog.tsx
@@ -308,7 +308,7 @@ export function ConnectionSettingsDialog({
 
 						<ModelsSelectionPanel
 							models={draftModels}
-							description="Choose available models and set the context limit used for prompt budgeting."
+							description="Choose available models. Max input tokens caps the prompt we send in one request; leave it blank to let the provider decide."
 							isRefreshing={discoverModels.isPending}
 							isUpdatingModel={isSavingConnectionSettings}
 							isBulkUpdating={isSavingConnectionSettings || bulkUpdateModels.isPending}

--- a/surfsense_web/components/settings/model-connections/connection-settings-dialog.tsx
+++ b/surfsense_web/components/settings/model-connections/connection-settings-dialog.tsx
@@ -6,6 +6,7 @@ import {
 	discoverConnectionModelsMutationAtom,
 	testPreviewModelMutationAtom,
 	updateModelConnectionMutationAtom,
+	updateModelMutationAtom,
 } from "@/atoms/model-connections/model-connections-mutation.atoms";
 import { Button } from "@/components/ui/button";
 import {
@@ -49,6 +50,7 @@ export function ConnectionSettingsDialog({
 	const discoverModels = useAtomValue(discoverConnectionModelsMutationAtom);
 	const testPreviewModel = useAtomValue(testPreviewModelMutationAtom);
 	const updateConnection = useAtomValue(updateModelConnectionMutationAtom);
+	const updateModel = useAtomValue(updateModelMutationAtom);
 	const bulkUpdateModels = useAtomValue(bulkUpdateModelsMutationAtom);
 
 	const [isOpen, setIsOpen] = useState(false);
@@ -59,6 +61,13 @@ export function ConnectionSettingsDialog({
 	const [draftEnabledModelIds, setDraftEnabledModelIds] = useState(() =>
 		enabledModelIds(connection.models)
 	);
+	const [draftContextLimits, setDraftContextLimits] = useState<Record<number, number | null>>(() =>
+		Object.fromEntries(
+			connection.models
+				.filter((model) => typeof model.id === "number")
+				.map((model) => [Number(model.id), model.max_input_tokens ?? null])
+		)
+	);
 
 	const hasConnectionChanges =
 		baseUrlDraft.trim() !== (connection.base_url ?? "") ||
@@ -67,15 +76,24 @@ export function ConnectionSettingsDialog({
 		() =>
 			connection.models.map((model) =>
 				typeof model.id === "number"
-					? { ...model, enabled: draftEnabledModelIds.has(model.id) }
+					? {
+							...model,
+							enabled: draftEnabledModelIds.has(model.id),
+							max_input_tokens: draftContextLimits[model.id] ?? null,
+						}
 					: model
 			),
-		[connection.models, draftEnabledModelIds]
+		[connection.models, draftContextLimits, draftEnabledModelIds]
 	);
 	const hasModelChanges = connection.models.some(
 		(model) => typeof model.id === "number" && draftEnabledModelIds.has(model.id) !== model.enabled
 	);
-	const canUpdate = hasConnectionChanges || hasModelChanges;
+	const hasContextChanges = connection.models.some(
+		(model) =>
+			typeof model.id === "number" &&
+			(draftContextLimits[model.id] ?? null) !== (model.max_input_tokens ?? null)
+	);
+	const canUpdate = hasConnectionChanges || hasModelChanges || hasContextChanges;
 
 	function handleOpenChange(open: boolean) {
 		setIsOpen(open);
@@ -85,7 +103,30 @@ export function ConnectionSettingsDialog({
 			setShowApiKey(false);
 			setIsSavingConnectionSettings(false);
 			setDraftEnabledModelIds(enabledModelIds(connection.models));
+			setDraftContextLimits(
+				Object.fromEntries(
+					connection.models
+						.filter((model) => typeof model.id === "number")
+						.map((model) => [Number(model.id), model.max_input_tokens ?? null])
+				)
+			);
 		}
+	}
+
+	async function saveContextChanges() {
+		const changedModels = connection.models.filter(
+			(model) =>
+				typeof model.id === "number" &&
+				(draftContextLimits[model.id] ?? null) !== (model.max_input_tokens ?? null)
+		);
+		await Promise.all(
+			changedModels.map((model) =>
+				updateModel.mutateAsync({
+					id: Number(model.id),
+					data: { max_input_tokens: draftContextLimits[Number(model.id)] ?? null },
+				})
+			)
+		);
 	}
 
 	async function saveModelChanges() {
@@ -152,9 +193,18 @@ export function ConnectionSettingsDialog({
 			if (hasModelChanges) {
 				await saveModelChanges();
 			}
+			if (hasContextChanges) {
+				await saveContextChanges();
+			}
 		} finally {
 			setIsSavingConnectionSettings(false);
 		}
+	}
+
+	function handleContextLimitChange(model: SelectableModel, value: number | null) {
+		if (typeof model.id !== "number") return;
+		const modelId = model.id;
+		setDraftContextLimits((current) => ({ ...current, [modelId]: value }));
 	}
 
 	function handleToggleModel(model: SelectableModel, enabled: boolean) {
@@ -258,6 +308,7 @@ export function ConnectionSettingsDialog({
 
 						<ModelsSelectionPanel
 							models={draftModels}
+							description="Choose available models and set the context limit used for prompt budgeting."
 							isRefreshing={discoverModels.isPending}
 							isUpdatingModel={isSavingConnectionSettings}
 							isBulkUpdating={isSavingConnectionSettings || bulkUpdateModels.isPending}
@@ -265,6 +316,7 @@ export function ConnectionSettingsDialog({
 							onRefresh={() => discoverModels.mutate(connection.id)}
 							onToggleModel={handleToggleModel}
 							onBulkToggle={handleBulkToggle}
+							onMaxInputTokensChange={handleContextLimitChange}
 						/>
 					</div>
 				</div>

--- a/surfsense_web/components/settings/model-connections/default-connect-form.tsx
+++ b/surfsense_web/components/settings/model-connections/default-connect-form.tsx
@@ -9,10 +9,7 @@ function baseUrlHint(provider: string) {
 		return "For local servers, use host.docker.internal instead of localhost.";
 	}
 	if (provider === "openai_compatible") {
-		return "Enter the full endpoint URL. This provider expects a /v1-compatible endpoint.";
-	}
-	if (provider === "openai_compatible_raw") {
-		return "Enter the exact chat-completions API base URL. SurfSense will not append /v1.";
+		return "Enter the exact API base URL, used as-is. Most endpoints end in /v1 (e.g. https://api.example.com/v1).";
 	}
 	if (
 		provider === "openai" ||

--- a/surfsense_web/components/settings/model-connections/model-provider-connections-panel.tsx
+++ b/surfsense_web/components/settings/model-connections/model-provider-connections-panel.tsx
@@ -188,6 +188,7 @@ export function ModelProviderConnectionsPanel({
 				},
 				{
 					onSuccess: mergePreviewModels,
+					onError: resetConnectState,
 				}
 			);
 		}
@@ -212,6 +213,7 @@ export function ModelProviderConnectionsPanel({
 			},
 			{
 				onSuccess: mergePreviewModels,
+				onError: resetConnectState,
 			}
 		);
 	}

--- a/surfsense_web/components/settings/model-connections/model-utils.ts
+++ b/surfsense_web/components/settings/model-connections/model-utils.ts
@@ -8,6 +8,12 @@ export const MODEL_CAPABILITY_FILTERS: { key: ModelCapabilityFilter; label: stri
 	{ key: "image_gen", label: "Image" },
 ];
 
+const CAPABILITY_FIELDS = {
+	chat: "supports_chat",
+	vision: "supports_image_input",
+	image_gen: "supports_image_generation",
+} as const;
+
 export type SelectableModel = (ModelRead | ModelPreviewRead) & {
 	id?: number | string;
 	connection_id?: number;
@@ -18,9 +24,13 @@ export function modelLabel(model: SelectableModel) {
 }
 
 export function capability(model: SelectableModel, key: ModelCapabilityFilter) {
-	if (key === "chat") return Boolean(model.supports_chat);
-	if (key === "vision") return Boolean(model.supports_image_input);
-	return Boolean(model.supports_image_generation);
+	const field = CAPABILITY_FIELDS[key];
+	const overrides =
+		"capabilities_override" in model ? model.capabilities_override : undefined;
+
+	if (overrides && field in overrides) return Boolean(overrides[field]);
+	if (overrides && key in overrides) return Boolean(overrides[key]);
+	return Boolean(model[field]);
 }
 
 export function capabilityLabels(model: SelectableModel) {

--- a/surfsense_web/components/settings/model-connections/model-utils.ts
+++ b/surfsense_web/components/settings/model-connections/model-utils.ts
@@ -25,12 +25,36 @@ export function modelLabel(model: SelectableModel) {
 
 export function capability(model: SelectableModel, key: ModelCapabilityFilter) {
 	const field = CAPABILITY_FIELDS[key];
-	const overrides =
-		"capabilities_override" in model ? model.capabilities_override : undefined;
+	const overrides = "capabilities_override" in model ? model.capabilities_override : undefined;
 
 	if (overrides && field in overrides) return Boolean(overrides[field]);
 	if (overrides && key in overrides) return Boolean(overrides[key]);
 	return Boolean(model[field]);
+}
+
+function positiveInteger(value: unknown) {
+	return typeof value === "number" && Number.isInteger(value) && value > 0 ? value : null;
+}
+
+/**
+ * The context length the model itself reports, read from the raw discovery
+ * payload. Shown as a hint next to the max input tokens field: it is what the
+ * model supports, not what the host loaded it with, so it is an upper bound to
+ * aim at rather than a value to apply.
+ */
+export function reportedContextLength(model: SelectableModel) {
+	const payload = ("catalog" in model ? model.catalog : model.metadata) ?? {};
+	const modelInfo = (payload.model_info ?? {}) as Record<string, unknown>;
+	const architecture = modelInfo["general.architecture"];
+	const details = (payload.details ?? {}) as Record<string, unknown>;
+
+	return (
+		positiveInteger(
+			typeof architecture === "string" ? modelInfo[`${architecture}.context_length`] : null
+		) ??
+		positiveInteger(details.context_length) ??
+		positiveInteger(payload.max_context_length)
+	);
 }
 
 export function capabilityLabels(model: SelectableModel) {

--- a/surfsense_web/components/settings/model-connections/models-selection-panel.tsx
+++ b/surfsense_web/components/settings/model-connections/models-selection-panel.tsx
@@ -2,6 +2,8 @@ import { RefreshCw } from "lucide-react";
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { Spinner } from "@/components/ui/spinner";
 import {
 	capability,
@@ -24,6 +26,7 @@ interface ModelsSelectionPanelProps {
 	onRefresh?: () => void;
 	onToggleModel?: (model: SelectableModel, enabled: boolean) => void;
 	onBulkToggle?: (models: SelectableModel[], enabled: boolean) => void;
+	onMaxInputTokensChange?: (model: SelectableModel, value: number | null) => void;
 }
 
 export function ModelsSelectionPanel({
@@ -38,6 +41,7 @@ export function ModelsSelectionPanel({
 	onRefresh,
 	onToggleModel,
 	onBulkToggle,
+	onMaxInputTokensChange,
 }: ModelsSelectionPanelProps) {
 	const [modelFilter, setModelFilter] = useState<ModelCapabilityFilter | null>(null);
 
@@ -166,6 +170,38 @@ export function ModelsSelectionPanel({
 									{capabilityLabels(model) || "No discovered capabilities"}
 								</div>
 							</div>
+							{onMaxInputTokensChange ? (
+								<div className="flex shrink-0 items-center gap-2">
+									<Label
+										htmlFor={`model-context-${model.id ?? model.model_id}`}
+										className="sr-only"
+									>
+										Context limit for {modelLabel(model)}
+									</Label>
+									<Input
+										id={`model-context-${model.id ?? model.model_id}`}
+										type="number"
+										min={1}
+										step={1024}
+										value={model.max_input_tokens ?? ""}
+										onChange={(event) => {
+											const value = event.target.valueAsNumber;
+											onMaxInputTokensChange(
+												model,
+												Number.isFinite(value) && value > 0 ? value : null
+											);
+										}}
+										className="h-8 w-28 text-right text-xs tabular-nums"
+										aria-describedby={`model-context-unit-${model.id ?? model.model_id}`}
+									/>
+									<span
+										id={`model-context-unit-${model.id ?? model.model_id}`}
+										className="text-xs text-muted-foreground"
+									>
+										tokens
+									</span>
+								</div>
+							) : null}
 						</div>
 					))}
 				</div>

--- a/surfsense_web/components/settings/model-connections/models-selection-panel.tsx
+++ b/surfsense_web/components/settings/model-connections/models-selection-panel.tsx
@@ -11,6 +11,7 @@ import {
 	MODEL_CAPABILITY_FILTERS,
 	type ModelCapabilityFilter,
 	modelLabel,
+	reportedContextLength,
 	type SelectableModel,
 } from "./model-utils";
 
@@ -151,59 +152,64 @@ export function ModelsSelectionPanel({
 					</div>
 				) : null}
 				<div className="space-y-2">
-					{filteredModels.map((model) => (
-						<div
-							key={model.id ?? model.model_id}
-							className="flex items-center gap-3 rounded-lg px-3 py-2 transition-colors hover:bg-popover"
-						>
-							<Checkbox
-								checked={model.enabled}
-								onCheckedChange={(checked) => onToggleModel?.(model, checked === true)}
-								disabled={!onToggleModel || isUpdatingModel}
-								className="border-muted-foreground/20"
-							/>
-							<div className="min-w-0 flex-1">
-								<div className="flex items-center gap-2 text-sm font-medium">
-									<span className="truncate">{modelLabel(model)}</span>
+					{filteredModels.map((model) => {
+						const reportedContext = reportedContextLength(model);
+
+						return (
+							<div
+								key={model.id ?? model.model_id}
+								className="flex items-center gap-3 rounded-lg px-3 py-2 transition-colors hover:bg-popover"
+							>
+								<Checkbox
+									checked={model.enabled}
+									onCheckedChange={(checked) => onToggleModel?.(model, checked === true)}
+									disabled={!onToggleModel || isUpdatingModel}
+									className="border-muted-foreground/20"
+								/>
+								<div className="min-w-0 flex-1">
+									<div className="flex items-center gap-2 text-sm font-medium">
+										<span className="truncate">{modelLabel(model)}</span>
+									</div>
+									<div className="text-xs text-muted-foreground">
+										{capabilityLabels(model) || "No discovered capabilities"}
+									</div>
 								</div>
-								<div className="text-xs text-muted-foreground">
-									{capabilityLabels(model) || "No discovered capabilities"}
-								</div>
+								{onMaxInputTokensChange ? (
+									<div className="flex shrink-0 items-center gap-2">
+										<Label
+											htmlFor={`model-context-${model.id ?? model.model_id}`}
+											className="sr-only"
+										>
+											Max input tokens for {modelLabel(model)}
+										</Label>
+										<Input
+											id={`model-context-${model.id ?? model.model_id}`}
+											type="number"
+											min={1}
+											step={1024}
+											placeholder="Auto"
+											value={model.max_input_tokens ?? ""}
+											onChange={(event) => {
+												const value = event.target.valueAsNumber;
+												onMaxInputTokensChange(
+													model,
+													Number.isFinite(value) && value > 0 ? value : null
+												);
+											}}
+											className="h-8 w-28 text-right text-xs tabular-nums"
+											aria-describedby={`model-context-unit-${model.id ?? model.model_id}`}
+										/>
+										<span
+											id={`model-context-unit-${model.id ?? model.model_id}`}
+											className="w-32 text-xs text-muted-foreground"
+										>
+											{reportedContext ? `of ${reportedContext.toLocaleString()} tokens` : "tokens"}
+										</span>
+									</div>
+								) : null}
 							</div>
-							{onMaxInputTokensChange ? (
-								<div className="flex shrink-0 items-center gap-2">
-									<Label
-										htmlFor={`model-context-${model.id ?? model.model_id}`}
-										className="sr-only"
-									>
-										Context limit for {modelLabel(model)}
-									</Label>
-									<Input
-										id={`model-context-${model.id ?? model.model_id}`}
-										type="number"
-										min={1}
-										step={1024}
-										value={model.max_input_tokens ?? ""}
-										onChange={(event) => {
-											const value = event.target.valueAsNumber;
-											onMaxInputTokensChange(
-												model,
-												Number.isFinite(value) && value > 0 ? value : null
-											);
-										}}
-										className="h-8 w-28 text-right text-xs tabular-nums"
-										aria-describedby={`model-context-unit-${model.id ?? model.model_id}`}
-									/>
-									<span
-										id={`model-context-unit-${model.id ?? model.model_id}`}
-										className="text-xs text-muted-foreground"
-									>
-										tokens
-									</span>
-								</div>
-							) : null}
-						</div>
-					))}
+						);
+					})}
 				</div>
 			</div>
 		</div>

--- a/surfsense_web/components/settings/model-connections/models-selection-panel.tsx
+++ b/surfsense_web/components/settings/model-connections/models-selection-panel.tsx
@@ -158,24 +158,28 @@ export function ModelsSelectionPanel({
 						return (
 							<div
 								key={model.id ?? model.model_id}
-								className="flex items-center gap-3 rounded-lg px-3 py-2 transition-colors hover:bg-popover"
+								className="flex flex-col gap-2 rounded-lg px-3 py-2 transition-colors hover:bg-popover sm:flex-row sm:items-center sm:gap-3"
 							>
-								<Checkbox
-									checked={model.enabled}
-									onCheckedChange={(checked) => onToggleModel?.(model, checked === true)}
-									disabled={!onToggleModel || isUpdatingModel}
-									className="border-muted-foreground/20"
-								/>
-								<div className="min-w-0 flex-1">
-									<div className="flex items-center gap-2 text-sm font-medium">
-										<span className="truncate">{modelLabel(model)}</span>
-									</div>
-									<div className="text-xs text-muted-foreground">
-										{capabilityLabels(model) || "No discovered capabilities"}
+								<div className="flex min-w-0 flex-1 items-center gap-3">
+									<Checkbox
+										checked={model.enabled}
+										onCheckedChange={(checked) => onToggleModel?.(model, checked === true)}
+										disabled={!onToggleModel || isUpdatingModel}
+										className="border-muted-foreground/20"
+									/>
+									<div className="min-w-0 flex-1">
+										<div className="truncate text-sm font-medium" title={modelLabel(model)}>
+											{modelLabel(model)}
+										</div>
+										<div className="text-xs text-muted-foreground">
+											{capabilityLabels(model) || "No discovered capabilities"}
+										</div>
 									</div>
 								</div>
 								{onMaxInputTokensChange ? (
-									<div className="flex shrink-0 items-center gap-2">
+									// Stacked below sm, so indent by the checkbox column to stay
+									// aligned under the model name.
+									<div className="flex shrink-0 items-center gap-2 pl-7 sm:pl-0">
 										<Label
 											htmlFor={`model-context-${model.id ?? model.model_id}`}
 											className="sr-only"
@@ -185,6 +189,7 @@ export function ModelsSelectionPanel({
 										<Input
 											id={`model-context-${model.id ?? model.model_id}`}
 											type="number"
+											inputMode="numeric"
 											min={1}
 											step={1024}
 											placeholder="Auto"
@@ -196,12 +201,12 @@ export function ModelsSelectionPanel({
 													Number.isFinite(value) && value > 0 ? value : null
 												);
 											}}
-											className="h-8 w-28 text-right text-xs tabular-nums"
+											className="h-9 w-24 text-right text-xs tabular-nums sm:h-8 sm:w-28"
 											aria-describedby={`model-context-unit-${model.id ?? model.model_id}`}
 										/>
 										<span
 											id={`model-context-unit-${model.id ?? model.model_id}`}
-											className="w-32 text-xs text-muted-foreground"
+											className="text-xs text-muted-foreground sm:w-32"
 										>
 											{reportedContext ? `of ${reportedContext.toLocaleString()} tokens` : "tokens"}
 										</span>

--- a/surfsense_web/components/settings/model-connections/provider-metadata.tsx
+++ b/surfsense_web/components/settings/model-connections/provider-metadata.tsx
@@ -108,7 +108,7 @@ export const BEDROCK_AUTH_LONG_TERM_API_KEY = "long_term_api_key";
 export const VERTEX_AUTH_SERVICE_ACCOUNT = "service_account_json";
 export const VERTEX_AUTH_WORKLOAD_IDENTITY = "workload_identity";
 
-// Mirrors Onyx's Azure "Target URI" parser: the user pastes the full endpoint
+// Parses the Azure "Target URI": the user pastes the full endpoint
 // (e.g. https://res.cognitiveservices.azure.com/openai/deployments/<dep>/chat/completions?api-version=<ver>)
 // which we split into api base (origin), api version, and deployment name.
 export function parseAzureTargetUri(rawUri: string) {

--- a/surfsense_web/content/docs/how-to/web-search.mdx
+++ b/surfsense_web/content/docs/how-to/web-search.mdx
@@ -21,18 +21,31 @@ When the assistant decides a request needs the open web:
 2. The specialist runs a Google search and returns ranked result items (title, URL, snippet).
 3. The assistant summarizes the findings and can follow up by crawling a specific result page.
 
-## Optional SearXNG fallback
+## SearXNG fallback
 
-Google occasionally walls every proxy exit, in which case a search returns nothing. You can point the scraper at a SearXNG instance to serve organic results as a last resort:
+Google occasionally walls every exit IP, in which case a search would return nothing. The Docker stack bundles a [SearXNG](https://docs.searxng.org/) container that serves organic results as a last resort in that case. It works out of the box — there is nothing to configure.
+
+It only fires after Google's own retry ladder is exhausted, and it only serves organic results plus query suggestions. Ads, People Also Ask, AI Overviews, and result totals are Google-only and come back empty, so requests that specifically ask for paid ads are never served from the fallback. Fallback pages are tagged with `resultsProvider: "searxng"` and are not billed at the Google SERP rate.
+
+The container is internal-only in production. The dev and deps-only stacks publish its UI on `http://localhost:8888` (`SEARXNG_PORT`) if you want to query it directly.
+
+### Configuration
 
 | Variable | Value |
 |----------|-------|
-| `SEARXNG_FALLBACK_URL` | Base URL of your instance, e.g. `https://searx.example.org` (unset = fallback off) |
+| `SEARXNG_FALLBACK_URL` | Where the scraper looks. Compose sets it to the bundled service; set it empty to turn the fallback off, or to another base URL to use your own instance |
 | `SEARXNG_FALLBACK_TIMEOUT_S` | Request timeout in seconds (default `10`) |
+| `SEARXNG_SECRET` | Session secret for the bundled container |
 
-Your instance must expose the JSON API — add `json` to `search.formats` in its `settings.yml`, or every fallback request is refused with HTTP 403.
+The instance's own settings live in `docker/searxng/settings.yml`. Two entries there are load-bearing. `search.formats` includes `json`, which is the API the scraper calls — remove it and every request comes back **HTTP 403**, with no environment variable to re-enable it. And the `google` engine is disabled on purpose: this instance only runs after Google walled you, so querying Google again from the same address is self-defeating. DuckDuckGo, Brave, Bing, and Wikipedia tolerate server IPs far better and are what make the fallback useful.
 
-The fallback only fires after Google's own retry ladder is exhausted, and it only serves organic results plus query suggestions. Ads, People Also Ask, AI Overviews, and result totals are Google-only and come back empty, so requests that specifically ask for paid ads are never served from the fallback. Fallback pages are tagged with `resultsProvider: "searxng"` and are not billed at the Google SERP rate.
+SearXNG reads that file only at startup, so restart the container after editing it.
+
+### Using your own instance
+
+Point `SEARXNG_FALLBACK_URL` at it and, if you like, remove the `searxng` service from your compose file. Your instance must have `json` in `search.formats` for the same reason as above; if it does not, SurfSense logs the 403 and names the setting.
+
+Nothing depends on the service being healthy, so a SearXNG that is down or misconfigured degrades searches to Google alone rather than blocking the stack.
 
 <Callout type="warn" title="Not the SearXNG connector">
 This is an operator-level setting for the Google Search scraper. The **SearXNG connector** remains deprecated and still cannot be connected.

--- a/surfsense_web/content/docs/how-to/web-search.mdx
+++ b/surfsense_web/content/docs/how-to/web-search.mdx
@@ -21,6 +21,23 @@ When the assistant decides a request needs the open web:
 2. The specialist runs a Google search and returns ranked result items (title, URL, snippet).
 3. The assistant summarizes the findings and can follow up by crawling a specific result page.
 
+## Optional SearXNG fallback
+
+Google occasionally walls every proxy exit, in which case a search returns nothing. You can point the scraper at a SearXNG instance to serve organic results as a last resort:
+
+| Variable | Value |
+|----------|-------|
+| `SEARXNG_FALLBACK_URL` | Base URL of your instance, e.g. `https://searx.example.org` (unset = fallback off) |
+| `SEARXNG_FALLBACK_TIMEOUT_S` | Request timeout in seconds (default `10`) |
+
+Your instance must expose the JSON API — add `json` to `search.formats` in its `settings.yml`, or every fallback request is refused with HTTP 403.
+
+The fallback only fires after Google's own retry ladder is exhausted, and it only serves organic results plus query suggestions. Ads, People Also Ask, AI Overviews, and result totals are Google-only and come back empty, so requests that specifically ask for paid ads are never served from the fallback. Fallback pages are tagged with `resultsProvider: "searxng"` and are not billed at the Google SERP rate.
+
+<Callout type="warn" title="Not the SearXNG connector">
+This is an operator-level setting for the Google Search scraper. The **SearXNG connector** remains deprecated and still cannot be connected.
+</Callout>
+
 Google web search is workspace-scoped and is not available in the free / anonymous (no-login) chat, which answers purely from the model's own knowledge.
 
 ## Still want Tavily or Linkup?

--- a/surfsense_web/content/docs/how-to/web-search.mdx
+++ b/surfsense_web/content/docs/how-to/web-search.mdx
@@ -33,8 +33,8 @@ The container is internal-only in production. The dev and deps-only stacks publi
 
 | Variable | Value |
 |----------|-------|
-| `SEARXNG_FALLBACK_URL` | Where the scraper looks. Compose sets it to the bundled service; set it empty to turn the fallback off, or to another base URL to use your own instance |
-| `SEARXNG_FALLBACK_TIMEOUT_S` | Request timeout in seconds (default `10`) |
+| `SEARXNG_URL` | Where the scraper looks. Compose sets it to the bundled service; set it empty to turn the fallback off, or to another base URL to use your own instance |
+| `SEARXNG_TIMEOUT_S` | Request timeout in seconds (default `10`) |
 | `SEARXNG_SECRET` | Session secret for the bundled container |
 
 The instance's own settings live in `docker/searxng/settings.yml`. Two entries there are load-bearing. `search.formats` includes `json`, which is the API the scraper calls — remove it and every request comes back **HTTP 403**, with no environment variable to re-enable it. And the `google` engine is disabled on purpose: this instance only runs after Google walled you, so querying Google again from the same address is self-defeating. DuckDuckGo, Brave, Bing, and Wikipedia tolerate server IPs far better and are what make the fallback useful.
@@ -43,7 +43,7 @@ SearXNG reads that file only at startup, so restart the container after editing 
 
 ### Using your own instance
 
-Point `SEARXNG_FALLBACK_URL` at it and, if you like, remove the `searxng` service from your compose file. Your instance must have `json` in `search.formats` for the same reason as above; if it does not, SurfSense logs the 403 and names the setting.
+Point `SEARXNG_URL` at it and, if you like, remove the `searxng` service from your compose file. Your instance must have `json` in `search.formats` for the same reason as above; if it does not, SurfSense logs the 403 and names the setting.
 
 Nothing depends on the service being healthy, so a SearXNG that is down or misconfigured degrades searches to Google alone rather than blocking the stack.
 
@@ -80,4 +80,4 @@ The following connectors are deprecated. Existing rows remain readable/manageabl
 - **Tavily** — add via Custom MCP connector (see above).
 - **Linkup** — add via Custom MCP connector (see above).
 - **Baidu Search** — no longer bundled; use the built-in Google Search or a Custom MCP connector for a provider of your choice.
-- **SearXNG** — the bundled SearXNG container and its `SEARXNG_*` environment variables have been removed from all Docker Compose files.
+- **SearXNG** — no longer a connectable source. The bundled `searxng` container still ships, but serves only as the Google Search scraper's fallback (see above).

--- a/surfsense_web/content/docs/local-models/lm-studio.mdx
+++ b/surfsense_web/content/docs/local-models/lm-studio.mdx
@@ -59,7 +59,7 @@ Replace `<host>` with the LAN IP or domain for that machine.
 6. Select the models you want to enable.
 7. Save the connection.
 
-SurfSense discovers models from `/v1/models`. If you enter the URL without `/v1`, SurfSense adds it for requests.
+SurfSense discovers models from `/v1/models`. The URL is used exactly as entered, so include `/v1`.
 
 ## Verify
 
@@ -89,4 +89,4 @@ Load a model in LM Studio, then refresh model discovery in SurfSense.
 
 ### Endpoint returned 404
 
-Use an OpenAI compatible server URL. The models endpoint must be available at `/v1/models`.
+Check that your API Base URL includes `/v1`. The URL is used exactly as entered, so a missing `/v1` is the most common cause. The models endpoint must be available at `/v1/models`.

--- a/surfsense_web/content/docs/local-models/other-local-servers.mdx
+++ b/surfsense_web/content/docs/local-models/other-local-servers.mdx
@@ -64,7 +64,7 @@ http://<host>:<port>/v1
 6. Select the models you want to enable.
 7. Save the connection.
 
-If you enter the URL without `/v1`, SurfSense adds `/v1` for requests.
+The URL is used exactly as entered. Include `/v1`, since most servers expose their OpenAI compatible routes under `/v1`.
 
 ## Verify
 
@@ -92,9 +92,9 @@ Use the LM Studio provider for LM Studio. Its default URL is already set.
 
 ### Endpoint returned 404
 
-The server does not expose `/v1/models`.
+First, check that your API Base URL includes `/v1`. The URL is used exactly as entered, so a missing `/v1` is the most common cause.
 
-Enable the server's OpenAI compatible mode.
+If `/v1` is present, the server does not expose `/v1/models`. Enable the server's OpenAI compatible mode.
 
 ### Connection refused
 

--- a/surfsense_web/contracts/types/model-connections.types.ts
+++ b/surfsense_web/contracts/types/model-connections.types.ts
@@ -78,7 +78,7 @@ export const modelUpdateRequest = z.object({
 	display_name: z.string().nullable().optional(),
 	enabled: z.boolean().optional(),
 	supports_chat: z.boolean().nullable().optional(),
-	max_input_tokens: z.number().nullable().optional(),
+	max_input_tokens: z.number().positive().nullable().optional(),
 	supports_image_input: z.boolean().nullable().optional(),
 	supports_tools: z.boolean().nullable().optional(),
 	supports_image_generation: z.boolean().nullable().optional(),

--- a/surfsense_web/lib/chat/chat-error-classifier.ts
+++ b/surfsense_web/lib/chat/chat-error-classifier.ts
@@ -103,6 +103,22 @@ function parseEmbeddedJson(text: string): Record<string, unknown> | null {
 	return null;
 }
 
+/**
+ * Prefer the message the backend composed for provider-classified errors.
+ *
+ * The stream classifier already tailors these strings to the situation (which
+ * knob to turn for an LM Studio context rejection, for instance), so replacing
+ * them client-side hides the actionable half. Falls back to the generic string
+ * when the code arrives from a non-stream path, whose body is an HTTP sentinel
+ * or a raw provider dump rather than prose.
+ */
+export function preferBackendMessage(rawMessage: string, fallback: string): string {
+	const trimmed = rawMessage.trim();
+	if (!trimmed || trimmed.length > 300) return fallback;
+	if (trimmed.includes("{") || trimmed.startsWith("Backend error:")) return fallback;
+	return trimmed;
+}
+
 function inferProviderErrorType(parsedJson: Record<string, unknown> | null): string | undefined {
 	if (!parsedJson) return undefined;
 	const topLevelType = parsedJson.type;
@@ -217,8 +233,10 @@ export function classifyChatError(input: RawChatErrorInput): NormalizedChatError
 			severity: "warn",
 			telemetryEvent: "chat_blocked",
 			isExpected: true,
-			userMessage:
-				"This model’s API key is invalid or expired. Switch models, or update the API key.",
+			userMessage: preferBackendMessage(
+				rawMessage,
+				"This model’s API key is invalid or expired. Switch models, or update the API key."
+			),
 			rawMessage,
 			errorCode: errorCode ?? "MODEL_AUTH_FAILED",
 			details: { flow: input.flow, providerErrorType },
@@ -232,8 +250,10 @@ export function classifyChatError(input: RawChatErrorInput): NormalizedChatError
 			severity: "warn",
 			telemetryEvent: "chat_blocked",
 			isExpected: true,
-			userMessage:
-				"This model is unavailable or no longer exists. Switch to another model and try again.",
+			userMessage: preferBackendMessage(
+				rawMessage,
+				"This model is unavailable or no longer exists. Switch to another model and try again."
+			),
 			rawMessage,
 			errorCode: errorCode ?? "MODEL_NOT_FOUND",
 			details: { flow: input.flow, providerErrorType },
@@ -247,8 +267,10 @@ export function classifyChatError(input: RawChatErrorInput): NormalizedChatError
 			severity: "warn",
 			telemetryEvent: "chat_blocked",
 			isExpected: true,
-			userMessage:
-				"This request is too large for the selected model. Reduce the input or switch models.",
+			userMessage: preferBackendMessage(
+				rawMessage,
+				"This request is too large for the selected model. Reduce the input or switch models."
+			),
 			rawMessage,
 			errorCode: errorCode ?? "MODEL_CONTEXT_LIMIT",
 			details: { flow: input.flow, providerErrorType },
@@ -262,8 +284,10 @@ export function classifyChatError(input: RawChatErrorInput): NormalizedChatError
 			severity: "warn",
 			telemetryEvent: "chat_blocked",
 			isExpected: true,
-			userMessage:
-				"The selected model provider is temporarily unavailable. Please try again or switch models.",
+			userMessage: preferBackendMessage(
+				rawMessage,
+				"The selected model provider is temporarily unavailable. Please try again or switch models."
+			),
 			rawMessage,
 			errorCode: errorCode ?? "MODEL_PROVIDER_UNAVAILABLE",
 			details: { flow: input.flow, providerErrorType },
@@ -277,8 +301,10 @@ export function classifyChatError(input: RawChatErrorInput): NormalizedChatError
 			severity: "warn",
 			telemetryEvent: "chat_blocked",
 			isExpected: true,
-			userMessage:
-				"This model is temporarily rate-limited. Please try again in a few seconds or switch models.",
+			userMessage: preferBackendMessage(
+				rawMessage,
+				"This model is temporarily rate-limited. Please try again in a few seconds or switch models."
+			),
 			rawMessage,
 			errorCode: errorCode ?? "RATE_LIMITED",
 			details: { flow: input.flow, providerErrorType },

--- a/surfsense_web/lib/chat/chat-error-classifier.ts
+++ b/surfsense_web/lib/chat/chat-error-classifier.ts
@@ -8,6 +8,7 @@ export type ChatErrorKind =
 	| "model_auth_failed"
 	| "model_not_found"
 	| "model_context_limit"
+	| "model_capability_error"
 	| "model_provider_unavailable"
 	| "rate_limited"
 	| "network_offline"
@@ -47,9 +48,20 @@ export interface RawChatErrorInput {
 export const PREMIUM_QUOTA_ASSISTANT_MESSAGE =
 	"I can’t continue with the current premium model because your premium credit is exhausted. Switch to a free model or top up your credit to continue.";
 
+export const GENERIC_CHAT_ERROR_MESSAGE =
+	"We couldn’t complete this response right now. Please try again.";
+
 function getErrorMessage(error: unknown): string {
 	if (error instanceof Error) return error.message;
 	if (typeof error === "string") return error;
+	if (
+		typeof error === "object" &&
+		error !== null &&
+		"message" in error &&
+		typeof error.message === "string"
+	) {
+		return error.message;
+	}
 	try {
 		return JSON.stringify(error);
 	} catch {
@@ -57,10 +69,7 @@ function getErrorMessage(error: unknown): string {
 	}
 }
 
-function getErrorCode(
-	error: unknown,
-	parsedJson: Record<string, unknown> | null
-): string | undefined {
+function getErrorCode(error: unknown): string | undefined {
 	if (error instanceof Error) {
 		const withCode = error as Error & { errorCode?: string; code?: string };
 		if (withCode.errorCode) return withCode.errorCode;
@@ -74,70 +83,13 @@ function getErrorCode(
 		}
 	}
 
-	if (parsedJson) {
-		const topLevelCode = parsedJson.errorCode;
-		if (typeof topLevelCode === "string" && topLevelCode) {
-			return topLevelCode;
-		}
-	}
-
-	return undefined;
-}
-
-function parseEmbeddedJson(text: string): Record<string, unknown> | null {
-	const candidates = [text];
-	const firstBraceIdx = text.indexOf("{");
-	if (firstBraceIdx >= 0) {
-		candidates.push(text.slice(firstBraceIdx));
-	}
-	for (const candidate of candidates) {
-		try {
-			const parsed = JSON.parse(candidate);
-			if (typeof parsed === "object" && parsed !== null) {
-				return parsed as Record<string, unknown>;
-			}
-		} catch {
-			// noop
-		}
-	}
-	return null;
-}
-
-/**
- * Prefer the message the backend composed for provider-classified errors.
- *
- * The stream classifier already tailors these strings to the situation (which
- * knob to turn for an LM Studio context rejection, for instance), so replacing
- * them client-side hides the actionable half. Falls back to the generic string
- * when the code arrives from a non-stream path, whose body is an HTTP sentinel
- * or a raw provider dump rather than prose.
- */
-export function preferBackendMessage(rawMessage: string, fallback: string): string {
-	const trimmed = rawMessage.trim();
-	if (!trimmed || trimmed.length > 300) return fallback;
-	if (trimmed.includes("{") || trimmed.startsWith("Backend error:")) return fallback;
-	return trimmed;
-}
-
-function inferProviderErrorType(parsedJson: Record<string, unknown> | null): string | undefined {
-	if (!parsedJson) return undefined;
-	const topLevelType = parsedJson.type;
-	if (typeof topLevelType === "string" && topLevelType) return topLevelType;
-	const nestedError = parsedJson.error;
-	if (typeof nestedError === "object" && nestedError !== null) {
-		const nestedType = (nestedError as Record<string, unknown>).type;
-		if (typeof nestedType === "string" && nestedType) return nestedType;
-	}
 	return undefined;
 }
 
 export function classifyChatError(input: RawChatErrorInput): NormalizedChatError {
 	const { error } = input;
 	const rawMessage = getErrorMessage(error);
-	const parsedJson = parseEmbeddedJson(rawMessage);
-	const errorCode = getErrorCode(error, parsedJson);
-	const providerErrorType = inferProviderErrorType(parsedJson);
-	const providerTypeNormalized = providerErrorType?.toLowerCase() ?? "";
+	const errorCode = getErrorCode(error);
 	const errorName = error instanceof Error ? error.name : undefined;
 
 	if (errorName === "AbortError") {
@@ -161,7 +113,7 @@ export function classifyChatError(input: RawChatErrorInput): NormalizedChatError
 			severity: "info",
 			telemetryEvent: "chat_blocked",
 			isExpected: true,
-			userMessage: "Buy more tokens to continue with this model, or switch to a free model.",
+			userMessage: rawMessage || GENERIC_CHAT_ERROR_MESSAGE,
 			assistantMessage: PREMIUM_QUOTA_ASSISTANT_MESSAGE,
 			rawMessage,
 			errorCode: errorCode ?? "PREMIUM_QUOTA_EXHAUSTED",
@@ -176,7 +128,7 @@ export function classifyChatError(input: RawChatErrorInput): NormalizedChatError
 			severity: "info",
 			telemetryEvent: "chat_blocked",
 			isExpected: true,
-			userMessage: "A previous response is still stopping. Please try again in a moment.",
+			userMessage: rawMessage || GENERIC_CHAT_ERROR_MESSAGE,
 			rawMessage,
 			errorCode: errorCode ?? "TURN_CANCELLING",
 			details: { flow: input.flow },
@@ -190,8 +142,7 @@ export function classifyChatError(input: RawChatErrorInput): NormalizedChatError
 			severity: "warn",
 			telemetryEvent: "chat_blocked",
 			isExpected: true,
-			userMessage:
-				"Another response is still finishing for this thread. Please try again in a moment.",
+			userMessage: rawMessage || GENERIC_CHAT_ERROR_MESSAGE,
 			rawMessage,
 			errorCode: errorCode ?? "THREAD_BUSY",
 			details: { flow: input.flow },
@@ -233,13 +184,10 @@ export function classifyChatError(input: RawChatErrorInput): NormalizedChatError
 			severity: "warn",
 			telemetryEvent: "chat_blocked",
 			isExpected: true,
-			userMessage: preferBackendMessage(
-				rawMessage,
-				"This model’s API key is invalid or expired. Switch models, or update the API key."
-			),
+			userMessage: rawMessage || GENERIC_CHAT_ERROR_MESSAGE,
 			rawMessage,
 			errorCode: errorCode ?? "MODEL_AUTH_FAILED",
-			details: { flow: input.flow, providerErrorType },
+			details: { flow: input.flow },
 		};
 	}
 
@@ -250,13 +198,10 @@ export function classifyChatError(input: RawChatErrorInput): NormalizedChatError
 			severity: "warn",
 			telemetryEvent: "chat_blocked",
 			isExpected: true,
-			userMessage: preferBackendMessage(
-				rawMessage,
-				"This model is unavailable or no longer exists. Switch to another model and try again."
-			),
+			userMessage: rawMessage || GENERIC_CHAT_ERROR_MESSAGE,
 			rawMessage,
 			errorCode: errorCode ?? "MODEL_NOT_FOUND",
-			details: { flow: input.flow, providerErrorType },
+			details: { flow: input.flow },
 		};
 	}
 
@@ -267,13 +212,24 @@ export function classifyChatError(input: RawChatErrorInput): NormalizedChatError
 			severity: "warn",
 			telemetryEvent: "chat_blocked",
 			isExpected: true,
-			userMessage: preferBackendMessage(
-				rawMessage,
-				"This request is too large for the selected model. Reduce the input or switch models."
-			),
+			userMessage: rawMessage || GENERIC_CHAT_ERROR_MESSAGE,
 			rawMessage,
 			errorCode: errorCode ?? "MODEL_CONTEXT_LIMIT",
-			details: { flow: input.flow, providerErrorType },
+			details: { flow: input.flow },
+		};
+	}
+
+	if (errorCode === "MODEL_DOES_NOT_SUPPORT_IMAGE_INPUT") {
+		return {
+			kind: "model_capability_error",
+			channel: "toast",
+			severity: "warn",
+			telemetryEvent: "chat_blocked",
+			isExpected: true,
+			userMessage: rawMessage || GENERIC_CHAT_ERROR_MESSAGE,
+			rawMessage,
+			errorCode: errorCode ?? "MODEL_DOES_NOT_SUPPORT_IMAGE_INPUT",
+			details: { flow: input.flow },
 		};
 	}
 
@@ -284,30 +240,24 @@ export function classifyChatError(input: RawChatErrorInput): NormalizedChatError
 			severity: "warn",
 			telemetryEvent: "chat_blocked",
 			isExpected: true,
-			userMessage: preferBackendMessage(
-				rawMessage,
-				"The selected model provider is temporarily unavailable. Please try again or switch models."
-			),
+			userMessage: rawMessage || GENERIC_CHAT_ERROR_MESSAGE,
 			rawMessage,
 			errorCode: errorCode ?? "MODEL_PROVIDER_UNAVAILABLE",
-			details: { flow: input.flow, providerErrorType },
+			details: { flow: input.flow },
 		};
 	}
 
-	if (errorCode === "RATE_LIMITED" || providerTypeNormalized === "rate_limit_error") {
+	if (errorCode === "RATE_LIMITED") {
 		return {
 			kind: "rate_limited",
 			channel: "toast",
 			severity: "warn",
 			telemetryEvent: "chat_blocked",
 			isExpected: true,
-			userMessage: preferBackendMessage(
-				rawMessage,
-				"This model is temporarily rate-limited. Please try again in a few seconds or switch models."
-			),
+			userMessage: rawMessage || GENERIC_CHAT_ERROR_MESSAGE,
 			rawMessage,
 			errorCode: errorCode ?? "RATE_LIMITED",
-			details: { flow: input.flow, providerErrorType },
+			details: { flow: input.flow },
 		};
 	}
 
@@ -346,23 +296,23 @@ export function classifyChatError(input: RawChatErrorInput): NormalizedChatError
 			severity: "error",
 			telemetryEvent: "chat_error",
 			isExpected: false,
-			userMessage: "A tool failed while processing your request. Please try again.",
+			userMessage: rawMessage || GENERIC_CHAT_ERROR_MESSAGE,
 			rawMessage,
 			errorCode: errorCode ?? "TOOL_EXECUTION_ERROR",
 			details: { flow: input.flow },
 		};
 	}
 
-	if (errorCode === "PERSIST_MESSAGE_FAILED") {
+	if (errorCode === "MESSAGE_PERSIST_FAILED") {
 		return {
 			kind: "persist_message_failed",
 			channel: "toast",
 			severity: "error",
 			telemetryEvent: "chat_error",
 			isExpected: false,
-			userMessage: "Response generated, but saving failed. Please retry once.",
+			userMessage: rawMessage || GENERIC_CHAT_ERROR_MESSAGE,
 			rawMessage,
-			errorCode: errorCode ?? "PERSIST_MESSAGE_FAILED",
+			errorCode: errorCode ?? "MESSAGE_PERSIST_FAILED",
 			details: { flow: input.flow },
 		};
 	}
@@ -374,10 +324,10 @@ export function classifyChatError(input: RawChatErrorInput): NormalizedChatError
 			severity: "error",
 			telemetryEvent: "chat_error",
 			isExpected: false,
-			userMessage: "We couldn’t complete this response right now. Please try again.",
+			userMessage: rawMessage || GENERIC_CHAT_ERROR_MESSAGE,
 			rawMessage,
 			errorCode: errorCode ?? "SERVER_ERROR",
-			details: { flow: input.flow, providerErrorType },
+			details: { flow: input.flow },
 		};
 	}
 
@@ -387,9 +337,9 @@ export function classifyChatError(input: RawChatErrorInput): NormalizedChatError
 		severity: "error",
 		telemetryEvent: "chat_error",
 		isExpected: false,
-		userMessage: "We couldn’t complete this response right now. Please try again.",
+		userMessage: GENERIC_CHAT_ERROR_MESSAGE,
 		rawMessage,
 		errorCode,
-		details: { flow: input.flow, providerErrorType },
+		details: { flow: input.flow },
 	};
 }

--- a/surfsense_web/lib/chat/chat-error-classifier.ts
+++ b/surfsense_web/lib/chat/chat-error-classifier.ts
@@ -8,6 +8,7 @@ export type ChatErrorKind =
 	| "model_auth_failed"
 	| "model_not_found"
 	| "model_context_limit"
+	| "model_out_of_memory"
 	| "model_capability_error"
 	| "model_provider_unavailable"
 	| "rate_limited"
@@ -215,6 +216,20 @@ export function classifyChatError(input: RawChatErrorInput): NormalizedChatError
 			userMessage: rawMessage || GENERIC_CHAT_ERROR_MESSAGE,
 			rawMessage,
 			errorCode: errorCode ?? "MODEL_CONTEXT_LIMIT",
+			details: { flow: input.flow },
+		};
+	}
+
+	if (errorCode === "MODEL_OUT_OF_MEMORY") {
+		return {
+			kind: "model_out_of_memory",
+			channel: "toast",
+			severity: "warn",
+			telemetryEvent: "chat_blocked",
+			isExpected: true,
+			userMessage: rawMessage || GENERIC_CHAT_ERROR_MESSAGE,
+			rawMessage,
+			errorCode: errorCode ?? "MODEL_OUT_OF_MEMORY",
 			details: { flow: input.flow },
 		};
 	}

--- a/surfsense_web/lib/chat/chat-request-errors.ts
+++ b/surfsense_web/lib/chat/chat-request-errors.ts
@@ -1,3 +1,5 @@
+import { GENERIC_CHAT_ERROR_MESSAGE } from "@/lib/chat/chat-error-classifier";
+
 export async function toHttpResponseError(
 	response: Response
 ): Promise<Error & { errorCode?: string; retryAfterMs?: number }> {
@@ -32,7 +34,6 @@ export async function toHttpResponseError(
 	const detail = parsedBody?.detail;
 	const detailObject =
 		typeof detail === "object" && detail !== null ? (detail as Record<string, unknown>) : null;
-	const detailMessage = typeof detail === "string" ? detail : undefined;
 	const topLevelMessage =
 		typeof parsedBody?.message === "string" ? (parsedBody.message as string) : undefined;
 	const detailNestedMessage =
@@ -75,8 +76,7 @@ export async function toHttpResponseError(
 			? Math.max(0, Math.round(retryAfterSeconds * 1000))
 			: undefined;
 	const retryAfterMs = detailRetryAfterMs ?? topRetryAfterMs ?? retryAfterMsFromHeader ?? undefined;
-	const message =
-		detailNestedMessage ?? detailMessage ?? topLevelMessage ?? `Backend error: ${response.status}`;
+	const message = detailNestedMessage ?? topLevelMessage ?? GENERIC_CHAT_ERROR_MESSAGE;
 
 	return Object.assign(new Error(message), { errorCode, retryAfterMs });
 }
@@ -94,12 +94,13 @@ export function tagPreAcceptSendFailure(error: unknown): unknown {
 			"MODEL_AUTH_FAILED",
 			"MODEL_NOT_FOUND",
 			"MODEL_CONTEXT_LIMIT",
+			"MODEL_DOES_NOT_SUPPORT_IMAGE_INPUT",
 			"MODEL_PROVIDER_UNAVAILABLE",
 			"RATE_LIMITED",
 			"NETWORK_ERROR",
 			"STREAM_PARSE_ERROR",
 			"TOOL_EXECUTION_ERROR",
-			"PERSIST_MESSAGE_FAILED",
+			"MESSAGE_PERSIST_FAILED",
 			"SERVER_ERROR",
 		]);
 		if (existingCode && passthroughCodes.has(existingCode)) {

--- a/surfsense_web/lib/chat/chat-request-errors.ts
+++ b/surfsense_web/lib/chat/chat-request-errors.ts
@@ -94,6 +94,7 @@ export function tagPreAcceptSendFailure(error: unknown): unknown {
 			"MODEL_AUTH_FAILED",
 			"MODEL_NOT_FOUND",
 			"MODEL_CONTEXT_LIMIT",
+			"MODEL_OUT_OF_MEMORY",
 			"MODEL_DOES_NOT_SUPPORT_IMAGE_INPUT",
 			"MODEL_PROVIDER_UNAVAILABLE",
 			"RATE_LIMITED",

--- a/surfsense_web/lib/chat/stream-pipeline.ts
+++ b/surfsense_web/lib/chat/stream-pipeline.ts
@@ -66,9 +66,10 @@ export function hasPersistableContent(
 
 function toStreamTerminalError(
 	event: Extract<SSEEvent, { type: "error" }>
-): Error & { errorCode?: string } {
-	return Object.assign(new Error(event.errorText || "Server error"), {
+): Error & { errorCode?: string; diagnostic?: string } {
+	return Object.assign(new Error(event.message), {
 		errorCode: event.errorCode,
+		diagnostic: event.diagnostic,
 	});
 }
 

--- a/surfsense_web/lib/chat/streaming-state.ts
+++ b/surfsense_web/lib/chat/streaming-state.ts
@@ -646,7 +646,7 @@ export type SSEEvent =
 				}>;
 			};
 	  }
-	| { type: "error"; errorText: string; errorCode?: string };
+	| { type: "error"; message: string; errorCode?: string; diagnostic?: string };
 
 /**
  * Async generator that reads an SSE stream and yields parsed JSON objects.

--- a/surfsense_web/lib/env-config.ts
+++ b/surfsense_web/lib/env-config.ts
@@ -67,6 +67,21 @@ export const BUILD_TIME_ETL_SERVICE = process.env.NEXT_PUBLIC_ETL_SERVICE || "DO
 // DEPLOYMENT_MODE through the runtime config provider first, then falls back to this baked value.
 export const BUILD_TIME_DEPLOYMENT_MODE = process.env.NEXT_PUBLIC_DEPLOYMENT_MODE || "self-hosted";
 
+/**
+ * Detect the environment for diagnostics (e.g. GitHub issue auto-fill).
+ * Inferred from the hostname so it needs no configuration from the operator.
+ *
+ * - "SurfSense Cloud": served from the official SurfSense domain (root + subdomains)
+ * - "self-hosted": everything else (covers self-hosted and community cloud deploys)
+ */
+export function detectEnvironment(): "SurfSense Cloud" | "self-hosted" {
+	const hostname = typeof window !== "undefined" ? window.location.hostname : "";
+	if (hostname === "surfsense.com" || hostname.endsWith(".surfsense.com")) {
+		return "SurfSense Cloud";
+	}
+	return "self-hosted";
+}
+
 // App version - defaults to package.json version
 // Can be overridden at build time with NEXT_PUBLIC_APP_VERSION for full git tag version
 export const APP_VERSION = process.env.NEXT_PUBLIC_APP_VERSION || packageJson.version;

--- a/surfsense_web/lib/error-toast.ts
+++ b/surfsense_web/lib/error-toast.ts
@@ -1,5 +1,6 @@
 import { toast } from "sonner";
 import { AbortedError, AppError, AuthenticationError, SURFSENSE_ISSUES_URL } from "./error";
+import { detectEnvironment } from "./env-config";
 
 /**
  * Build a GitHub issue URL pre-filled with diagnostic context.
@@ -7,6 +8,8 @@ import { AbortedError, AppError, AuthenticationError, SURFSENSE_ISSUES_URL } fro
  */
 export function buildIssueUrl(error: unknown): string {
 	const params = new URLSearchParams();
+
+	const environment = detectEnvironment();
 
 	const lines: string[] = ["## Bug Report", "", "**Describe what happened:**", "", ""];
 
@@ -16,9 +19,11 @@ export function buildIssueUrl(error: unknown): string {
 		if (error.requestId) lines.push(`- **Request ID:** \`${error.requestId}\``);
 		if (error.status) lines.push(`- **HTTP status:** ${error.status}`);
 		lines.push(`- **Message:** ${error.message}`);
+		lines.push(`- **Environment:** ${environment}`);
 	} else if (error instanceof Error) {
 		lines.push("## Diagnostics (auto-filled)", "");
 		lines.push(`- **Error:** ${error.message}`);
+		lines.push(`- **Environment:** ${environment}`);
 	}
 
 	lines.push(`- **Timestamp:** ${new Date().toISOString()}`);


### PR DESCRIPTION
<!--- Summarize your pull request in a few sentences -->

## Description
<!--- Clearly describe what has changed in this pull request -->
- Discover models through LM Studio’s native `/api/v1/models` endpoint, with legacy v0 and OpenAI-compatible fallbacks and explicit upgrade guidance when the native API is unavailable.
- Detect chat, vision, embedding, tool-use, and reported context-length capabilities while preserving user overrides during rediscovery and frontend filtering.
- Fail discovery when a reachable endpoint returns no models, rather than reporting a misleading success.
- Return bounded provider response details as `PROVIDER_ERROR` during connection tests instead of misclassifying them as connectivity failures.
- Centralize message conversion, context trimming, and tool-schema token reservation in `app/services/context_admission.py`.
- Enforce input budgets across synchronous, asynchronous, streaming, and non-streaming generation paths.
- Resolve input budgets from the stored per-model value, LiteLLM’s catalog, then `SURFSENSE_UNKNOWN_MODEL_MAX_INPUT_TOKENS`, which defaults to 32k and is documented in both environment examples.
- Seed Ollama budgets from an explicit Modelfile `num_ctx`; otherwise cap the model’s reported architecture limit at the unknown-model fallback while retaining the full reported limit as metadata.
- Keep input budgeting separate from runtime allocation: do not synthesize Ollama `num_ctx`, preserving Ollama’s automatic memory-based sizing while passing through explicit operator configuration.
- Make max input tokens editable per model, initialize the value only during first discovery, and preserve operator changes across rediscovery.
- Show the provider-reported context length as a settings hint while allowing the max-input value to remain automatic.
- Improve the model settings layout for smaller screens, numeric keyboard input, accessible labels, and truncated model-name tooltips.
- Validate max input tokens as a positive integer in both backend schemas and the web contract.
- Classify provider errors by traversing wrapper chains and prioritizing provider semantics over HTTP status, including LM Studio context overflow and Ollama out-of-memory responses.
- Skip retries for terminal error categories such as authentication, permission, unknown model, bad request, context overflow, and insufficient memory.
- Report out-of-memory failures with actionable guidance to free host memory or select a smaller model, rather than incorrectly suggesting a lower prompt budget.
- Centralize backend chat-error copy, separate user-facing messages from diagnostics, and render backend-provided messages in the web client.
- Reset connection UI state after connection or discovery failures and avoid success notifications when discovery returns no models.
- Add unit coverage for native discovery, capability extraction, budget seeding and admission, Ollama runtime sizing, retry classification, LLM bundle wiring, and streaming error contracts.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If this PR relates to an open issue, please link to the issue here: FIX #123 -->
FIX #


## Screenshots
<!-- If applicable, add screenshots or images to demonstrate the changes visually -->

## API Changes
<!-- Document any API changes if applicable -->
- [ ] This PR includes API changes

## Change Type
<!--- Indicate what kind(s) of changes this PR includes: -->
- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Dependency/Build system
- [ ] Breaking change
- [ ] Other (specify):

## Testing Performed
<!--- Briefly describe how you have tested these changes and what verification was performed -->
- [ ] Tested locally
- [ ] Manual/QA verification

## Checklist
<!--- Please confirm the following by marking with an 'x' as appropriate -->
- [ ] Follows project coding standards and conventions
- [ ] Documentation updated as needed
- [ ] Dependencies updated as needed
- [ ] No lint/build errors or new warnings
- [ ] All relevant tests are passing

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR implements a custom model discovery mechanism for LM Studio connections by adding support for LM Studio's native API endpoints (`/api/v1/models` and `/api/v0/models`) with fallback to OpenAI-compatible discovery. The changes include a new discovery strategy in the provider registry, comprehensive parsing logic for LM Studio's model metadata including capabilities like vision and tool support, robust error handling, and a frontend capability override mechanism to respect user-defined model capabilities.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_backend/app/services/provider_registry.py` |
| 2 | `surfsense_backend/app/services/model_connection_service.py` |
| 3 | `surfsense_backend/tests/unit/services/test_lm_studio_discovery.py` |
| 4 | `surfsense_web/components/settings/model-connections/model-utils.ts` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->