### PR TITLE
style(web): sort imports in error-toast.ts to unblock the Biome check

### DIFF
--- a/surfsense_web/lib/error-toast.ts
+++ b/surfsense_web/lib/error-toast.ts
@@ -1,6 +1,6 @@
 import { toast } from "sonner";
-import { AbortedError, AppError, AuthenticationError, SURFSENSE_ISSUES_URL } from "./error";
 import { detectEnvironment } from "./env-config";
+import { AbortedError, AppError, AuthenticationError, SURFSENSE_ISSUES_URL } from "./error";
 
 /**
  * Build a GitHub issue URL pre-filled with diagnostic context.


### PR DESCRIPTION
`Frontend Quality` — and with it the `Quality Gate` aggregator — currently fails on every pull request opened against `dev`, including ones that change no TypeScript at all. This is the one unsorted import causing it.

## Description

`surfsense_web/lib/error-toast.ts` imports `./error` before `./env-config`, which Biome's `assist/source/organizeImports` reports as an error. The fix is Biome's own suggested safe fix, applied verbatim — two import lines swapped, nothing else in the file touched.

**Why one import breaks unrelated pull requests.** The hook is declared in `.pre-commit-config.yaml`:

```yaml
- id: biome-check-web
  entry: bash -c 'cd surfsense_web && npx @biomejs/biome@2.4.6 check --diagnostic-level=error .'
  files: ^surfsense_web/
  pass_filenames: false
  always_run: true
```

`always_run: true` makes pre-commit run the hook whatever the changed-file set is, so the `files:` filter never gets to exclude it, and `pass_filenames: false` plus the trailing `.` means the entry checks the whole `surfsense_web` tree rather than the changed files. The `--from-ref/--to-ref` invocation in `.github/workflows/code-quality.yml` therefore narrows nothing for this hook: any pull request, on any path, is measured against every file in `surfsense_web`.

That is why the job is red on PRs that touch only documentation, and why it is red on merged PRs too — [#1663](https://github.com/MODSetter/SurfSense/pull/1663) carries the same `Frontend Quality` and `Quality Gate` failures. `dev`'s own Code Quality runs have been failing since late July.

I am reporting the hook behaviour, not changing it. Whether `always_run` is intentional (a deliberate "always check the whole app" policy) or an oversight is a maintainer's call, and either way this file has to be sorted first.

## Motivation and Context

No linked issue. Found while opening #1665, a documentation-only PR that came back red on a TypeScript check.

## Screenshots

Not applicable — no UI change. The file's runtime behaviour is unchanged; only the order of two import statements differs.

## API Changes
- [ ] This PR includes API changes

## Change Type
- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Dependency/Build system
- [ ] Breaking change
- [ ] Other (specify):

Marked as a bug fix because the effect is on CI rather than on the file itself; the edit is pure formatting.

## Testing Performed
- [x] Tested locally

`npx @biomejs/biome@2.4.6 check --diagnostic-level=error lib/error-toast.ts` from `surfsense_web`:

| | before | after |
|---|---|---|
| `lib/error-toast.ts` | `Found 1 error` — `assist/source/organizeImports` | `Checked 1 file. No fixes applied.` |

The failing run this PR addresses is [the `Frontend Quality` job on #1665](https://github.com/MODSetter/SurfSense/actions/runs/31075702482), whose log reports exactly one diagnostic across the tree: `Checked 1055 files in 1479ms. Found 1 error.` — this file. So the tree is clean once this lands, rather than this being the first of many.

Runtime behaviour is untested because there is none to test: reordering two side-effect-free ES module imports of local modules cannot change evaluation order in a way this file observes, and no other file changed.

## Checklist
- [x] Follows project coding standards and conventions
- [ ] Documentation updated as needed
- [ ] Dependencies updated as needed
- [x] No lint/build errors or new warnings
- [x] All relevant tests are passing

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a failing CI check by reordering two import statements in `error-toast.ts` to comply with Biome's import sorting rules. The file was causing the `Frontend Quality` check to fail on all pull requests (including unrelated ones) because the pre-commit hook runs Biome against the entire `surfsense_web` directory regardless of which files were changed. The fix simply swaps the position of two imports so that `./env-config` comes before `./error`, which is Biome's expected alphabetical order.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/lib/error-toast.ts` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->