### PR TITLE
refactor(agents): share the tolerant structured-output parser with the video agent

### DIFF
--- a/surfsense_backend/app/agents/video_presentation/nodes.py
+++ b/surfsense_backend/app/agents/video_presentation/nodes.py
@@ -1,6 +1,7 @@
 import asyncio
 import contextlib
 import json
+import logging
 import math
 import os
 import shutil
@@ -18,6 +19,7 @@ from app.services.kokoro_tts_service import get_kokoro_tts_service
 from app.services.llm_service import get_agent_llm
 from app.utils.content_utils import extract_text_content, strip_markdown_fences
 from app.utils.file_io import write_bytes
+from app.utils.structured_output import invoke_json
 
 from .configuration import Configuration
 from .prompts import (
@@ -40,6 +42,8 @@ from .state import (
     State,
 )
 from .utils import get_voice_for_provider
+
+logger = logging.getLogger(__name__)
 
 MAX_REFINE_ATTEMPTS = 3
 
@@ -68,32 +72,7 @@ async def create_presentation_slides(
         ),
     ]
 
-    llm_response = await llm.ainvoke(messages)
-    content = strip_markdown_fences(extract_text_content(llm_response.content))
-
-    try:
-        presentation = PresentationSlides.model_validate(json.loads(content))
-    except (json.JSONDecodeError, TypeError, ValueError) as e:
-        print(f"Direct JSON parsing failed, trying fallback approach: {e!s}")
-
-        try:
-            json_start = content.find("{")
-            json_end = content.rfind("}") + 1
-            if json_start >= 0 and json_end > json_start:
-                json_str = content[json_start:json_end]
-                parsed_data = json.loads(json_str)
-                presentation = PresentationSlides.model_validate(parsed_data)
-                print("Successfully parsed presentation slides using fallback approach")
-            else:
-                error_message = f"Could not find valid JSON in LLM response. Raw response: {content}"
-                print(error_message)
-                raise ValueError(error_message)
-
-        except (json.JSONDecodeError, TypeError, ValueError) as e2:
-            error_message = f"Error parsing LLM response (fallback also failed): {e2!s}"
-            print(f"Error parsing LLM response: {e2!s}")
-            print(f"Raw response: {content}")
-            raise
+    presentation = await invoke_json(llm, messages, PresentationSlides)
 
     return {"slides": presentation.slides}
 
