### PR TITLE
docs: point CONTRIBUTING at the tooling the repo actually uses

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,14 +102,14 @@ SurfSense consists of three main components:
 ### Code Quality & Pre-commit Hooks
 We use pre-commit hooks to maintain code quality, security, and consistency across the codebase. Before you start developing:
 
-1. **Install and set up pre-commit hooks** - See our detailed [Pre-commit Guide](./PRE_COMMIT.md)
-2. **Understand the automated checks** that will run on your code
+1. **Install and set up pre-commit hooks** - `pip install pre-commit && pre-commit install`
+2. **Understand the automated checks** that will run on your code - every hook is listed in [`.pre-commit-config.yaml`](./.pre-commit-config.yaml); run them all with `pre-commit run --all-files`
 3. **Learn about bypassing hooks** when necessary (use sparingly!)
 
 ### Code Style
 - **Backend**: Follow Python PEP 8 style guidelines
 - **Frontend**: Use TypeScript and follow the existing code patterns
-- **Formatting**: Use the project's configured formatters (Black for Python, Prettier for TypeScript)
+- **Formatting**: Use the project's configured formatters (Ruff for Python, Biome for TypeScript)
 
 ### Commit Messages
 Use clear, descriptive commit messages:


### PR DESCRIPTION
The Code Quality section of `CONTRIBUTING.md` sends a new contributor to a file that is not in the repository, and then names two formatters the project does not use.

## Description

Both problems are in the same twelve lines, which is why they are one PR.

**The dead link.** `CONTRIBUTING.md:105` reads *"See our detailed [Pre-commit Guide](./PRE_COMMIT.md)"*. `PRE_COMMIT.md` does not exist — `git ls-files` has no match, and that line is the only reference to it anywhere in the repo, so it is not a file that moved. This is step 1 of the first section a contributor is told to complete before writing code, so the first instruction in the onboarding path is a 404.

**The formatter names.** `CONTRIBUTING.md:112` says *"Black for Python, Prettier for TypeScript"*. Neither is configured:

| | claimed | actually configured |
|---|---|---|
| Python | Black | `ruff` + `ruff-format` (`.pre-commit-config.yaml`, `[tool.ruff]` in `surfsense_backend/pyproject.toml`) |
| TypeScript | Prettier | `biome` (`biome.json`, run as the `biome-check-web` hook) |

`git grep -inE '\bblack\b|prettier' -- '*.toml' '*.json' '*.yaml' '*.yml'` returns nothing, so this is not a case of two tools coexisting — the named ones are absent and the real ones are unnamed. The practical cost is a contributor running `black .` on the backend and producing a diff that `ruff-format` then disagrees with.

**What changed**

- The dead link is replaced with the install command (`pip install pre-commit && pre-commit install`) and a link to `.pre-commit-config.yaml`. `pip install pre-commit` is the same invocation `.github/workflows/code-quality.yml:35` uses, rather than one invented here.
- The "understand the automated checks" line now points at that config file and gives `pre-commit run --all-files`. Pointing at the config rather than at prose is deliberate: the hook list is then generated from the thing being described and cannot go stale the way the deleted guide did.
- `Black` → `Ruff`, `Prettier` → `Biome`.

No new documentation file is added. Writing a replacement `PRE_COMMIT.md` would restore the same failure mode this PR is fixing — a second description of the hooks that drifts from `.pre-commit-config.yaml` — and choosing to maintain one is a maintainer's call, not something to smuggle into a link repair.

## Motivation and Context

No linked issue; found while contributing #1660, #1661 and #1662, all of which required reading this section first.

## Screenshots

Not applicable — documentation only.

## API Changes
- [ ] This PR includes API changes

## Change Type
- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [x] Documentation
- [ ] Dependency/Build system
- [ ] Breaking change
- [ ] Other (specify):

## Testing Performed
- [x] Tested locally

One file changed, 3 lines. No code, no tests, nothing executable.

Verified rather than assumed:

- `PRE_COMMIT.md` absent: `git ls-files` has no match on `dev` at `cc8fa6e`.
- Black and Prettier absent: the `git grep` above returns nothing across every tracked `.toml`, `.json`, `.yaml` and `.yml`.
- The replacement command matches CI: `.github/workflows/code-quality.yml:35` is `pip install pre-commit`.
- The new relative link resolves — `.pre-commit-config.yaml` is at the repository root, alongside `CONTRIBUTING.md`.

## Checklist
- [x] Follows project coding standards and conventions
- [x] Documentation updated as needed
- [ ] Dependencies updated as needed
- [x] No lint/build errors or new warnings
- [x] All relevant tests are passing

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes documentation errors in `CONTRIBUTING.md` by removing a broken link to a non-existent `PRE_COMMIT.md` file and correcting the formatter tool names from Black/Prettier to the actually configured tools (Ruff/Biome). The dead link is replaced with the actual installation command and a reference to `.pre-commit-config.yaml`, ensuring contributors can follow working instructions for setting up the development environment.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `CONTRIBUTING.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->