### PR TITLE
fix(retriever): compute document query embeddings off the event loop

### DIFF
--- a/surfsense_backend/app/retriever/documents_hybrid_search.py
+++ b/surfsense_backend/app/retriever/documents_hybrid_search.py
@@ -1,3 +1,4 @@
+import asyncio
 import contextlib
 import functools
 import time
@@ -88,7 +89,7 @@ class DocumentHybridSearchRetriever:
 
         # Get embedding for the query
         embedding_model = config.embedding_model_instance
-        query_embedding = embedding_model.embed(query_text)
+        query_embedding = await asyncio.to_thread(embedding_model.embed, query_text)
 
         # Build the query filtered by workspace
         query = (
@@ -222,7 +223,7 @@ class DocumentHybridSearchRetriever:
 
         if query_embedding is None:
             embedding_model = config.embedding_model_instance
-            query_embedding = embedding_model.embed(query_text)
+            query_embedding = await asyncio.to_thread(embedding_model.embed, query_text)
 
         # RRF constants
         k = 60

--- a/surfsense_backend/tests/unit/retriever/test_query_embedding_offloading.py
+++ b/surfsense_backend/tests/unit/retriever/test_query_embedding_offloading.py
@@ -1,0 +1,95 @@
+"""Query embedding must not be computed on the event loop.
+
+A local embedding model runs a synchronous forward pass that takes tens to
+hundreds of milliseconds. Calling it directly from a coroutine stalls every
+other request sharing that worker for the duration. The chunk retriever, the
+connector service and the chat retrieval path all offload it with
+``asyncio.to_thread``; the document retriever was the one place that did not.
+
+The fake model here blocks a real thread, so the assertion is that the loop
+kept running while it did -- not that a particular function was called.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+
+import pytest
+
+from app.retriever.documents_hybrid_search import DocumentHybridSearchRetriever
+
+pytestmark = pytest.mark.unit
+
+
+class _BlockingEmbeddingModel:
+    """Embeds by blocking a thread until released, like a real forward pass."""
+
+    def __init__(self) -> None:
+        self.started = threading.Event()
+        self.release = threading.Event()
+
+    def embed(self, _text: str) -> list[float]:
+        self.started.set()
+        self.release.wait(timeout=5)
+        return [0.0, 0.0, 0.0]
+
+
+class _NoRowsSession:
+    """An AsyncSession stand-in that returns an empty result set."""
+
+    async def execute(self, _query):
+        return _EmptyResult()
+
+
+class _EmptyResult:
+    def all(self):
+        return []
+
+    def scalars(self):
+        return self
+
+    def unique(self):
+        return self
+
+
+@pytest.fixture
+def blocking_embeddings(monkeypatch):
+    from app.config import config
+
+    model = _BlockingEmbeddingModel()
+    monkeypatch.setattr(config, "embedding_model_instance", model)
+    return model
+
+
+async def test_vector_search_embeds_without_blocking_the_event_loop(
+    blocking_embeddings,
+):
+    retriever = DocumentHybridSearchRetriever(_NoRowsSession())
+    task = asyncio.create_task(
+        retriever.vector_search(query_text="anything", top_k=1, workspace_id=1)
+    )
+
+    while not blocking_embeddings.started.is_set():
+        await asyncio.sleep(0)
+
+    assert not task.done(), "embedding should still be in flight"
+    blocking_embeddings.release.set()
+    await task
+
+
+async def test_hybrid_search_embeds_without_blocking_the_event_loop(
+    blocking_embeddings,
+):
+    """Only reached when the caller did not precompute the embedding."""
+    retriever = DocumentHybridSearchRetriever(_NoRowsSession())
+    task = asyncio.create_task(
+        retriever.hybrid_search(query_text="anything", top_k=1, workspace_id=1)
+    )
+
+    while not blocking_embeddings.started.is_set():
+        await asyncio.sleep(0)
+
+    assert not task.done(), "embedding should still be in flight"
+    blocking_embeddings.release.set()
+    await task


### PR DESCRIPTION
`DocumentHybridSearchRetriever` calls `embedding_model.embed()` synchronously inside its coroutines. Every sibling in the codebase offloads that call; this one file does not.

## Description

A local sentence-transformers model runs a synchronous forward pass taking tens to hundreds of milliseconds. Calling it directly from a coroutine stalls the event loop — and therefore every other request on that worker — for its duration.

The correct pattern is already established in four places:

| Location | |
|---|---|
| `app/retriever/chunks_hybrid_search.py:93` | `await asyncio.to_thread(embedding_model.embed, query_text)` |
| `app/retriever/chunks_hybrid_search.py:241` | same |
| `app/services/connector_service.py:187` | same |
| `app/agents/chat/multi_agent_chat/shared/retrieval/hybrid_search.py:91` | same |

`app/retriever/documents_hybrid_search.py` lines 91 and 225 were the two that were missed — the direct sibling of `chunks_hybrid_search.py`, in the same two methods.

## Motivation and Context

Consistency with the pattern the rest of the retrieval layer already follows.

**Please read this part before weighing the PR.** I checked whether these lines are reachable today, and they are not:

- `vector_search` and `full_text_search` on this class have no callers anywhere in the repo.
- `hybrid_search` has exactly one caller, `ConnectorService._combined_rrf`, which always passes a precomputed `query_embedding` — so the `if query_embedding is None` branch does not execute.

So this is **not** a measured latency improvement, and I would rather say that up front than let the diff imply one. The value is that the file stops disagreeing with its four siblings, and the next caller to use these entry points does not silently reintroduce the stall. If you would rather delete the two unused methods than fix them, that is a reasonable alternative and I am happy to send that instead.

## Screenshots

Not applicable — backend only.

## API Changes
- [ ] This PR includes API changes

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Dependency/Build system
- [ ] Breaking change
- [ ] Other (specify):

## Testing Performed
- [x] Tested locally
- [ ] Manual/QA verification

`uv run pytest -m unit`: **2845 passed**, same 7 pre-existing failures as `dev` on this machine (git-tree and PAT static tests, unrelated and failing before this branch).

Two tests added. They use a fake embedding model that blocks a real thread on a `threading.Event`, then assert the coroutine has not completed while it is blocked — so the assertion is that the loop kept running, not that a particular function was called. Stashing only the source change:

```
                                                    dev    this branch
test_vector_search_embeds_without_blocking...      FAILED     passed
test_hybrid_search_embeds_without_blocking...      FAILED     passed
```

Both hang until the 5s release timeout and then fail on `dev`, which is the stall itself being observed.

## Checklist
- [x] Follows project coding standards and conventions
- [ ] Documentation updated as needed
- [ ] Dependencies updated as needed
- [x] No lint/build errors or new warnings
- [x] All relevant tests are passing

## What does not change

- Query semantics, ranking, RRF scoring, filters, and returned shapes are identical — only where the embedding is computed moves.
- `chunks_hybrid_search.py` and `connector_service.py` are untouched; they were already correct.
- No config, schema, dependency, or API change.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes `DocumentHybridSearchRetriever` to compute query embeddings off the event loop using `asyncio.to_thread`, matching the pattern already established in four sibling files (`chunks_hybrid_search.py`, `connector_service.py`, and chat retrieval). The fix prevents potential event loop blocking when embedding models perform synchronous forward passes that can take tens to hundreds of milliseconds. While the affected code paths (`vector_search` and `hybrid_search` without precomputed embeddings) are currently unreachable in production, this change ensures consistency across the codebase and prevents future regressions when these methods are used.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_backend/app/retriever/documents_hybrid_search.py` |
| 2 | `surfsense_backend/tests/unit/retriever/test_query_embedding_offloading.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->