### PR TITLE
feat: add healthchecks for celery_worker, frontend and proxy services

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -195,6 +195,12 @@ services:
         condition: service_completed_successfully
       backend:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "celery -A app.celery_app inspect ping --timeout=10"]
+      interval: 30s
+      timeout: 25s
+      retries: 10
+      start_period: 200s
 
   celery_beat:
     build: *backend-build
@@ -215,7 +221,7 @@ services:
       migrations:
         condition: service_completed_successfully
       celery_worker:
-        condition: service_started
+        condition: service_healthy
 
   zero-cache:
     image: rocicorp/zero:1.6.0
@@ -273,6 +279,12 @@ services:
         condition: service_healthy
       zero-cache:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD", "node", "-e", "var http=require('http');http.get('http://localhost:3000/api/health',function(res){process.exit(res.statusCode===200?0:1)}).on('error',function(){process.exit(1)})"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 60s
 
 volumes:
   postgres_data:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -117,11 +117,17 @@ services:
       SURFSENSE_MAX_BODY_SIZE: ${SURFSENSE_MAX_BODY_SIZE:-5GB}
     depends_on:
       frontend:
-        condition: service_started
+        condition: service_healthy
       backend:
         condition: service_healthy
       zero-cache:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:80/"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 60s
 
   backend:
     image: ghcr.io/modsetter/surfsense-backend:${SURFSENSE_VERSION:-latest}${SURFSENSE_VARIANT:+-${SURFSENSE_VARIANT}}
@@ -222,6 +228,12 @@ services:
     labels:
       - "com.centurylinklabs.watchtower.enable=true"
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "celery -A app.celery_app inspect ping --timeout=10"]
+      interval: 30s
+      timeout: 25s
+      retries: 10
+      start_period: 200s
 
   celery_beat:
     image: ghcr.io/modsetter/surfsense-backend:${SURFSENSE_VERSION:-latest}${SURFSENSE_VARIANT:+-${SURFSENSE_VARIANT}}
@@ -242,7 +254,7 @@ services:
       migrations:
         condition: service_completed_successfully
       celery_worker:
-        condition: service_started
+        condition: service_healthy
     labels:
       - "com.centurylinklabs.watchtower.enable=true"
     restart: unless-stopped
@@ -303,6 +315,12 @@ services:
       zero-cache:
         condition: service_healthy
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "node", "-e", "var http=require('http');http.get('http://localhost:3000/api/health',function(res){process.exit(res.statusCode===200?0:1)}).on('error',function(){process.exit(1)})"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 60s
 
 volumes:
   postgres_data:

--- a/surfsense_web/app/api/health/route.ts
+++ b/surfsense_web/app/api/health/route.ts
@@ -1,0 +1,3 @@
+export function GET() {
+	return new Response("ok");
+}


### PR DESCRIPTION
## Summary
Adds Docker healthchecks to the three long-running services that had none,
and upgrades `celery_beat` → `celery_worker` and `proxy` → `frontend` from
`service_started` to `service_healthy`. Without this, a hung worker or a
frontend that stopped serving still reports as `Up`.

## Changes
- **`celery_worker`** — `celery inspect ping` (no HTTP surface, so the check
  goes through the broker).
- **`frontend`** — Node's built-in `http` module; `node:20-alpine` has
  neither `curl` nor `wget`.
- **`proxy`** — `curl` against the local listener.
- Adds `GET /api/health` returning a plain `200`, so the frontend check
  doesn't render the whole home page every interval.

`celery_beat` is intentionally left without one — it exposes no
request/response channel, so a check could only assert the process exists,
which stays true even when it's hung.

## Testing
All services reach `healthy` on the dev stack and on prod compose; suspending the worker
process flips it to failing and it recovers once resumed.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds Docker healthchecks to three long-running services (`celery_worker`, `frontend`, and `proxy`) that previously had none. The healthchecks use `celery inspect ping` for the Celery worker, a Node.js HTTP request for the frontend, and `curl` for the proxy service. A new lightweight `/api/health` endpoint is added to the frontend to support efficient health checking without rendering the full homepage. Service dependencies are also upgraded from `service_started` to `service_healthy` for `celery_worker` (in `celery_beat`) and `frontend` (in `proxy`), ensuring that dependent services only start once their dependencies are genuinely healthy rather than just running.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/app/api/health/route.ts` |
| 2 | `docker/docker-compose.dev.yml` |
| 3 | `docker/docker-compose.yml` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->