@@ -313,9 +292,11 @@ async def _assign_themes_with_llm(
         valid_themes = set(THEME_PRESETS)
         result: dict[int, tuple[str, str]] = {}
         for entry in assignments:
+            if not isinstance(entry, dict):
+                continue
             sn = entry.get("slide_number")
-            theme = entry.get("theme", "").upper()
-            mode = entry.get("mode", "dark").lower()
+            theme = str(entry.get("theme", "")).upper()
+            mode = str(entry.get("mode", "dark")).lower()
             if sn and theme in valid_themes and mode in ("dark", "light"):
                 result[sn] = (theme, mode)
 
@@ -337,8 +318,12 @@ async def _assign_themes_with_llm(
                 )
         return result
 
-    except Exception as e:
-        print(f"LLM theme assignment failed ({e!s}), using fallback")
+    except Exception:
+        # Theming is cosmetic, so any failure here degrades to the round-robin
+        # presets rather than failing the presentation. Log it with a traceback
+        # anyway: this branch also swallows LLM transport errors, and a print
+        # with no stack made those indistinguishable from a malformed reply.
+        logger.warning("LLM theme assignment failed, using fallback", exc_info=True)
         return {
             s.slide_number: pick_theme_and_mode_fallback(s.slide_number - 1, total)
             for s in slides

--- a/surfsense_backend/app/podcasts/generation/transcript/nodes.py
+++ b/surfsense_backend/app/podcasts/generation/transcript/nodes.py
@@ -14,9 +14,9 @@ from langchain_core.runnables import RunnableConfig
 
 from app.podcasts.schemas import PodcastSpec, Transcript, TranscriptTurn
 from app.services.llm_service import get_agent_llm
+from app.utils.structured_output import invoke_json
 
 from ..prompts import draft_segment_prompt, plan_outline_prompt
-from ..structured import invoke_json
 from .config import TranscriptConfig
 from .planning import Outline, SegmentDraft
 from .state import TranscriptState

--- a/surfsense_backend/app/utils/structured_output.py
+++ b/surfsense_backend/app/utils/structured_output.py
@@ -2,7 +2,9 @@
 
 Agent LLMs return JSON wrapped in prose, markdown fences, or reasoning blocks,
 so a plain ``model_validate_json`` is unreliable. Centralising the tolerant
-parse here keeps every generation node validating replies the same way.
+parse here keeps every node that asks a model for structured data validating
+replies the same way, instead of each one growing its own brace-scanning
+fallback and its own idea of what a parse failure looks like.
 """
 
 from __future__ import annotations

--- a/surfsense_backend/tests/unit/agents/video_presentation/test_slide_parsing.py
+++ b/surfsense_backend/tests/unit/agents/video_presentation/test_slide_parsing.py
@@ -1,0 +1,125 @@
+"""Parsing the slide-generation reply.
+
+The video agent used to carry its own copy of the tolerant-parse algorithm and
+report failures with ``print``, which dumped the entire model reply — including
+the source document it was summarising — into the worker's stdout. It now uses
+the shared parser, so these tests pin the tolerance it inherits and the fact
+that a failure no longer prints the reply.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.agents.video_presentation import nodes
+from app.agents.video_presentation.state import PresentationSlides
+from app.utils.structured_output import StructuredOutputError, invoke_json
+
+pytestmark = pytest.mark.unit
+
+_SLIDES_JSON = """
+{
+  "slides": [
+    {
+      "slide_number": 1,
+      "title": "Title",
+      "subtitle": "Subtitle",
+      "content_in_markdown": "## Heading",
+      "speaker_transcripts": ["One sentence."],
+      "background_explanation": "Warm and organic"
+    }
+  ]
+}
+"""
+
+
+class _Reply:
+    def __init__(self, content: str) -> None:
+        self.content = content
+
+
+class _CannedLLM:
+    """Stands in for the chat model with one fixed reply."""
+
+    def __init__(self, reply: str) -> None:
+        self._reply = reply
+
+    async def ainvoke(self, _messages):
+        return _Reply(self._reply)
+
+
+async def _parse(reply: str) -> PresentationSlides:
+    return await invoke_json(_CannedLLM(reply), [], PresentationSlides)
+
+
+async def test_parses_a_clean_reply():
+    presentation = await _parse(_SLIDES_JSON)
+    assert presentation.slides[0].title == "Title"
+
+
+async def test_parses_a_reply_wrapped_in_a_markdown_fence():
+    presentation = await _parse(f"```json\n{_SLIDES_JSON}\n```")
+    assert len(presentation.slides) == 1
+
+
+async def test_parses_a_reply_wrapped_in_prose():
+    """Reasoning models narrate before and after the object."""
+    presentation = await _parse(
+        f"Here are the slides you asked for:\n{_SLIDES_JSON}\nHope that helps."
+    )
+    assert len(presentation.slides) == 1
+
+
+async def test_an_unparseable_reply_raises_a_typed_error():
+    with pytest.raises(StructuredOutputError):
+        await _parse("I could not produce slides for this content.")
+
+
+async def test_a_parse_failure_does_not_print_the_model_reply(monkeypatch, capsys):
+    """The reply summarises the user's source document; keep it out of stdout.
+
+    Asserted through the node rather than the helper: the leak was the node's
+    own ``print(f"Raw response: {content}")``, so calling the helper directly
+    would pass either way and prove nothing.
+    """
+    secret = "CONFIDENTIAL-PATIENT-RECORD-42"
+
+    async def _fake_llm(*_args, **_kwargs):
+        return _CannedLLM(f"I cannot do that. Source was: {secret}")
+
+    monkeypatch.setattr(nodes, "get_agent_llm", _fake_llm)
+
+    from app.agents.video_presentation.state import State
+
+    state = State(db_session=None, source_content=secret)
+    with pytest.raises(StructuredOutputError):
+        await nodes.create_presentation_slides(
+            state, {"configurable": {"workspace_id": 1, "video_title": "t"}}
+        )
+
+    assert secret not in capsys.readouterr().out
+
+
+async def test_the_slide_node_uses_the_shared_parser(monkeypatch):
+    """The node must not grow a second parsing path alongside the shared one."""
+    calls = []
+
+    async def _fake_invoke_json(_llm, _messages, model):
+        calls.append(model)
+        return PresentationSlides.model_validate_json(_SLIDES_JSON)
+
+    async def _fake_llm(*_args, **_kwargs):
+        return _CannedLLM(_SLIDES_JSON)
+
+    monkeypatch.setattr(nodes, "invoke_json", _fake_invoke_json)
+    monkeypatch.setattr(nodes, "get_agent_llm", _fake_llm)
+
+    from app.agents.video_presentation.state import State
+
+    state = State(db_session=None, source_content="anything")
+    result = await nodes.create_presentation_slides(
+        state, {"configurable": {"workspace_id": 1, "video_title": "t"}}
+    )
+
+    assert calls == [PresentationSlides]
+    assert len(result["slides"]) == 1

--- a/surfsense_backend/tests/unit/utils/test_structured_output.py
+++ b/surfsense_backend/tests/unit/utils/test_structured_output.py
@@ -1,9 +1,9 @@
 """Parsing a model's reply into a structured shape.
 
 Agent LLMs wrap JSON in prose and markdown fences. ``invoke_json`` exists so
-every generation node tolerates that the same way. The LLM is an external
-boundary, so it is faked with a canned reply; the behavior under test is the
-parsing, not the model.
+every node that asks a model for structured data tolerates that the same way.
+The LLM is an external boundary, so it is faked with a canned reply; the
+behavior under test is the parsing, not the model.
 """
 
 from __future__ import annotations
@@ -11,7 +11,7 @@ from __future__ import annotations
 import pytest
 from pydantic import BaseModel
 
-from app.podcasts.generation.structured import StructuredOutputError, invoke_json
+from app.utils.structured_output import StructuredOutputError, invoke_json
 
 pytestmark = pytest.mark.unit
 


### PR DESCRIPTION
`invoke_json` already does tolerant LLM-reply parsing properly, but nothing outside `app/podcasts` calls it. The video presentation agent had grown its own copy — and that copy printed the whole model reply to stdout on failure.

## Description

`app/podcasts/generation/structured.py::invoke_json` strips fences, validates against a Pydantic model, retries on a brace-scanned substring, logs a bounded snippet, and raises a typed `StructuredOutputError`. Its docstring says it exists "so every generation node validates replies the same way" — but its only callers were two podcast transcript nodes.

Meanwhile `app/agents/video_presentation/nodes.py` reimplemented the same algorithm by hand. Two concrete problems with the copy:

1. **It leaked document content into worker logs.** The failure path ended in `print(f"Raw response: {content}")`, and `content` is the model's summary of whatever the user fed in. A malformed reply wrote that to stdout.
2. **Failures were untyped and unstructured.** It re-raised the raw `json`/`ValueError` and reported progress with `print`, so callers could not distinguish "the model returned prose" from anything else.

**What changed**

- `invoke_json` and `StructuredOutputError` move to `app/utils/structured_output.py` (via `git mv`, so history follows). A general-purpose LLM parsing helper should not live under a feature package; the podcast transcript nodes now import it from there.
- `create_presentation_slides` drops its 26-line hand-rolled parser for one `await invoke_json(llm, messages, PresentationSlides)`.
- Theme assignment keeps its degrade-to-round-robin behaviour, but its bare `except Exception: print(...)` becomes `logger.warning(..., exc_info=True)`. That branch also swallows LLM transport errors, and a print with no stack made those indistinguishable from a malformed reply. Its entry loop also now tolerates a non-dict list element instead of raising `AttributeError` into the same catch-all.

`_extract_code_and_title` is deliberately left alone: its job is "JSON object *or* raw component source", which is not what `invoke_json` models.

## Motivation and Context

FIX #1440

The issue's first reported symptom is a `json.loads` failure (`Invalid \escape`) during generation. The podcast side already routes through the tolerant parser; the video side did not, which is the half this addresses. #1660 covers the same issue's TTS language half.

## Screenshots

Not applicable — backend only.

## API Changes
- [ ] This PR includes API changes

## Change Type
- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [x] Refactoring
- [ ] Documentation
- [ ] Dependency/Build system
- [ ] Breaking change
- [ ] Other (specify):

## Testing Performed
- [x] Tested locally
- [ ] Manual/QA verification

`uv run pytest -m unit`: **2849 passed**, same 7 pre-existing failures as `dev` on this machine (git-tree and PAT static tests, unrelated and failing before this branch).

The existing `test_structured.py` moves with the helper. Six tests added for the video agent's parsing.

Reverting only `nodes.py` and re-running the new file:

```
                                                dev nodes.py   this branch
test_a_parse_failure_does_not_print_the_model_reply   FAILED       passed
test_the_slide_node_uses_the_shared_parser            FAILED       passed
(4 tolerance tests)                                   passed       passed
```

Worth noting how that measurement went, since it changed the test: I first wrote the stdout-leak assertion against `invoke_json` directly, and it passed with the fix reverted — it was testing the helper, which never leaked, not the node, which did. Asserting through `create_presentation_slides` is what makes it a regression test. The four tolerance tests pass either way by design; they pin behaviour the video agent now inherits rather than behaviour this PR introduces.

## Checklist
- [x] Follows project coding standards and conventions
- [ ] Documentation updated as needed
- [ ] Dependencies updated as needed
- [x] No lint/build errors or new warnings
- [x] All relevant tests are passing

## What does not change

- `invoke_json`'s implementation is byte-identical; only its module path and docstring wording moved.
- Podcast transcript generation behaves exactly as before.
- Slide content, theming output, Remotion generation, and the graph shape are untouched.
- Theme assignment still degrades to round-robin presets on failure — same behaviour, now visible in logs.
- No new dependency, no config, no schema change.

`print` is not banned here (`T201` is in the ruff ignore list), so this is not a style change. The move is specifically about a log level and about document content reaching stdout.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This refactoring extracts a tolerant LLM structured-output parser (`invoke_json`) from the podcasts module into a shared utility and replaces the video presentation agent's hand-rolled parsing logic with it. The change fixes two issues: **1)** a security leak where malformed LLM replies caused the entire model response (including user document content) to be printed to stdout, and **2)** unstructured error handling that made parse failures indistinguishable from other errors. The parser moves from `app/podcasts/generation/structured.py` to `app/utils/structured_output.py`, and the video agent's 26-line custom parser is replaced with a single call to `await invoke_json()`. Theme assignment error handling also improves from bare `print` statements to proper `logger.warning()` with traceback capture.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_backend/app/utils/structured_output.py` |
| 2 | `surfsense_backend/app/podcasts/generation/transcript/nodes.py` |
| 3 | `surfsense_backend/app/agents/video_presentation/nodes.py` |
| 4 | `surfsense_backend/tests/unit/utils/test_structured_output.py` |
| 5 | `surfsense_backend/tests/unit/agents/video_presentation/test_slide_parsing.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->