### PR TITLE
fix(web): restore biome compliance in the documents view

### DIFF
--- a/surfsense_web/components/documents/DocumentsEmptyState.tsx
+++ b/surfsense_web/components/documents/DocumentsEmptyState.tsx
@@ -9,16 +9,14 @@ export function DocumentsEmptyState({ reason }: { reason: DocumentsEmptyReason }
 
 	if (reason.kind === "loading") {
 		return (
-			<div className="space-y-1 px-4 py-2" aria-busy="true" aria-label={t("loading")}>
-				{["loading-1", "loading-2", "loading-3", "loading-4", "loading-5"].map(
-					(key, index) => (
-						<div key={key} className="flex h-8 items-center gap-2">
-							<Skeleton className="size-4 rounded-sm" />
-							<Skeleton className={index % 2 === 0 ? "h-4 w-44" : "h-4 w-32"} />
-						</div>
-					)
-				)}
-			</div>
+			<output className="block space-y-1 px-4 py-2" aria-busy="true" aria-label={t("loading")}>
+				{["loading-1", "loading-2", "loading-3", "loading-4", "loading-5"].map((key, index) => (
+					<div key={key} className="flex h-8 items-center gap-2">
+						<Skeleton className="size-4 rounded-sm" />
+						<Skeleton className={index % 2 === 0 ? "h-4 w-44" : "h-4 w-32"} />
+					</div>
+				))}
+			</output>
 		);
 	}
 
@@ -32,13 +30,12 @@ export function DocumentsEmptyState({ reason }: { reason: DocumentsEmptyReason }
 				: t("empty_adjust_filters");
 
 	return (
-		<div
+		<output
 			className="flex flex-1 select-none flex-col items-center justify-center gap-1 px-4 py-12 text-center text-muted-foreground"
-			role="status"
 			aria-live="polite"
 		>
 			<p className="text-sm font-medium">{title}</p>
 			<p className="text-xs text-muted-foreground/70">{description}</p>
-		</div>
+		</output>
 	);
 }

--- a/surfsense_web/components/documents/DocumentsSearchResults.tsx
+++ b/surfsense_web/components/documents/DocumentsSearchResults.tsx
@@ -2,8 +2,8 @@
 
 import { CircleAlert, Dot, Folder, LoaderCircle } from "lucide-react";
 import { useTranslations } from "next-intl";
-import { getDocumentTypeLabel } from "@/lib/documents/document-type-labels";
 import type { DocumentNodeDoc, FolderDisplay } from "@/lib/documents/document-tree-types";
+import { getDocumentTypeLabel } from "@/lib/documents/document-type-labels";
 import type { DocumentSearchHit } from "@/lib/documents/documents-view-model";
 import { getDocumentTypeIcon } from "./DocumentTypeIcon";
 import { HighlightedText } from "./HighlightedText";
@@ -23,9 +23,9 @@ export function DocumentsSearchResults({
 
 	return (
 		<div className="px-2 py-1">
-			<p className="px-2 pb-1.5 text-[11px] font-medium text-muted-foreground" role="status">
+			<output className="block px-2 pb-1.5 text-[11px] font-medium text-muted-foreground">
 				{t("search_results", { count: hits.length })}
-			</p>
+			</output>
 			<ul aria-label={t("search_results_label")}>
 				{hits.map((hit) => {
 					const title = hit.kind === "document" ? hit.document.title : hit.folder.name;
@@ -35,22 +35,16 @@ export function DocumentsSearchResults({
 						(hit.document.status?.state === "pending" ||
 							hit.document.status?.state === "processing");
 					const isUnavailable =
-						isProcessing ||
-						(hit.kind === "document" && hit.document.status?.state === "failed");
-					const isFailed =
-						hit.kind === "document" && hit.document.status?.state === "failed";
+						isProcessing || (hit.kind === "document" && hit.document.status?.state === "failed");
+					const isFailed = hit.kind === "document" && hit.document.status?.state === "failed";
 
 					return (
-						<li
-							key={`${hit.kind}-${hit.kind === "document" ? hit.document.id : hit.folder.id}`}
-						>
+						<li key={`${hit.kind}-${hit.kind === "document" ? hit.document.id : hit.folder.id}`}>
 							<button
 								type="button"
 								disabled={isUnavailable}
 								onClick={() =>
-									hit.kind === "document"
-										? onOpenDocument(hit.document)
-										: onOpenFolder(hit.folder)
+									hit.kind === "document" ? onOpenDocument(hit.document) : onOpenFolder(hit.folder)
 								}
 								className="group flex w-full items-center gap-2 rounded-md px-2 py-2 text-left transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-60"
 							>
@@ -72,20 +66,20 @@ export function DocumentsSearchResults({
 										<HighlightedText text={title} ranges={hit.match.ranges} />
 									</span>
 									<span className="flex items-center text-[11px] text-muted-foreground">
-										{isFailed
-											? (hit.kind === "document" && hit.document.status?.reason) ||
-												t("search_document_failed")
-											: (
-												<>
-													<span className="truncate">{path}</span>
-													<Dot className="size-3 shrink-0" aria-hidden="true" />
-													<span className="shrink-0">
-														{hit.kind === "document"
-															? getDocumentTypeLabel(hit.document.document_type)
-															: t("search_folder")}
-													</span>
-												</>
-											)}
+										{isFailed ? (
+											(hit.kind === "document" && hit.document.status?.reason) ||
+											t("search_document_failed")
+										) : (
+											<>
+												<span className="truncate">{path}</span>
+												<Dot className="size-3 shrink-0" aria-hidden="true" />
+												<span className="shrink-0">
+													{hit.kind === "document"
+														? getDocumentTypeLabel(hit.document.document_type)
+														: t("search_folder")}
+												</span>
+											</>
+										)}
 									</span>
 								</span>
 							</button>

--- a/surfsense_web/components/documents/DocumentsView.tsx
+++ b/surfsense_web/components/documents/DocumentsView.tsx
@@ -6,17 +6,12 @@ import { DocumentsEmptyState } from "./DocumentsEmptyState";
 import { DocumentsSearchResults } from "./DocumentsSearchResults";
 import { FolderTreeView, type FolderTreeViewProps } from "./FolderTreeView";
 
-interface DocumentsViewProps
-	extends Omit<FolderTreeViewProps, "folders" | "documents"> {
+interface DocumentsViewProps extends Omit<FolderTreeViewProps, "folders" | "documents"> {
 	viewModel: DocumentsViewModel;
 	onOpenFolder: (folder: FolderDisplay) => void;
 }
 
-export function DocumentsView({
-	viewModel,
-	onOpenFolder,
-	...treeProps
-}: DocumentsViewProps) {
+export function DocumentsView({ viewModel, onOpenFolder, ...treeProps }: DocumentsViewProps) {
 	if (viewModel.mode === "empty") {
 		return <DocumentsEmptyState reason={viewModel.reason} />;
 	}
@@ -32,10 +27,6 @@ export function DocumentsView({
 	}
 
 	return (
-		<FolderTreeView
-			{...treeProps}
-			folders={viewModel.folders}
-			documents={viewModel.documents}
-		/>
+		<FolderTreeView {...treeProps} folders={viewModel.folders} documents={viewModel.documents} />
 	);
 }

--- a/surfsense_web/components/documents/FolderPickerDialog.tsx
+++ b/surfsense_web/components/documents/FolderPickerDialog.tsx
@@ -11,8 +11,8 @@ import {
 	DialogHeader,
 	DialogTitle,
 } from "@/components/ui/dialog";
-import { cn } from "@/lib/utils";
 import type { FolderDisplay } from "@/lib/documents/document-tree-types";
+import { cn } from "@/lib/utils";
 
 interface FolderPickerDialogProps {
 	open: boolean;

--- a/surfsense_web/components/documents/HighlightedText.tsx
+++ b/surfsense_web/components/documents/HighlightedText.tsx
@@ -1,12 +1,6 @@
 import type { MatchRange } from "@/lib/documents/document-search";
 
-export function HighlightedText({
-	text,
-	ranges,
-}: {
-	text: string;
-	ranges: MatchRange[];
-}) {
+export function HighlightedText({ text, ranges }: { text: string; ranges: MatchRange[] }) {
 	let cursor = 0;
 
 	return (

--- a/surfsense_web/hooks/use-documents-view-model.ts
+++ b/surfsense_web/hooks/use-documents-view-model.ts
@@ -2,11 +2,11 @@
 
 import { useDeferredValue, useMemo } from "react";
 import type { DocumentTypeEnum } from "@/contracts/types/document.types";
+import type { DocumentNodeDoc, FolderDisplay } from "@/lib/documents/document-tree-types";
 import {
 	buildDocumentsViewModel,
 	type DocumentsViewModel,
 } from "@/lib/documents/documents-view-model";
-import type { DocumentNodeDoc, FolderDisplay } from "@/lib/documents/document-tree-types";
 
 interface UseDocumentsViewModelInput {
 	folders: FolderDisplay[];

--- a/surfsense_web/lib/documents/documents-view-model.ts
+++ b/surfsense_web/lib/documents/documents-view-model.ts
@@ -130,9 +130,7 @@ export function buildDocumentsViewModel({
 	}
 
 	const visibleFolders =
-		activeTypes.length === 0
-			? folders
-			: foldersContainingDocuments(folders, filteredDocuments);
+		activeTypes.length === 0 ? folders : foldersContainingDocuments(folders, filteredDocuments);
 
 	if (!trimmedQuery) {
 		return {

--- a/surfsense_web/tests/helpers/ui/connector-popup.ts
+++ b/surfsense_web/tests/helpers/ui/connector-popup.ts
@@ -11,9 +11,7 @@ import { expect } from "@playwright/test";
  */
 
 export async function openConnectorPopup(page: Page): Promise<void> {
-	const trigger = page
-		.getByRole("button", { name: "Upload files, manage tools and more" })
-		.first();
+	const trigger = page.getByRole("button", { name: "Upload files, manage tools and more" }).first();
 
 	// Long timeout absorbs Next.js dev cold-compile of the new-chat route.
 	await expect(trigger).toBeVisible({ timeout: 60_000 });


### PR DESCRIPTION
## Summary

`biome-check-web` runs `npx @biomejs/biome@2.4.6 check --diagnostic-level=error .` over the entire `surfsense_web` tree, so the twelve diagnostics currently sitting in the documents view fail **Frontend Quality** on every PR that touches anything under `surfsense_web/`, regardless of what that PR changed. This restores a clean run.

On current `dev` (`339fe12`):

```
$ npx @biomejs/biome@2.4.6 check --diagnostic-level=error .
components/documents/DocumentsEmptyState.tsx:12:4     lint/a11y/useAriaPropsSupportedByRole
components/documents/DocumentsEmptyState.tsx:37:4     lint/a11y/useSemanticElements
components/documents/DocumentsEmptyState.tsx          format
components/documents/DocumentsSearchResults.tsx:3:1   assist/source/organizeImports
components/documents/DocumentsSearchResults.tsx:26:77 lint/a11y/useSemanticElements
components/documents/DocumentsSearchResults.tsx       format
components/documents/DocumentsView.tsx                format
components/documents/FolderPickerDialog.tsx:3:1       assist/source/organizeImports
components/documents/HighlightedText.tsx              format
hooks/use-documents-view-model.ts:3:1                 assist/source/organizeImports
lib/documents/documents-view-model.ts                 format
tests/helpers/ui/connector-popup.ts                   format
Found 12 errors.
```

The same twelve show up in the Frontend Quality logs of unrelated PRs — for example [#1648](https://github.com/MODSetter/SurfSense/pull/1648), which touches three other web files and inherits all of them.

## Changes

**Nine mechanical (`biome check --write`).** Six files were formatted at a narrower line width than the configured `lineWidth: 100`, and three had unsorted imports. No hand edits.

**Three a11y rules with no automatic fix.** All three resolve to the native `<output>` element:

- `DocumentsEmptyState.tsx:12` — the loading skeleton carried `aria-label` on a role-less `<div>`, which `useAriaPropsSupportedByRole` rejects.
- `DocumentsEmptyState.tsx:37` and `DocumentsSearchResults.tsx:26` — `role="status"`, which `useSemanticElements` wants expressed as `<output>`.

`<output>` has the implicit `status` role and accepts `aria-label` / `aria-busy` / `aria-live`, so what a screen reader announces is unchanged. `role="status"` is dropped where it became redundant, and `block` is added on the two that replaced block-level elements (`<output>` is inline by default) so layout is untouched.

## Testing

```
$ cd surfsense_web && npx @biomejs/biome@2.4.6 check --diagnostic-level=error .
Checked 1066 files in 797ms. No fixes applied.
```

Clean across the whole tree — the exact command the pre-commit hook runs.

`npx tsc --noEmit` reports the same 38 pre-existing errors before and after; none of them are in the eight files touched here. They are unrelated to this change (missing `@/.source/server` codegen, `ElectronAPI` globals, and similar) and CI does not run `tsc`, so they are left alone.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes 12 Biome linting errors in the documents view that were blocking Frontend Quality checks across all PRs touching the `surfsense_web/` directory. The changes include nine mechanical formatting and import organization fixes applied via `biome check --write`, and three accessibility improvements that replace non-semantic elements with the native `<output>` element to satisfy a11y rules (`useAriaPropsSupportedByRole` and `useSemanticElements`). The accessibility changes maintain the same screen reader behavior while achieving Biome compliance.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/components/documents/DocumentsEmptyState.tsx` |
| 2 | `surfsense_web/components/documents/DocumentsSearchResults.tsx` |
| 3 | `surfsense_web/components/documents/DocumentsView.tsx` |
| 4 | `surfsense_web/components/documents/HighlightedText.tsx` |
| 5 | `surfsense_web/components/documents/FolderPickerDialog.tsx` |
| 6 | `surfsense_web/hooks/use-documents-view-model.ts` |
| 7 | `surfsense_web/lib/documents/documents-view-model.ts` |
| 8 | `surfsense_web/tests/helpers/ui/connector-popup.ts` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->