### PR TITLE
feat: add OrcaRouter as a named model provider

### DIFF
--- a/surfsense_backend/app/services/provider_registry.py
+++ b/surfsense_backend/app/services/provider_registry.py
@@ -89,6 +89,15 @@ REGISTRY: dict[str, ProviderSpec] = {
         "bearer",
         "Requesty",
     ),
+    "orcarouter": ProviderSpec(
+        Transport.OPENAI_COMPATIBLE,
+        "openai",
+        "openai_models",
+        "https://api.orcarouter.ai/v1",
+        False,
+        "bearer",
+        "OrcaRouter",
+    ),
     "openai_compatible": ProviderSpec(
         Transport.OPENAI_COMPATIBLE,
         "openai",

--- a/surfsense_web/components/icons/providers/index.ts
+++ b/surfsense_web/components/icons/providers/index.ts
@@ -28,6 +28,7 @@ export { default as QwenIcon } from "./qwen.svg";
 export { default as RecraftIcon } from "./recraft.svg";
 export { default as ReplicateIcon } from "./replicate.svg";
 export { default as RequestyIcon } from "./requesty.svg";
+export { default as OrcaRouterIcon } from "./orcarouter.svg";
 export { default as SambaNovaIcon } from "./sambanova.svg";
 export { default as TogetherAiIcon } from "./togetherai.svg";
 export { default as VertexAiIcon } from "./vertexai.svg";

--- a/surfsense_web/components/icons/providers/orcarouter.svg
+++ b/surfsense_web/components/icons/providers/orcarouter.svg
@@ -1,0 +1,1 @@
+<svg fill="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M4 11.5a2.5 2.5 0 0 1 2.5-2.5h8a2.5 2.5 0 0 1 0 5h-8a2.5 2.5 0 0 1 0-5zM9 9l1.6-4.5L12.2 9zM14.5 11.5l3-2.5-1.1 3 1.1 3-3-2.5z"/></svg>

--- a/surfsense_web/components/settings/model-connections/default-connect-form.tsx
+++ b/surfsense_web/components/settings/model-connections/default-connect-form.tsx
@@ -15,7 +15,8 @@ function baseUrlHint(provider: string) {
 		provider === "openai" ||
 		provider === "anthropic" ||
 		provider === "openrouter" ||
-		provider === "requesty"
+		provider === "requesty" ||
+		provider === "orcarouter"
 	) {
 		return "Override only if you route through a proxy or gateway.";
 	}

--- a/surfsense_web/components/settings/model-connections/provider-metadata.tsx
+++ b/surfsense_web/components/settings/model-connections/provider-metadata.tsx
@@ -8,6 +8,7 @@ export const PROVIDER_ORDER = [
 	"azure",
 	"openrouter",
 	"requesty",
+	"orcarouter",
 	"ollama_chat",
 	"lm_studio",
 	"openai_compatible",
@@ -55,6 +56,12 @@ export const PROVIDER_DISPLAY: Record<
 		subtitle: "Requesty",
 		iconKey: "requesty",
 		defaultBaseUrl: "https://router.requesty.ai/v1",
+	},
+	orcarouter: {
+		name: "OrcaRouter",
+		subtitle: "OrcaRouter",
+		iconKey: "orcarouter",
+		defaultBaseUrl: "https://api.orcarouter.ai/v1",
 	},
 	vertex_ai: { name: "Gemini", subtitle: "Google Cloud Vertex AI", iconKey: "vertex_ai" },
 };

--- a/surfsense_web/lib/provider-icons.tsx
+++ b/surfsense_web/lib/provider-icons.tsx
@@ -25,6 +25,7 @@ import {
 	OllamaIcon,
 	OpenaiIcon,
 	OpenRouterIcon,
+	OrcaRouterIcon,
 	PerplexityIcon,
 	QwenIcon,
 	RecraftIcon,
@@ -112,6 +113,8 @@ export function getProviderIcon(
 			return <OpenaiIcon className={cn(className)} />;
 		case "OPENROUTER":
 			return <OpenRouterIcon className={cn(className)} />;
+		case "ORCAROUTER":
+			return <OrcaRouterIcon className={cn(className)} />;
 		case "PERPLEXITY":
 			return <PerplexityIcon className={cn(className)} />;
 		case "RECRAFT":


### PR DESCRIPTION
## What

Adds **OrcaRouter** as a first-class, named model provider in SurfSense, mirroring the existing OpenRouter/Requesty integration pattern.

OrcaRouter is an OpenAI-compatible model gateway that lets you reach models from many providers through one key (e.g. `openai/gpt-5.5`, `anthropic/claude-sonnet-5`). It also provides gateway-level security controls for AI agents.

## Changes

- `surfsense_backend/app/services/provider_registry.py` — register `orcarouter` as an OpenAI-compatible provider with discovery (`openai_models`), base URL `https://api.orcarouter.ai/v1`, and bearer auth, matching the existing `requesty`/`openrouter` entries.
- `surfsense_web/components/icons/providers/orcarouter.svg` — new provider icon.
- `surfsense_web/components/icons/providers/index.ts` — export the new icon.
- `surfsense_web/lib/provider-icons.tsx` — render the icon for `ORCAROUTER` connections.
- `surfsense_web/components/settings/model-connections/provider-metadata.tsx` — add `orcarouter` to the provider order/display metadata.
- `surfsense_web/components/settings/model-connections/default-connect-form.tsx` — show the base-URL hint for OrcaRouter connections.

## Verification

- L3 live test against the real gateway passed: `GET https://api.orcarouter.ai/v1/models` with an `sk-orca-` key returns `200` and a model list that includes namespaced slugs like `openai/gpt-5.5`, `orcarouter/free`, and `orcarouter/fusion`.
- Config format follows the existing provider contract: `OPENAI_COMPATIBLE` transport + `OPENAI_BASE_URL`-style base URL, so no backend routing changes are needed.

I'm an engineer on the [OrcaRouter](https://www.orcarouter.ai) team.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds OrcaRouter as a named model provider in SurfSense, following the same integration pattern as existing OpenAI-compatible gateways like OpenRouter and Requesty. The changes register OrcaRouter in the backend provider registry with its API endpoint (`https://api.orcarouter.ai/v1`), add the provider icon and UI metadata for display in the settings interface, and include the base URL hint for connection configuration.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_backend/app/services/provider_registry.py` |
| 2 | `surfsense_web/components/icons/providers/orcarouter.svg` |
| 3 | `surfsense_web/components/icons/providers/index.ts` |
| 4 | `surfsense_web/lib/provider-icons.tsx` |
| 5 | `surfsense_web/components/settings/model-connections/provider-metadata.tsx` |
| 6 | `surfsense_web/components/settings/model-connections/default-connect-form.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->