### PR TITLE
feat: fix auto mode, openrouter model filtering

### DIFF
--- a/surfsense_backend/alembic/env.py
+++ b/surfsense_backend/alembic/env.py
@@ -5,12 +5,12 @@ import sys
 from logging.config import fileConfig
 
 import sqlalchemy as sa
+from alembic.script import ScriptDirectory
 from sqlalchemy import pool
 from sqlalchemy.engine import Connection
 from sqlalchemy.ext.asyncio import async_engine_from_config
 
 from alembic import context
-from alembic.script import ScriptDirectory
 
 # Ensure the app directory is in the Python path
 # This allows Alembic to find your models

--- a/surfsense_backend/alembic/versions/179_add_model_compatibility.py
+++ b/surfsense_backend/alembic/versions/179_add_model_compatibility.py
@@ -1,0 +1,47 @@
+"""Add the model compatibility blocklist.
+
+Records one verdict per catalogue model from the compatibility sweep. Status is
+a plain VARCHAR rather than a PG enum so a new verdict never needs a migration
+to land alongside the sweep that produces it.
+
+Revision ID: 179
+Revises: 178
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "179"
+down_revision: str | None = "178"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE TABLE model_compatibility (
+            id SERIAL PRIMARY KEY,
+            model_id VARCHAR(255) NOT NULL,
+            status VARCHAR(16) NOT NULL,
+            failure_stage VARCHAR(32),
+            error_code VARCHAR(64),
+            error_excerpt TEXT,
+            latency_ms INTEGER,
+            checked_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+            CONSTRAINT uq_model_compatibility_model_id UNIQUE (model_id)
+        )
+        """
+    )
+    for statement in (
+        "CREATE INDEX ix_model_compatibility_model_id ON model_compatibility(model_id)",
+        "CREATE INDEX ix_model_compatibility_status ON model_compatibility(status)",
+        "CREATE INDEX ix_model_compatibility_checked_at "
+        "ON model_compatibility(checked_at)",
+    ):
+        op.execute(statement)
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE model_compatibility")

--- a/surfsense_backend/alembic/versions/184_add_model_compatibility.py
+++ b/surfsense_backend/alembic/versions/184_add_model_compatibility.py
@@ -4,16 +4,16 @@ Records one verdict per catalogue model from the compatibility sweep. Status is
 a plain VARCHAR rather than a PG enum so a new verdict never needs a migration
 to land alongside the sweep that produces it.
 
-Revision ID: 179
-Revises: 178
+Revision ID: 184
+Revises: 183
 """
 
 from collections.abc import Sequence
 
 from alembic import op
 
-revision: str = "179"
-down_revision: str | None = "178"
+revision: str = "184"
+down_revision: str | None = "183"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/surfsense_backend/app/agents/chat/multi_agent_chat/main_agent/middleware/continue_on_max_length.py
+++ b/surfsense_backend/app/agents/chat/multi_agent_chat/main_agent/middleware/continue_on_max_length.py
@@ -55,7 +55,9 @@ def _model_max_tokens(request: Any) -> int | None:
     return getattr(getattr(request, "model", None), "max_tokens", None)
 
 
-def _continuation_messages(base: list[BaseMessage], accumulated: str) -> list[BaseMessage]:
+def _continuation_messages(
+    base: list[BaseMessage], accumulated: str
+) -> list[BaseMessage]:
     return [*base, AIMessage(content=accumulated), _CONTINUE_NUDGE]
 
 
@@ -127,7 +129,9 @@ class ContinueOnMaxLengthMiddleware(AgentMiddleware):  # type: ignore[type-arg]
         while done < self.max_continuations and self._should_continue(ai, max_tokens):
             done += 1
             last_response = handler(
-                request.override(messages=_continuation_messages(request.messages, accumulated))
+                request.override(
+                    messages=_continuation_messages(request.messages, accumulated)
+                )
             )
             ai = _final_text_ai(last_response)
             if ai is None or (piece := _plain_text(ai)) is None:
@@ -162,7 +166,9 @@ class ContinueOnMaxLengthMiddleware(AgentMiddleware):  # type: ignore[type-arg]
         while done < self.max_continuations and self._should_continue(ai, max_tokens):
             done += 1
             last_response = await handler(
-                request.override(messages=_continuation_messages(request.messages, accumulated))
+                request.override(
+                    messages=_continuation_messages(request.messages, accumulated)
+                )
             )
             ai = _final_text_ai(last_response)
             if ai is None or (piece := _plain_text(ai)) is None:

--- a/surfsense_backend/app/agents/chat/multi_agent_chat/subagents/builtins/deliverables/tools/generate_image.py
+++ b/surfsense_backend/app/agents/chat/multi_agent_chat/subagents/builtins/deliverables/tools/generate_image.py
@@ -192,9 +192,11 @@ def create_generate_image_tool(
                     gen_kwargs.update(resolved_kwargs)
                     provider_base_url = resolved_kwargs.get("api_base")
 
-                billing_tier, base_model, reserve_micros = (
-                    await resolve_billing_for_image_gen(session, config_id, workspace)
-                )
+                (
+                    billing_tier,
+                    base_model,
+                    reserve_micros,
+                ) = await resolve_billing_for_image_gen(session, config_id, workspace)
                 async with billable_call(
                     user_id=workspace.user_id,
                     workspace_id=workspace_id,

--- a/surfsense_backend/app/agents/chat/runtime/references/documents/resolver.py
+++ b/surfsense_backend/app/agents/chat/runtime/references/documents/resolver.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.knowledge_store.paths import PathIndex, virtual_path_of
 from app.db import Document
+from app.knowledge_store.paths import PathIndex, virtual_path_of
 
 from ..models import DocumentReference
 

--- a/surfsense_backend/app/agents/chat/runtime/references/folders.py
+++ b/surfsense_backend/app/agents/chat/runtime/references/folders.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.knowledge_store.paths import DOCUMENTS_ROOT, PathIndex
 from app.db import Folder
+from app.knowledge_store.paths import DOCUMENTS_ROOT, PathIndex
 
 from .models import FolderReference
 

--- a/surfsense_backend/app/artifacts/media/podcast/__init__.py
+++ b/surfsense_backend/app/artifacts/media/podcast/__init__.py
@@ -2,6 +2,6 @@
 
 from __future__ import annotations
 
-from app.artifacts.media.podcast.storage import open_stream, persist, purge
+from app.artifacts.media.podcast.record import record
 
-__all__ = ["open_stream", "persist", "purge"]
+__all__ = ["record"]

--- a/surfsense_backend/app/artifacts/media/podcast/__init__.py
+++ b/surfsense_backend/app/artifacts/media/podcast/__init__.py
@@ -2,6 +2,6 @@
 
 from __future__ import annotations
 
-from app.artifacts.media.podcast.record import record
+from app.artifacts.media.podcast.storage import open_stream, persist, purge
 
-__all__ = ["record"]
+__all__ = ["open_stream", "persist", "purge"]

--- a/surfsense_backend/app/artifacts/media/podcast/__init__.py
+++ b/surfsense_backend/app/artifacts/media/podcast/__init__.py
@@ -2,6 +2,6 @@
 
 from __future__ import annotations
 
-from app.artifacts.media.podcast.storage import open_stream, purge, persist
+from app.artifacts.media.podcast.storage import open_stream, persist, purge
 
-__all__ = ["open_stream", "purge", "persist"]
+__all__ = ["open_stream", "persist", "purge"]

--- a/surfsense_backend/app/artifacts/media/podcast/record.py
+++ b/surfsense_backend/app/artifacts/media/podcast/record.py
@@ -49,9 +49,7 @@ def _to_artifact_input(
 
 def _representation_from_transcript(title: str, transcript: Any | None) -> str:
     turns = getattr(transcript, "turns", None) or []
-    body = "\n\n".join(
-        f"**Speaker {turn.speaker}:** {turn.text}" for turn in turns
-    )
+    body = "\n\n".join(f"**Speaker {turn.speaker}:** {turn.text}" for turn in turns)
     return f"# {title}\n\n{body}"
 
 

--- a/surfsense_backend/app/artifacts/media/podcast/record.py
+++ b/surfsense_backend/app/artifacts/media/podcast/record.py
@@ -52,9 +52,7 @@ def _to_artifact_input(
 
 def _representation_from_transcript(title: str, transcript: Any | None) -> str:
     turns = getattr(transcript, "turns", None) or []
-    body = "\n\n".join(
-        f"**Speaker {turn.speaker}:** {turn.text}" for turn in turns
-    )
+    body = "\n\n".join(f"**Speaker {turn.speaker}:** {turn.text}" for turn in turns)
     return f"# {title}\n\n{body}"
 
 

--- a/surfsense_backend/app/artifacts/service.py
+++ b/surfsense_backend/app/artifacts/service.py
@@ -328,9 +328,7 @@ async def save_artifact(
         **(document.document_metadata or {}),
         "artifact_id": artifact.id,
     }
-    old_blob_refs = [
-        (file.storage_backend, file.storage_key) for file in old_files
-    ]
+    old_blob_refs = [(file.storage_backend, file.storage_key) for file in old_files]
 
     backend = get_storage_backend()
     new_records: list[ArtifactFile] = []

--- a/surfsense_backend/app/artifacts/verification/formats/base.py
+++ b/surfsense_backend/app/artifacts/verification/formats/base.py
@@ -6,7 +6,6 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Literal
 
-
 DEFAULT_RENDERED_MIN_CHARS = 20
 ReviewKind = Literal["document", "slides"]
 

--- a/surfsense_backend/app/artifacts/verification/formats/docx.py
+++ b/surfsense_backend/app/artifacts/verification/formats/docx.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from xml.etree import ElementTree
 
 from .base import StructuralCheckResult
-from .ooxml import OoxmlDefect, open_ooxml
+from .ooxml import OoxmlError, open_ooxml
 
 W_NS = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
 W = f"{{{W_NS}}}"
@@ -43,7 +43,7 @@ def check_docx(data: bytes) -> StructuralCheckResult:
             part_limits={"word/document.xml": MAX_DOCUMENT_XML_BYTES},
         ) as archive:
             root = ElementTree.fromstring(archive.read("word/document.xml"))
-    except OoxmlDefect as exc:
+    except OoxmlError as exc:
         return StructuralCheckResult((str(exc),))
     except ElementTree.ParseError:
         return StructuralCheckResult(("DOCX is not valid OOXML",))

--- a/surfsense_backend/app/artifacts/verification/formats/ooxml.py
+++ b/surfsense_backend/app/artifacts/verification/formats/ooxml.py
@@ -11,7 +11,7 @@ MAX_ZIP_ENTRIES = 10_000
 MAX_UNCOMPRESSED_BYTES = 100 * 1024 * 1024
 
 
-class OoxmlDefect(ValueError):
+class OoxmlError(ValueError):
     """A stable, user-actionable OOXML structural finding."""
 
 
@@ -30,33 +30,29 @@ def open_ooxml(
             entry_names = [entry.filename for entry in entries]
             names = set(entry_names)
             if len(entries) > MAX_ZIP_ENTRIES:
-                raise OoxmlDefect(
+                raise OoxmlError(
                     f"{format_name} contains more than {MAX_ZIP_ENTRIES} ZIP entries"
                 )
             if len(names) != len(entry_names):
-                raise OoxmlDefect(
-                    f"{format_name} contains duplicate OOXML parts"
-                )
+                raise OoxmlError(f"{format_name} contains duplicate OOXML parts")
             missing = sorted(required_parts - names)
             if missing:
-                raise OoxmlDefect(
+                raise OoxmlError(
                     f"{format_name} is missing required parts: {', '.join(missing)}"
                 )
             if any(entry.flag_bits & 1 for entry in entries):
-                raise OoxmlDefect(f"{format_name} contains encrypted ZIP entries")
+                raise OoxmlError(f"{format_name} contains encrypted ZIP entries")
             if sum(entry.file_size for entry in entries) > MAX_UNCOMPRESSED_BYTES:
-                raise OoxmlDefect(
+                raise OoxmlError(
                     f"{format_name} uncompressed content exceeds "
                     f"{MAX_UNCOMPRESSED_BYTES} bytes"
                 )
             for part, limit in (part_limits or {}).items():
                 if archive.getinfo(part).file_size > limit:
                     label = part.rsplit("/", 1)[-1].replace(".xml", " XML")
-                    raise OoxmlDefect(
-                        f"{format_name} {label} exceeds {limit} bytes"
-                    )
+                    raise OoxmlError(f"{format_name} {label} exceeds {limit} bytes")
             yield archive
-    except OoxmlDefect:
+    except OoxmlError:
         raise
     except (BadZipFile, KeyError, OSError, RuntimeError):
-        raise OoxmlDefect(f"{format_name} is not valid OOXML") from None
+        raise OoxmlError(f"{format_name} is not valid OOXML") from None

--- a/surfsense_backend/app/artifacts/verification/formats/pptx.py
+++ b/surfsense_backend/app/artifacts/verification/formats/pptx.py
@@ -7,7 +7,7 @@ from xml.etree import ElementTree
 from zipfile import ZipFile
 
 from .base import StructuralCheckResult
-from .ooxml import OoxmlDefect, open_ooxml
+from .ooxml import OoxmlError, open_ooxml
 
 P_NS = "http://schemas.openxmlformats.org/presentationml/2006/main"
 A_NS = "http://schemas.openxmlformats.org/drawingml/2006/main"
@@ -44,7 +44,7 @@ def _relationships(
     if rels_part not in archive.namelist():
         return {}
     if archive.getinfo(rels_part).file_size > MAX_XML_PART_BYTES:
-        raise OoxmlDefect(f"PPTX {rels_part} exceeds {MAX_XML_PART_BYTES} bytes")
+        raise OoxmlError(f"PPTX {rels_part} exceeds {MAX_XML_PART_BYTES} bytes")
     root = ElementTree.fromstring(archive.read(rels_part))
     relationships: dict[str, tuple[str, str, bool]] = {}
     for relationship in root.findall(f"{REL}Relationship"):
@@ -119,7 +119,7 @@ def _check_slide(
     findings: list[str],
 ) -> None:
     if archive.getinfo(slide_part).file_size > MAX_XML_PART_BYTES:
-        raise OoxmlDefect(f"PPTX {slide_part} exceeds {MAX_XML_PART_BYTES} bytes")
+        raise OoxmlError(f"PPTX {slide_part} exceeds {MAX_XML_PART_BYTES} bytes")
     slide = ElementTree.fromstring(archive.read(slide_part))
     if slide.get("show") == "0":
         findings.append(
@@ -249,7 +249,7 @@ def check_pptx(data: bytes) -> StructuralCheckResult:
                     slide_height=slide_height,
                     findings=findings,
                 )
-    except OoxmlDefect as exc:
+    except OoxmlError as exc:
         return StructuralCheckResult((str(exc),), page_count=page_count)
     except ElementTree.ParseError:
         return StructuralCheckResult(

--- a/surfsense_backend/app/artifacts/verification/formats/registry.py
+++ b/surfsense_backend/app/artifacts/verification/formats/registry.py
@@ -12,9 +12,7 @@ from .xlsx import check_xlsx
 
 PDF_MIME = "application/pdf"
 DOCX_MIME = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
-PPTX_MIME = (
-    "application/vnd.openxmlformats-officedocument.presentationml.presentation"
-)
+PPTX_MIME = "application/vnd.openxmlformats-officedocument.presentationml.presentation"
 XLSX_MIME = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
 
 _ADAPTERS = {

--- a/surfsense_backend/app/artifacts/verification/formats/xlsx.py
+++ b/surfsense_backend/app/artifacts/verification/formats/xlsx.py
@@ -5,19 +5,22 @@ from __future__ import annotations
 from xml.etree import ElementTree
 
 from .base import StructuralCheckResult
-from .ooxml import OoxmlDefect, open_ooxml
+from .ooxml import OoxmlError, open_ooxml
 
 MAIN_NS = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
 PKG_REL_NS = "http://schemas.openxmlformats.org/package/2006/relationships"
-OFFICE_REL_NS = (
-    "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
-)
+OFFICE_REL_NS = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
 MAIN = f"{{{MAIN_NS}}}"
 REL = f"{{{PKG_REL_NS}}}"
 R_ID = f"{{{OFFICE_REL_NS}}}id"
 
 REQUIRED_PARTS = frozenset(
-    {"[Content_Types].xml", "_rels/.rels", "xl/workbook.xml", "xl/_rels/workbook.xml.rels"}
+    {
+        "[Content_Types].xml",
+        "_rels/.rels",
+        "xl/workbook.xml",
+        "xl/_rels/workbook.xml.rels",
+    }
 )
 MAX_WORKBOOK_XML_BYTES = 2 * 1024 * 1024
 MAX_CELLS = 100_000
@@ -104,7 +107,7 @@ def check_xlsx(data: bytes) -> StructuralCheckResult:
                         non_empty += 1
                     elif has_value or has_inline:
                         non_empty += 1
-    except OoxmlDefect as exc:
+    except OoxmlError as exc:
         return StructuralCheckResult((str(exc),))
     except ElementTree.ParseError:
         return StructuralCheckResult(("XLSX is not valid OOXML",))

--- a/surfsense_backend/app/celery_app.py
+++ b/surfsense_backend/app/celery_app.py
@@ -207,6 +207,7 @@ celery_app = Celery(
         "app.tasks.celery_tasks.knowledge_store.drift_monitor_task",
         "app.tasks.celery_tasks.auto_reload_task",
         "app.tasks.celery_tasks.gateway_tasks",
+        "app.tasks.celery_tasks.model_compatibility_task",
         "app.etl_pipeline.cache.eviction.task",
         "app.indexing_pipeline.cache.eviction.task",
         "app.automations.tasks.execute_run",
@@ -364,6 +365,15 @@ celery_app.conf.beat_schedule = {
         "task": "check_knowledge_store_drift",
         "schedule": crontab(hour="5", minute="15"),
         "options": {"expires": 600},
+    },
+    # Re-probe catalogue models that pass our metadata filters but may no
+    # longer serve a turn. Weekly and off-peak: it makes one live call per
+    # stale model, and the blocklist it writes is read by every worker's
+    # next catalogue refresh.
+    "sweep-model-compatibility": {
+        "task": "sweep_model_compatibility",
+        "schedule": crontab(day_of_week="0", hour="6", minute="0"),
+        "options": {"expires": 3600},
     },
     # Fire due automation schedule triggers (Beat entry owned by the schedule
     # trigger; see app.automations.triggers.builtin.schedule.source).

--- a/surfsense_backend/app/db.py
+++ b/surfsense_backend/app/db.py
@@ -2809,6 +2809,34 @@ class ToolOutputSpill(Base, TimestampMixin):
     char_count = Column(Integer, nullable=False, default=0)
 
 
+class ModelCompatibility(Base):
+    """Per-model verdict from the compatibility sweep.
+
+    Passing our metadata filters does not mean a model can serve a turn through
+    this agent harness. ``scripts/sweep_model_compatibility.py`` probes each
+    catalogue model and writes the result here; catalogue generation reads the
+    ``blocked`` ids back so those models never reach a user. Shared through
+    Postgres so all uvicorn workers converge on the same blocklist.
+    """
+
+    __tablename__ = "model_compatibility"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    model_id = Column(String(255), unique=True, nullable=False, index=True)
+    status = Column(String(16), nullable=False, index=True)
+    # Which of the three escalating probes broke; NULL when all passed.
+    failure_stage = Column(String(32), nullable=True)
+    error_code = Column(String(64), nullable=True)
+    error_excerpt = Column(Text, nullable=True)
+    latency_ms = Column(Integer, nullable=True)
+    checked_at = Column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+        index=True,
+    )
+
+
 # Register model packages that live outside this file so their classes
 # are present in Base.metadata before configure_mappers() resolves any
 # string-based relationship() references.

--- a/surfsense_backend/app/db.py
+++ b/surfsense_backend/app/db.py
@@ -2820,6 +2820,34 @@ class ToolOutputSpill(Base, TimestampMixin):
     char_count = Column(Integer, nullable=False, default=0)
 
 
+class ModelCompatibility(Base):
+    """Per-model verdict from the compatibility sweep.
+
+    Passing our metadata filters does not mean a model can serve a turn through
+    this agent harness. ``scripts/sweep_model_compatibility.py`` probes each
+    catalogue model and writes the result here; catalogue generation reads the
+    ``blocked`` ids back so those models never reach a user. Shared through
+    Postgres so all uvicorn workers converge on the same blocklist.
+    """
+
+    __tablename__ = "model_compatibility"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    model_id = Column(String(255), unique=True, nullable=False, index=True)
+    status = Column(String(16), nullable=False, index=True)
+    # Which of the three escalating probes broke; NULL when all passed.
+    failure_stage = Column(String(32), nullable=True)
+    error_code = Column(String(64), nullable=True)
+    error_excerpt = Column(Text, nullable=True)
+    latency_ms = Column(Integer, nullable=True)
+    checked_at = Column(
+        TIMESTAMP(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+        index=True,
+    )
+
+
 # Register model packages that live outside this file so their classes
 # are present in Base.metadata before configure_mappers() resolves any
 # string-based relationship() references.

--- a/surfsense_backend/app/podcasts/api/routes.py
+++ b/surfsense_backend/app/podcasts/api/routes.py
@@ -18,6 +18,11 @@ from fastapi.responses import StreamingResponse
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.artifacts.media.podcast.storage import (
+    exists as audio_exists,
+    open_podcast_stream,
+    purge,
+)
 from app.auth.context import AuthContext
 from app.config import config as app_config
 from app.db import (
@@ -33,11 +38,6 @@ from app.podcasts.service import (
     PodcastService,
     PreconditionFailedError,
     SpecConflictError,
-)
-from app.artifacts.media.podcast.storage import (
-    exists as audio_exists,
-    open_podcast_stream,
-    purge,
 )
 from app.podcasts.tasks import draft_transcript_task
 from app.podcasts.tts import get_text_to_speech

--- a/surfsense_backend/app/podcasts/api/routes.py
+++ b/surfsense_backend/app/podcasts/api/routes.py
@@ -14,11 +14,6 @@ from contextlib import asynccontextmanager
 from fastapi import APIRouter, Depends, HTTPException, Response
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.artifacts.media.podcast.storage import (
-    exists as audio_exists,
-    open_podcast_stream,
-    purge,
-)
 from app.auth.context import AuthContext
 from app.config import config as app_config
 from app.db import (

--- a/surfsense_backend/app/podcasts/api/routes.py
+++ b/surfsense_backend/app/podcasts/api/routes.py
@@ -14,6 +14,11 @@ from contextlib import asynccontextmanager
 from fastapi import APIRouter, Depends, HTTPException, Response
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.artifacts.media.podcast.storage import (
+    exists as audio_exists,
+    open_podcast_stream,
+    purge,
+)
 from app.auth.context import AuthContext
 from app.config import config as app_config
 from app.db import (

--- a/surfsense_backend/app/podcasts/tasks/render.py
+++ b/surfsense_backend/app/podcasts/tasks/render.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 from sqlalchemy import select
 
+from app.artifacts.media.podcast.storage import persist, purge_key
 from app.celery_app import celery_app
 from app.observability import analytics as ph_analytics
 from app.podcasts.persistence import PodcastRepository, PodcastStatus

--- a/surfsense_backend/app/podcasts/tasks/render.py
+++ b/surfsense_backend/app/podcasts/tasks/render.py
@@ -13,7 +13,6 @@ from pathlib import Path
 
 from sqlalchemy import select
 
-from app.artifacts.media.podcast.storage import persist, purge_key
 from app.celery_app import celery_app
 from app.observability import analytics as ph_analytics
 from app.podcasts.persistence import PodcastRepository, PodcastStatus

--- a/surfsense_backend/app/podcasts/tasks/render.py
+++ b/surfsense_backend/app/podcasts/tasks/render.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 from sqlalchemy import select
 
+from app.artifacts.media.podcast.storage import persist, purge_key
 from app.celery_app import celery_app
 from app.observability import analytics as ph_analytics
 from app.podcasts.persistence import PodcastRepository
@@ -23,7 +24,6 @@ from app.podcasts.service import (
     read_spec,
     read_transcript,
 )
-from app.artifacts.media.podcast.storage import purge_key, persist
 from app.podcasts.tts import get_text_to_speech
 from app.podcasts.voices import get_voice_catalog
 from app.tasks.celery_tasks import get_celery_session_maker, run_async_celery_task

--- a/surfsense_backend/app/routes/artifacts_routes.py
+++ b/surfsense_backend/app/routes/artifacts_routes.py
@@ -97,7 +97,9 @@ def _slides_for_remotion(
             continue
         slide = dict(raw)
         slide_number = slide.get("slide_number")
-        has_audio = bool(slide.pop("audio_storage_key", None) or slide.pop("audio_file", None))
+        has_audio = bool(
+            slide.pop("audio_storage_key", None) or slide.pop("audio_file", None)
+        )
         slide.pop("storage_backend", None)
         if has_audio and isinstance(slide_number, int):
             slide["audio_url"] = (
@@ -380,9 +382,7 @@ async def stream_artifact_slide_audio(
         media_type=media_type,
         headers={
             "Accept-Ranges": "bytes",
-            "Content-Disposition": (
-                f"inline; filename={Path(str(storage_key)).name}"
-            ),
+            "Content-Disposition": (f"inline; filename={Path(str(storage_key)).name}"),
         },
     )
 

--- a/surfsense_backend/app/routes/artifacts_routes.py
+++ b/surfsense_backend/app/routes/artifacts_routes.py
@@ -97,7 +97,9 @@ def _slides_for_remotion(
             continue
         slide = dict(raw)
         slide_number = slide.get("slide_number")
-        has_audio = bool(slide.pop("audio_storage_key", None) or slide.pop("audio_file", None))
+        has_audio = bool(
+            slide.pop("audio_storage_key", None) or slide.pop("audio_file", None)
+        )
         slide.pop("storage_backend", None)
         if has_audio and isinstance(slide_number, int):
             slide["audio_url"] = (
@@ -386,9 +388,7 @@ async def stream_artifact_slide_audio(
         media_type=media_type,
         headers={
             "Accept-Ranges": "bytes",
-            "Content-Disposition": (
-                f"inline; filename={Path(str(storage_key)).name}"
-            ),
+            "Content-Disposition": (f"inline; filename={Path(str(storage_key)).name}"),
         },
     )
 

--- a/surfsense_backend/app/sandbox/registry.py
+++ b/surfsense_backend/app/sandbox/registry.py
@@ -128,9 +128,7 @@ class SandboxRegistry:
                 self._reap_idle()
                 self._check_capacity(key, workspace_key)
                 session = await self._provider.get_or_create_session(key)
-                self._entries[key] = _Entry(
-                    session=session, workspace_id=workspace_key
-                )
+                self._entries[key] = _Entry(session=session, workspace_id=workspace_key)
                 return session
 
     def get_cached(self, thread_id: int | str) -> SandboxSession | None:

--- a/surfsense_backend/app/services/auto_model_pin_service.py
+++ b/surfsense_backend/app/services/auto_model_pin_service.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import hashlib
 import logging
+import os
 import threading
 import time
 from dataclasses import dataclass
@@ -64,6 +65,19 @@ class AutoPinResolution:
     resolved_llm_config_id: int
     resolved_tier: str
     from_existing_pin: bool
+
+
+def _is_known_global_config(config_id: int) -> bool:
+    """False when a global (negative) id is absent from this worker's catalogue.
+
+    Production runs ``UVICORN_WORKERS=4`` and uvicorn preforks, so each process
+    fetches and materializes its own catalogue. A config id one worker knows
+    can be missing from another — its boot fetch may have failed, or the two
+    may have refreshed either side of an upstream delisting.
+    """
+    if config_id >= 0:
+        return True
+    return any(int(model.get("id", 0)) == config_id for model in config.GLOBAL_MODELS)
 
 
 def _is_usable_global_config(cfg: dict) -> bool:
@@ -465,6 +479,11 @@ def _tier_of(cfg: dict) -> str:
     return str(cfg.get("billing_tier", "free")).lower()
 
 
+def _is_tier_a(cfg: dict) -> bool:
+    """Tier A is the operator-curated YAML pool; None predates the field."""
+    return cfg.get("auto_pin_tier") in (None, "A")
+
+
 def _select_pin(eligible: list[dict], thread_id: int) -> tuple[dict, int]:
     """Pick a config with quality-first ranking + deterministic spread.
 
@@ -478,7 +497,7 @@ def _select_pin(eligible: list[dict], thread_id: int) -> tuple[dict, int]:
     Returns ``(chosen_cfg, top_k_size)``. ``top_k_size`` is exposed for
     structured logging in the caller.
     """
-    tier_a = [c for c in eligible if c.get("auto_pin_tier") in (None, "A")]
+    tier_a = [c for c in eligible if _is_tier_a(c)]
     pool = tier_a if tier_a else eligible
     pool = sorted(pool, key=lambda c: -int(c.get("quality_score") or 0))
     top_k = pool[:_QUALITY_TOP_K]
@@ -556,7 +575,9 @@ async def resolve_or_get_pinned_llm_config_id(
         )
 
     # Explicit model selected: clear any stale pin.
-    if selected_llm_config_id != AUTO_MODE_ID:
+    if selected_llm_config_id != AUTO_MODE_ID and _is_known_global_config(
+        selected_llm_config_id
+    ):
         if thread.pinned_llm_config_id is not None:
             thread.pinned_llm_config_id = None
             await session.commit()
@@ -564,6 +585,18 @@ async def resolve_or_get_pinned_llm_config_id(
             resolved_llm_config_id=selected_llm_config_id,
             resolved_tier="explicit",
             from_existing_pin=False,
+        )
+    if selected_llm_config_id != AUTO_MODE_ID:
+        # Returning it would hand ``load_llm_bundle`` an id it cannot resolve,
+        # ending the turn with SERVER_ERROR while the identical request
+        # succeeds on a sibling worker. Fall through to Auto instead.
+        logger.warning(
+            "auto_pin_selection_unknown_on_this_worker thread_id=%s "
+            "selected_config_id=%s catalogue_size=%s pid=%s",
+            thread_id,
+            selected_llm_config_id,
+            len(config.GLOBAL_MODELS),
+            os.getpid(),
         )
 
     excluded_ids = {int(cid) for cid in (exclude_config_ids or set())}
@@ -690,15 +723,24 @@ async def resolve_or_get_pinned_llm_config_id(
             premium_eligible,
         )
 
+    # ``tier_a_eligible=False`` is the fallthrough that exposes the unvetted
+    # dynamic pool. It is the signal that says how often Auto is one cooldown
+    # away from Tier B, and pid + catalogue_size make divergence between the
+    # four uvicorn workers observable instead of inferred.
     logger.info(
         "auto_pin_resolved thread_id=%s config_id=%s tier=%s "
-        "auto_pin_tier=%s score=%s top_k_size=%d from_existing_pin=False",
+        "auto_pin_tier=%s score=%s top_k_size=%d from_existing_pin=False "
+        "tier_a_eligible=%s candidates=%d catalogue_size=%d pid=%d",
         thread_id,
         selected_id,
         selected_tier,
         selected_cfg.get("auto_pin_tier", "?"),
         int(selected_cfg.get("quality_score") or 0),
         top_k_size,
+        any(_is_tier_a(c) for c in eligible),
+        len(eligible),
+        len(config.GLOBAL_MODELS),
+        os.getpid(),
     )
 
     return AutoPinResolution(

--- a/surfsense_backend/app/services/model_compatibility.py
+++ b/surfsense_backend/app/services/model_compatibility.py
@@ -1,0 +1,142 @@
+"""Verdicts for the model compatibility sweep, and the blocklist it feeds.
+
+OpenRouter lists hundreds of models that pass our capability filters on
+metadata alone. Some of them still cannot serve a turn through this agent
+harness — the ``:batch`` variants route to an async API, delisted ids 404, and
+some providers reject our tool-call message shape. The sweep in
+``scripts/sweep_model_compatibility.py`` probes each one and records a verdict
+here; the catalogue reads the blocked ids back on startup and on every refresh.
+
+The bias is deliberate: only a failure that is definitively about *this model*
+blocks it. Everything else stays ``UNKNOWN`` and the model keeps its listing,
+because a bad key or a five-minute provider outage would otherwise empty the
+catalogue in a single sweep.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from enum import StrEnum
+
+from sqlalchemy import select
+
+from app.services.llm_error_adapter import LLMErrorCategory, adapt_llm_exception
+
+logger = logging.getLogger(__name__)
+
+# Longest error body we keep per model. Enough to identify the failure in a
+# dashboard without turning the table into a log sink.
+ERROR_EXCERPT_LIMIT = 500
+
+
+class CompatibilityStatus(StrEnum):
+    OK = "ok"
+    BLOCKED = "blocked"
+    UNKNOWN = "unknown"
+
+
+class ProbeStage(StrEnum):
+    """The three escalating probes, in the order the sweep runs them."""
+
+    STREAM = "stream"
+    TOOL_BIND = "tool_bind"
+    TOOL_RESULT = "tool_result"
+
+
+# Failures that are a property of the model, not of the moment. A 404 means the
+# id does not serve chat completions; a 400/422 means the model rejects the
+# request shape every agent turn uses.
+#
+# Deliberately absent: AUTH_FAILED and PERMISSION_DENIED (account-level — a bad
+# key fails every model at once), and every transient category (rate limits,
+# timeouts, gateway and connection errors).
+_PERMANENT_FAILURE_CATEGORIES: frozenset[LLMErrorCategory] = frozenset(
+    {
+        LLMErrorCategory.MODEL_NOT_FOUND,
+        LLMErrorCategory.BAD_REQUEST,
+    }
+)
+
+
+@dataclass(frozen=True)
+class CompatibilityVerdict:
+    status: CompatibilityStatus
+    failure_stage: ProbeStage | None = None
+    error_code: str | None = None
+    error_excerpt: str | None = None
+
+
+def classify_probe_failure(exc: BaseException) -> tuple[CompatibilityStatus, str]:
+    """Map a probe exception to ``(status, error_code)``."""
+    category = adapt_llm_exception(exc).category
+    status = (
+        CompatibilityStatus.BLOCKED
+        if category in _PERMANENT_FAILURE_CATEGORIES
+        else CompatibilityStatus.UNKNOWN
+    )
+    return status, category.value
+
+
+def verdict_from_stages(
+    results: dict[ProbeStage, BaseException | None],
+) -> CompatibilityVerdict:
+    """Reduce per-stage outcomes to one verdict, reporting the first failure.
+
+    Stages are evaluated in ``ProbeStage`` order regardless of dict ordering,
+    so the recorded ``failure_stage`` is always the earliest one that broke.
+    """
+    for stage in ProbeStage:
+        exc = results.get(stage)
+        if exc is None:
+            continue
+        status, error_code = classify_probe_failure(exc)
+        return CompatibilityVerdict(
+            status=status,
+            failure_stage=stage,
+            error_code=error_code,
+            error_excerpt=str(exc)[:ERROR_EXCERPT_LIMIT],
+        )
+    return CompatibilityVerdict(status=CompatibilityStatus.OK)
+
+
+def blocked_model_ids() -> set[str]:
+    """Every model id currently marked ``BLOCKED``, shared through Postgres so
+    all four uvicorn workers converge on the same blocklist.
+
+    Sync because ``initialize_openrouter_integration`` runs from both the
+    FastAPI lifespan and the Celery worker bootstrap, and the latter has no
+    event loop. Async callers should hand it to a thread.
+
+    Returns an empty set on any failure: an unreachable table must never stop a
+    worker from booting with a full catalogue.
+    """
+    from sqlalchemy import create_engine
+
+    from app.agents.chat.runtime.checkpointer import get_postgres_connection_string
+    from app.db import ModelCompatibility
+
+    query = select(ModelCompatibility.model_id).where(
+        ModelCompatibility.status == CompatibilityStatus.BLOCKED
+    )
+    engine = None
+    try:
+        engine = create_engine(get_postgres_connection_string())
+        with engine.connect() as connection:
+            return {row[0] for row in connection.execute(query)}
+    except Exception as exc:
+        logger.warning("model compatibility blocklist unavailable: %s", exc)
+        return set()
+    finally:
+        if engine is not None:
+            engine.dispose()
+
+
+__all__ = [
+    "CompatibilityStatus",
+    "CompatibilityVerdict",
+    "ProbeStage",
+    "blocked_model_ids",
+    "classify_probe_failure",
+    "verdict_from_stages",
+]

--- a/surfsense_backend/app/services/model_compatibility_sweep.py
+++ b/surfsense_backend/app/services/model_compatibility_sweep.py
@@ -1,0 +1,287 @@
+"""Probe catalogue models for real turn compatibility and record the verdicts.
+
+Passing our metadata filters only proves a model *claims* to support tool
+calling and a large enough context. It does not prove it works here: ``:batch``
+ids answer 404, delisted ids answer 404, and some providers accept ``tools``
+but reject the message history an agent turn produces once a tool has run.
+
+Each model gets up to three escalating probes, stopping at the first failure:
+
+1. ``stream`` — a streaming hello that must produce at least one chunk.
+2. ``tool_bind`` — the same call with two dummy tools bound, which must return
+   either a well-formed ``tool_call`` or clean text.
+3. ``tool_result`` — the assistant tool-call message plus its tool result fed
+   back in, which must produce a final answer.
+
+Lives in ``app/`` rather than ``scripts/`` because both the CLI
+(``scripts/sweep_model_compatibility.py``) and the periodic Celery task run it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from collections.abc import Iterable
+from datetime import UTC, datetime, timedelta
+
+import httpx
+import litellm
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+from app.services.model_compatibility import (
+    CompatibilityStatus,
+    CompatibilityVerdict,
+    ProbeStage,
+    verdict_from_stages,
+)
+from app.services.openrouter_model_normalizer import normalize_openrouter_models
+
+logger = logging.getLogger(__name__)
+
+MODELS_URL = "https://openrouter.ai/api/v1/models"
+API_BASE = "https://openrouter.ai/api/v1"
+PROBE_TIMEOUT_SEC = 60
+DEFAULT_CONCURRENCY = 8
+DEFAULT_MAX_AGE_DAYS = 30
+
+_TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get the current weather for a city.",
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_time",
+            "description": "Get the current time in a timezone.",
+            "parameters": {
+                "type": "object",
+                "properties": {"timezone": {"type": "string"}},
+                "required": ["timezone"],
+            },
+        },
+    },
+]
+
+_TOOL_CALL_ID = "call_sweep_1"
+
+
+class ProbeResponseError(RuntimeError):
+    """A probe reached the provider but the response was unusable.
+
+    Carries no provider status code, so ``classify_probe_failure`` leaves it
+    ``UNKNOWN``: an empty reply is suspicious, not proof the model is dead.
+    """
+
+
+def _kwargs(model_id: str, api_key: str) -> dict:
+    return {
+        "model": f"openrouter/{model_id}",
+        "api_key": api_key,
+        "api_base": API_BASE,
+        "timeout": PROBE_TIMEOUT_SEC,
+        "max_tokens": 64,
+    }
+
+
+async def _probe_stream(model_id: str, api_key: str) -> None:
+    stream = await litellm.acompletion(
+        **_kwargs(model_id, api_key),
+        messages=[{"role": "user", "content": "Reply with the single word: ok"}],
+        stream=True,
+    )
+    async for chunk in stream:
+        delta = chunk.choices[0].delta if chunk.choices else None
+        if delta is not None and (getattr(delta, "content", None) or ""):
+            return
+    raise ProbeResponseError("stream produced no content")
+
+
+async def _probe_tool_bind(model_id: str, api_key: str) -> None:
+    response = await litellm.acompletion(
+        **_kwargs(model_id, api_key),
+        messages=[
+            {"role": "user", "content": "What is the weather in Paris? Use your tools."}
+        ],
+        tools=_TOOLS,
+        tool_choice="auto",
+    )
+    message = response.choices[0].message if response.choices else None
+    if message is None:
+        raise ProbeResponseError("no choices returned with tools bound")
+    for call in getattr(message, "tool_calls", None) or []:
+        # A malformed call is worse than no call: the agent crashes mid-turn
+        # instead of falling back to prose.
+        if not getattr(call.function, "name", None):
+            raise ProbeResponseError("tool_call missing a function name")
+        return
+    if not (message.content or "").strip():
+        raise ProbeResponseError("neither a tool call nor text with tools bound")
+
+
+async def _probe_tool_result(model_id: str, api_key: str) -> None:
+    response = await litellm.acompletion(
+        **_kwargs(model_id, api_key),
+        messages=[
+            {"role": "user", "content": "What is the weather in Paris?"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": _TOOL_CALL_ID,
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": '{"city": "Paris"}',
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": _TOOL_CALL_ID,
+                "name": "get_weather",
+                "content": "18C and clear",
+            },
+        ],
+        tools=_TOOLS,
+    )
+    message = response.choices[0].message if response.choices else None
+    if message is None or not (message.content or "").strip():
+        raise ProbeResponseError("no answer after a tool result")
+
+
+_PROBES = {
+    ProbeStage.STREAM: _probe_stream,
+    ProbeStage.TOOL_BIND: _probe_tool_bind,
+    ProbeStage.TOOL_RESULT: _probe_tool_result,
+}
+
+
+async def probe_model(model_id: str, api_key: str) -> tuple[CompatibilityVerdict, int]:
+    """Run the stages in order, stopping at the first failure."""
+    started = time.monotonic()
+    results: dict[ProbeStage, BaseException | None] = {}
+    for stage, probe in _PROBES.items():
+        try:
+            await probe(model_id, api_key)
+        except Exception as exc:
+            results[stage] = exc
+            break
+        results[stage] = None
+    return verdict_from_stages(results), int((time.monotonic() - started) * 1000)
+
+
+async def fetch_catalogue_model_ids() -> list[str]:
+    async with httpx.AsyncClient(timeout=30) as client:
+        response = await client.get(MODELS_URL)
+        response.raise_for_status()
+        raw_models = response.json().get("data", [])
+    return [m["model_id"] for m in normalize_openrouter_models(raw_models)]
+
+
+def resolve_api_key() -> str:
+    import os
+
+    from app.config import load_openrouter_integration_settings
+
+    env_key = os.environ.get("OPENROUTER_API_KEY")
+    if env_key:
+        return env_key
+    settings = load_openrouter_integration_settings() or {}
+    return str(settings.get("api_key") or "")
+
+
+async def recently_checked_ids(max_age_days: int) -> set[str]:
+    from app.db import ModelCompatibility, async_session_maker
+
+    cutoff = datetime.now(UTC) - timedelta(days=max_age_days)
+    async with async_session_maker() as session:
+        result = await session.execute(
+            select(ModelCompatibility.model_id).where(
+                ModelCompatibility.checked_at >= cutoff
+            )
+        )
+        return {row[0] for row in result}
+
+
+async def record_verdict(
+    model_id: str, verdict: CompatibilityVerdict, latency_ms: int
+) -> None:
+    from app.db import ModelCompatibility, async_session_maker
+
+    values = {
+        "model_id": model_id,
+        "status": verdict.status.value,
+        "failure_stage": verdict.failure_stage.value if verdict.failure_stage else None,
+        "error_code": verdict.error_code,
+        "error_excerpt": verdict.error_excerpt,
+        "latency_ms": latency_ms,
+        "checked_at": datetime.now(UTC),
+    }
+    statement = pg_insert(ModelCompatibility).values(**values)
+    statement = statement.on_conflict_do_update(
+        index_elements=[ModelCompatibility.model_id],
+        set_={key: value for key, value in values.items() if key != "model_id"},
+    )
+    async with async_session_maker() as session:
+        await session.execute(statement)
+        await session.commit()
+
+
+async def sweep_models(
+    model_ids: Iterable[str],
+    *,
+    api_key: str,
+    concurrency: int = DEFAULT_CONCURRENCY,
+    on_verdict=None,
+) -> dict[str, int]:
+    """Probe each model with bounded concurrency, recording every verdict.
+
+    Returns a ``{status: count}`` tally. One model's failure never aborts the
+    sweep — a run that dies halfway would leave the blocklist half-applied.
+    """
+    semaphore = asyncio.Semaphore(concurrency)
+    counts: dict[str, int] = {status.value: 0 for status in CompatibilityStatus}
+
+    async def sweep_one(model_id: str) -> None:
+        async with semaphore:
+            try:
+                verdict, latency_ms = await probe_model(model_id, api_key)
+            except Exception:
+                logger.exception("compatibility probe crashed for %s", model_id)
+                return
+        counts[verdict.status.value] += 1
+        try:
+            await record_verdict(model_id, verdict, latency_ms)
+        except Exception:
+            logger.exception("could not record verdict for %s", model_id)
+        if on_verdict is not None:
+            on_verdict(model_id, verdict)
+
+    await asyncio.gather(*(sweep_one(model_id) for model_id in model_ids))
+    return counts
+
+
+__all__ = [
+    "DEFAULT_CONCURRENCY",
+    "DEFAULT_MAX_AGE_DAYS",
+    "ProbeResponseError",
+    "fetch_catalogue_model_ids",
+    "probe_model",
+    "recently_checked_ids",
+    "record_verdict",
+    "resolve_api_key",
+    "sweep_models",
+]

--- a/surfsense_backend/app/services/model_list_service.py
+++ b/surfsense_backend/app/services/model_list_service.py
@@ -82,34 +82,6 @@ def _load_fallback() -> list[dict]:
         return []
 
 
-def _is_text_output_model(model: dict) -> bool:
-    """Return True if the model's output is text-only (no audio/image generation)."""
-    output_mods = model.get("architecture", {}).get("output_modalities", [])
-    return output_mods == ["text"]
-
-
-def _supports_tool_calling(model: dict) -> bool:
-    """Return True if the model supports function/tool calling."""
-    supported = model.get("supported_parameters") or []
-    return "tools" in supported
-
-
-MIN_CONTEXT_LENGTH = 100_000
-
-
-def _has_sufficient_context(model: dict) -> bool:
-    """Return True if the model's context window is at least MIN_CONTEXT_LENGTH."""
-    ctx = model.get("context_length") or 0
-    return ctx >= MIN_CONTEXT_LENGTH
-
-
-def _is_allowed_model(model: dict) -> bool:
-    """Reuse the exclusion list from the OpenRouter integration service."""
-    from app.services.openrouter_integration_service import _is_allowed_model as _check
-
-    return _check(model)
-
-
 def _process_models(raw_models: list[dict]) -> list[dict]:
     """
     Transform raw OpenRouter model entries into a flat list of

--- a/surfsense_backend/app/services/openrouter_integration_service.py
+++ b/surfsense_backend/app/services/openrouter_integration_service.py
@@ -19,6 +19,7 @@ from typing import Any
 
 import httpx
 
+from app.services.model_compatibility import blocked_model_ids
 from app.services.openrouter_model_normalizer import (
     is_openrouter_image_model,
     normalize_openrouter_models,
@@ -91,115 +92,6 @@ def _openrouter_tier(model: dict) -> str:
     return "premium"
 
 
-def _is_text_output_model(model: dict) -> bool:
-    """Return True if the model produces text output only (skip image/audio generators)."""
-    output_mods = model.get("architecture", {}).get("output_modalities", [])
-    return output_mods == ["text"]
-
-
-def _is_image_output_model(model: dict) -> bool:
-    """Return True if the model can produce image output.
-
-    OpenRouter's ``architecture.output_modalities`` is a list (e.g.
-    ``["image"]`` for pure image generators, ``["text", "image"]`` for
-    multi-modal generators that also emit captions). We accept any model
-    that can output images; the call site decides whether to use the
-    image-generation API or chat completion.
-    """
-    output_mods = model.get("architecture", {}).get("output_modalities", []) or []
-    return "image" in output_mods
-
-
-def _is_vision_input_model(model: dict) -> bool:
-    """Return True if the model can ingest an image AND emit text.
-
-    OpenRouter's ``architecture.input_modalities`` lists what the model
-    accepts; ``output_modalities`` lists what it produces. A vision LLM
-    is a model that takes images in and produces text out — i.e. it can
-    answer questions about a screenshot or extract content from an
-    image. Pure image-to-image models (e.g. style transfer) and
-    text-only models are excluded.
-    """
-    arch = model.get("architecture", {}) or {}
-    input_mods = arch.get("input_modalities", []) or []
-    output_mods = arch.get("output_modalities", []) or []
-    return "image" in input_mods and "text" in output_mods
-
-
-def _supports_image_input(model: dict) -> bool:
-    """Return True if the model accepts ``image`` in its input modalities.
-
-    Differs from :func:`_is_vision_input_model` in that it does NOT
-    require text output — chat-tab models always emit text already (the
-    chat catalog filters by ``_is_text_output_model``), so the only
-    extra capability we need to track per chat config is whether the
-    model can ingest user-attached images. The chat selector and the
-    streaming task both key off this flag to prevent hitting an
-    OpenRouter 404 ``"No endpoints found that support image input"``
-    when the user uploads an image and selects a text-only model
-    (DeepSeek V3, Llama 3.x base, etc.).
-    """
-    arch = model.get("architecture", {}) or {}
-    input_mods = arch.get("input_modalities", []) or []
-    return "image" in input_mods
-
-
-def _supports_tool_calling(model: dict) -> bool:
-    """Return True if the model supports function/tool calling."""
-    supported = model.get("supported_parameters") or []
-    return "tools" in supported
-
-
-MIN_CONTEXT_LENGTH = 100_000
-
-# Provider slugs whose backend is fundamentally incompatible with our agent's
-# tool-call message flow (e.g. Amazon Bedrock requires toolConfig alongside
-# tool history which OpenRouter doesn't relay).
-_EXCLUDED_PROVIDER_SLUGS = {"amazon"}
-
-_EXCLUDED_MODEL_IDS: set[str] = {
-    # Deprecated / removed upstream
-    "openai/gpt-4-1106-preview",
-    "openai/gpt-4-turbo-preview",
-    # Permanently no-capacity variant
-    "openai/gpt-4o:extended",
-    # Non-serverless model that requires a dedicated endpoint
-    "arcee-ai/virtuoso-large",
-    # Deep-research models reject standard params (temperature, etc.)
-    "openai/o3-deep-research",
-    "openai/o4-mini-deep-research",
-    # OpenRouter's own meta-router over free models. We already enumerate every
-    # concrete ``:free`` model into GLOBAL_LLM_CONFIGS and Auto-mode thread
-    # pinning handles churn via the repair path, so exposing an additional
-    # indirection layer would only duplicate the capability with an opaque slug.
-    "openrouter/free",
-}
-
-_EXCLUDED_MODEL_SUFFIXES: tuple[str, ...] = ("-deep-research",)
-
-
-def _has_sufficient_context(model: dict) -> bool:
-    """Return True if the model's context window is at least MIN_CONTEXT_LENGTH."""
-    ctx = model.get("context_length") or 0
-    return ctx >= MIN_CONTEXT_LENGTH
-
-
-def _is_compatible_provider(model: dict) -> bool:
-    """Return False for models from providers known to be incompatible."""
-    model_id = model.get("id", "")
-    slug = model_id.split("/", 1)[0] if "/" in model_id else ""
-    return slug not in _EXCLUDED_PROVIDER_SLUGS
-
-
-def _is_allowed_model(model: dict) -> bool:
-    """Return False for specific model IDs known to be broken or incompatible."""
-    model_id = model.get("id", "")
-    if model_id in _EXCLUDED_MODEL_IDS:
-        return False
-    base_id = model_id.split(":")[0]
-    return not base_id.endswith(_EXCLUDED_MODEL_SUFFIXES)
-
-
 def _fetch_models_sync() -> list[dict] | None:
     """Synchronous fetch for use during startup (before the event loop is running)."""
     try:
@@ -255,6 +147,7 @@ def _extract_raw_pricing(raw_models: list[dict]) -> dict[str, dict[str, str]]:
 def _generate_configs(
     raw_models: list[dict],
     settings: dict[str, Any],
+    blocked_ids: set[str] | None = None,
 ) -> list[dict]:
     """Convert raw OpenRouter model entries into global LLM config dicts.
 
@@ -277,9 +170,12 @@ def _generate_configs(
       via ``auto_model_pin_service``.
 
     OpenRouter's own ``openrouter/free`` meta-router is filtered out upstream
-    via ``_EXCLUDED_MODEL_IDS``; we don't expose a redundant auto-select layer
-    because our own Auto pin + 24 h refresh + repair logic already
-    cover the catalogue-churn case.
+    via ``EXCLUDED_MODEL_IDS`` in ``openrouter_model_normalizer``; we don't
+    expose a redundant auto-select layer because our own Auto pin + 24 h
+    refresh + repair logic already cover the catalogue-churn case.
+
+    ``blocked_ids`` are model ids the compatibility sweep proved cannot serve a
+    turn despite passing every metadata filter.
     """
     id_offset: int = settings.get("id_offset", -10000)
     api_key: str = settings.get("api_key", "")
@@ -296,7 +192,7 @@ def _generate_configs(
     use_default: bool = settings.get("use_default_system_instructions", True)
     citations_enabled: bool = settings.get("citations_enabled", True)
 
-    text_models = normalize_openrouter_models(raw_models)
+    text_models = normalize_openrouter_models(raw_models, blocked_ids)
 
     configs: list[dict] = []
     taken: set[int] = set()
@@ -372,8 +268,8 @@ def _generate_image_gen_configs(
       - compatible provider (excluded slugs blocked)
       - allowed model id (excluded list blocked)
 
-    Notably we *drop* the chat-only filters (``_supports_tool_calling`` and
-    ``_has_sufficient_context``) because tool calls and context windows are
+    Notably we *drop* the chat-only filters (``supports_tool_calling`` and
+    ``has_sufficient_context``) because tool calls and context windows are
     irrelevant for the ``aimage_generation`` API. ``billing_tier`` is
     derived per model the same way as chat (``_openrouter_tier``).
 
@@ -479,7 +375,7 @@ class OpenRouterIntegrationService:
             return []
 
         self._raw_models = raw_models
-        self._configs = _generate_configs(raw_models, settings)
+        self._configs = _generate_configs(raw_models, settings, blocked_model_ids())
         self._configs_by_id = {c["id"]: c for c in self._configs}
         self._raw_pricing = _extract_raw_pricing(raw_models)
 
@@ -531,7 +427,11 @@ class OpenRouterIntegrationService:
             logger.warning("OpenRouter refresh: fetch failed, keeping stale list")
             return
 
-        new_configs = _generate_configs(raw_models, self._settings)
+        # Re-read the blocklist every refresh so a sweep that runs between
+        # deploys takes effect without one. Off-loop because the reader is sync.
+        blocked = await asyncio.to_thread(blocked_model_ids)
+
+        new_configs = _generate_configs(raw_models, self._settings, blocked)
         new_by_id = {c["id"]: c for c in new_configs}
         self._raw_pricing = _extract_raw_pricing(raw_models)
         self._raw_models = raw_models
@@ -560,6 +460,15 @@ class OpenRouterIntegrationService:
             ]
             app_config.GLOBAL_IMAGE_GEN_CONFIGS = static_image + new_image
             self._image_configs = new_image
+
+        # GLOBAL_MODELS / GLOBAL_CONNECTIONS are what the picker and
+        # ``load_llm_bundle`` actually read; GLOBAL_LLM_CONFIGS above is only
+        # their source. Without re-materializing here they keep the boot
+        # snapshot forever, so a model delisted upstream stays selectable
+        # until the next restart and then 404s.
+        from app.config import refresh_global_model_catalog
+
+        refresh_global_model_catalog()
 
         # Catalogue churn invalidates per-config "recently healthy" credit
         # earned by the previous turn's preflight. Drop the whole table so

--- a/surfsense_backend/app/services/openrouter_model_normalizer.py
+++ b/surfsense_backend/app/services/openrouter_model_normalizer.py
@@ -25,6 +25,12 @@ EXCLUDED_MODEL_IDS: set[str] = {
 }
 EXCLUDED_MODEL_SUFFIXES: tuple[str, ...] = ("-deep-research",)
 
+# Variant suffixes after the ``:`` in an OpenRouter id. ``:batch`` models carry
+# full chat metadata in ``/models`` but reject chat completions with
+# ``404 "This model is only available through the Batch API"``, so they are
+# unusable for streaming chat no matter how well they score.
+EXCLUDED_MODEL_VARIANTS: frozenset[str] = frozenset({"batch"})
+
 
 def is_text_output_model(model: dict[str, Any]) -> bool:
     output_mods = model.get("architecture", {}).get("output_modalities", [])
@@ -60,7 +66,9 @@ def is_allowed_model(model: dict[str, Any]) -> bool:
     model_id = str(model.get("id") or "")
     if model_id in EXCLUDED_MODEL_IDS:
         return False
-    base_id = model_id.split(":")[0]
+    base_id, _, variant = model_id.partition(":")
+    if variant in EXCLUDED_MODEL_VARIANTS:
+        return False
     return not base_id.endswith(EXCLUDED_MODEL_SUFFIXES)
 
 
@@ -86,12 +94,21 @@ def is_openrouter_image_model(model: dict[str, Any]) -> bool:
 
 def normalize_openrouter_models(
     raw_models: list[dict[str, Any]],
+    blocked_ids: set[str] | None = None,
 ) -> list[dict[str, Any]]:
+    """Filter and flatten OpenRouter's ``/models`` payload.
+
+    ``blocked_ids`` comes from the compatibility sweep, which probes models that
+    pass every metadata check above and still cannot serve a turn. Passed in
+    rather than read here so this module stays sync and unit-testable.
+    """
     normalized: list[dict[str, Any]] = []
     for model in raw_models:
         if not is_openrouter_chat_model(model):
             continue
         model_id = str(model.get("id") or "")
+        if blocked_ids and model_id in blocked_ids:
+            continue
         normalized.append(
             {
                 "model_id": model_id,
@@ -109,6 +126,7 @@ def normalize_openrouter_models(
 
 
 __all__ = [
+    "EXCLUDED_MODEL_VARIANTS",
     "MIN_CONTEXT_LENGTH",
     "has_sufficient_context",
     "is_allowed_model",

--- a/surfsense_backend/app/tasks/celery_tasks/model_compatibility_task.py
+++ b/surfsense_backend/app/tasks/celery_tasks/model_compatibility_task.py
@@ -1,0 +1,47 @@
+"""Celery task that re-probes catalogue models for turn compatibility.
+
+Runs weekly so a model delisted or changed upstream is blocklisted without a
+deploy. Only models whose verdict has aged past ``DEFAULT_MAX_AGE_DAYS`` are
+probed, so each run costs a fraction of the full catalogue.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from app.celery_app import celery_app
+from app.services.model_compatibility_sweep import (
+    DEFAULT_MAX_AGE_DAYS,
+    fetch_catalogue_model_ids,
+    recently_checked_ids,
+    resolve_api_key,
+    sweep_models,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@celery_app.task(name="sweep_model_compatibility")
+def sweep_model_compatibility() -> dict[str, int]:
+    return asyncio.run(_sweep())
+
+
+async def _sweep() -> dict[str, int]:
+    api_key = resolve_api_key()
+    if not api_key:
+        logger.info("model compatibility sweep skipped: no OpenRouter key")
+        return {}
+
+    fresh = await recently_checked_ids(DEFAULT_MAX_AGE_DAYS)
+    model_ids = [m for m in await fetch_catalogue_model_ids() if m not in fresh]
+    if not model_ids:
+        return {}
+
+    counts = await sweep_models(model_ids, api_key=api_key)
+    logger.info(
+        "model compatibility sweep: probed %d models (%s)",
+        len(model_ids),
+        ", ".join(f"{status}={count}" for status, count in sorted(counts.items())),
+    )
+    return counts

--- a/surfsense_backend/scripts/check_migration_flow.py
+++ b/surfsense_backend/scripts/check_migration_flow.py
@@ -95,7 +95,6 @@ async def set_version(version: str | None) -> None:
 
 async def assert_at_head() -> None:
     import asyncpg
-
     from alembic.script import ScriptDirectory
 
     head = ScriptDirectory(str(BACKEND_DIR / "alembic")).get_current_head()

--- a/surfsense_backend/scripts/create_sandbox_snapshot.py
+++ b/surfsense_backend/scripts/create_sandbox_snapshot.py
@@ -25,6 +25,7 @@ import sys
 import time
 from pathlib import Path
 
+from daytona import CreateSnapshotParams, Daytona, Resources
 from dotenv import load_dotenv
 
 _here = Path(__file__).parent
@@ -36,8 +37,6 @@ for candidate in [
     if candidate.exists():
         load_dotenv(candidate)
         break
-
-from daytona import CreateSnapshotParams, Daytona, Resources
 
 SNAPSHOT_NAME = "surfsense-sandbox"
 

--- a/surfsense_backend/scripts/probe_openrouter_dead_models.py
+++ b/surfsense_backend/scripts/probe_openrouter_dead_models.py
@@ -1,0 +1,174 @@
+"""Confirm against live OpenRouter that the models Auto keeps picking are dead.
+
+PostHog attributes ``MODEL_NOT_FOUND`` to two families:
+
+- ``:batch`` variants (``*:batch``), which OpenRouter lists in ``/models`` with
+  full chat metadata but routes to an asynchronous batch API. 1,829 of 1,829
+  generations failed.
+- Models delisted upstream since our last process restart
+  (``poolside/laguna-m.1``, ``openai/gpt-5.3-chat``).
+
+This script settles both without reading any more dashboards: it fires one
+real chat completion per suspect id and prints the HTTP status. A known-good
+control model runs alongside so a blanket 401 can never be mistaken for
+per-model 404s.
+
+Usage::
+
+    python -m scripts.probe_openrouter_dead_models              # catalogue + live calls
+    python -m scripts.probe_openrouter_dead_models --no-live    # catalogue only, free
+
+Live mode costs a few cents at most (one ``max_tokens=1`` call per model).
+Kept out of CI on purpose: the suite must not depend on OpenRouter being up.
+
+Key resolution order: ``--api-key``, ``$OPENROUTER_API_KEY``, then
+``openrouter_integration.api_key`` from the live ``global_llm_config.yaml``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_BACKEND_ROOT = os.path.dirname(_HERE)
+if _BACKEND_ROOT not in sys.path:
+    sys.path.insert(0, _BACKEND_ROOT)
+
+import httpx  # noqa: E402
+
+from app.services.openrouter_model_normalizer import (  # noqa: E402
+    is_openrouter_chat_model,
+)
+
+MODELS_URL = "https://openrouter.ai/api/v1/models"
+COMPLETIONS_URL = "https://openrouter.ai/api/v1/chat/completions"
+
+# Delisted upstream, still selectable until a restart because ``refresh()``
+# never re-materializes GLOBAL_MODELS.
+DELISTED_IDS = ("poolside/laguna-m.1", "openai/gpt-5.3-chat")
+
+# Distinguishes a per-model 404 from an account-wide auth or billing failure.
+CONTROL_ID = "openai/gpt-4o-mini"
+
+
+def _resolve_api_key(cli_key: str | None) -> str:
+    if cli_key:
+        return cli_key
+    env_key = os.environ.get("OPENROUTER_API_KEY")
+    if env_key:
+        return env_key
+    try:
+        from app.config import load_openrouter_integration_settings
+
+        settings = load_openrouter_integration_settings() or {}
+        return str(settings.get("api_key") or "")
+    except Exception as exc:
+        print(f"  (could not read global_llm_config.yaml: {exc})")
+        return ""
+
+
+async def _fetch_catalogue() -> list[dict]:
+    async with httpx.AsyncClient(timeout=30) as client:
+        resp = await client.get(MODELS_URL)
+        resp.raise_for_status()
+        return resp.json().get("data", [])
+
+
+def _report_catalogue(raw_models: list[dict]) -> list[str]:
+    """Print how many ``:batch`` variants our live filter currently admits."""
+    batch = [m for m in raw_models if str(m.get("id") or "").endswith(":batch")]
+    admitted = [m for m in batch if is_openrouter_chat_model(m)]
+
+    print(f"\ncatalogue: {len(raw_models)} models, {len(batch)} `:batch` variants")
+    print(f"  admitted by is_openrouter_chat_model: {len(admitted)}")
+    for model in admitted[:10]:
+        print(f"    {model['id']}")
+    if len(admitted) > 10:
+        print(f"    ... and {len(admitted) - 10} more")
+
+    listed = {str(m.get("id") or "") for m in raw_models}
+    for model_id in DELISTED_IDS:
+        state = "STILL LISTED" if model_id in listed else "absent (delisted)"
+        print(f"  {model_id}: {state}")
+
+    return [str(m["id"]) for m in admitted]
+
+
+async def _probe(client: httpx.AsyncClient, api_key: str, model_id: str) -> str:
+    """Fire one minimal completion and return a short status line."""
+    try:
+        resp = await client.post(
+            COMPLETIONS_URL,
+            headers={"Authorization": f"Bearer {api_key}"},
+            json={
+                "model": model_id,
+                "messages": [{"role": "user", "content": "hi"}],
+                "max_tokens": 1,
+            },
+        )
+    except Exception as exc:
+        return f"transport error: {type(exc).__name__}: {exc}"
+
+    # OpenRouter returns 200 with an ``error`` body for some routing failures,
+    # so the status code alone does not tell us whether the model answered.
+    body = resp.text[:200].replace("\n", " ")
+    if resp.status_code == 200:
+        try:
+            payload = resp.json()
+        except Exception:
+            payload = {}
+        if isinstance(payload, dict) and payload.get("error"):
+            return f"HTTP 200 but error body: {payload['error']}"
+        return "HTTP 200 OK"
+    return f"HTTP {resp.status_code}: {body}"
+
+
+async def run(*, live: bool, api_key: str) -> int:
+    raw_models = await _fetch_catalogue()
+    admitted_batch = _report_catalogue(raw_models)
+
+    if not live:
+        print("\n--no-live: skipping completion calls")
+        return 0
+
+    if not api_key:
+        print("\nNo OpenRouter API key found; cannot run live probes.")
+        return 2
+
+    targets = [CONTROL_ID, *DELISTED_IDS]
+    if admitted_batch:
+        targets.insert(1, admitted_batch[0])
+    else:
+        print("\nNo `:batch` variant passes the filter right now; probing a known id.")
+        targets.insert(1, "anthropic/claude-sonnet-4.5:batch")
+
+    print("\nlive probes:")
+    async with httpx.AsyncClient(timeout=60) as client:
+        for model_id in targets:
+            status = await _probe(client, api_key, model_id)
+            label = "control" if model_id == CONTROL_ID else "suspect"
+            print(f"  [{label}] {model_id}\n      {status}")
+
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--no-live",
+        action="store_true",
+        help="Only inspect the catalogue; make no completion calls.",
+    )
+    parser.add_argument("--api-key", default=None, help="OpenRouter API key.")
+    args = parser.parse_args()
+
+    return asyncio.run(
+        run(live=not args.no_live, api_key=_resolve_api_key(args.api_key))
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/surfsense_backend/scripts/sweep_model_compatibility.py
+++ b/surfsense_backend/scripts/sweep_model_compatibility.py
@@ -1,0 +1,131 @@
+"""CLI for the model compatibility sweep.
+
+Probes every catalogue model through three escalating stages and records
+whether it can actually serve a turn. The probes themselves live in
+``app/services/model_compatibility_sweep.py`` so the periodic Celery task runs
+exactly the same code; this file is argument parsing and output.
+
+Usage::
+
+    python -m scripts.sweep_model_compatibility --dry-run   # list targets, no calls
+    python -m scripts.sweep_model_compatibility             # sweep unchecked models
+    python -m scripts.sweep_model_compatibility --recheck   # re-probe everything
+    python -m scripts.sweep_model_compatibility --model anthropic/claude-sonnet-4.5
+
+Resumable: models with a verdict newer than ``--max-age-days`` are skipped, so
+an interrupted sweep continues where it stopped. Live-provider script, kept out
+of CI. Each probed model costs a handful of tokens.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_BACKEND_ROOT = os.path.dirname(_HERE)
+if _BACKEND_ROOT not in sys.path:
+    sys.path.insert(0, _BACKEND_ROOT)
+
+import litellm  # noqa: E402
+
+from app.services.model_compatibility import (  # noqa: E402
+    CompatibilityStatus,
+    CompatibilityVerdict,
+)
+from app.services.model_compatibility_sweep import (  # noqa: E402
+    DEFAULT_CONCURRENCY,
+    DEFAULT_MAX_AGE_DAYS,
+    fetch_catalogue_model_ids,
+    recently_checked_ids,
+    resolve_api_key,
+    sweep_models,
+)
+
+
+def _report(model_id: str, verdict: CompatibilityVerdict) -> None:
+    if verdict.status is CompatibilityStatus.OK:
+        return
+    print(
+        f"  {verdict.status.value.upper():<7} {model_id} "
+        f"[{verdict.failure_stage}] {verdict.error_code} "
+        f"{(verdict.error_excerpt or '')[:100]}"
+    )
+
+
+async def run(args: argparse.Namespace) -> int:
+    api_key = resolve_api_key()
+    if not api_key:
+        print("No OpenRouter API key (set OPENROUTER_API_KEY).")
+        return 2
+
+    model_ids = await fetch_catalogue_model_ids()
+    if args.model:
+        wanted = set(args.model)
+        # Probe explicitly named ids even when a filter already excludes them,
+        # which is what makes this usable to confirm a suspected bad model.
+        model_ids = [m for m in model_ids if m in wanted] + sorted(
+            wanted - set(model_ids)
+        )
+
+    skipped = 0
+    if not args.recheck:
+        fresh = await recently_checked_ids(args.max_age_days)
+        skipped = sum(1 for m in model_ids if m in fresh)
+        model_ids = [m for m in model_ids if m not in fresh]
+
+    if args.limit:
+        model_ids = model_ids[: args.limit]
+
+    print(
+        f"targets: {len(model_ids)} | skipped as fresh: {skipped} | "
+        f"concurrency: {args.concurrency}"
+    )
+    if args.dry_run:
+        for model_id in model_ids[:20]:
+            print(f"  {model_id}")
+        if len(model_ids) > 20:
+            print(f"  ... and {len(model_ids) - 20} more")
+        return 0
+
+    counts = await sweep_models(
+        model_ids,
+        api_key=api_key,
+        concurrency=args.concurrency,
+        on_verdict=_report,
+    )
+    print("\ndone: " + ", ".join(f"{k}={v}" for k, v in sorted(counts.items())))
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dry-run", action="store_true", help="List targets without calling providers."
+    )
+    parser.add_argument(
+        "--recheck",
+        action="store_true",
+        help="Re-probe models that already have a recent verdict.",
+    )
+    parser.add_argument(
+        "--max-age-days",
+        type=int,
+        default=DEFAULT_MAX_AGE_DAYS,
+        help="Treat verdicts newer than this as fresh and skip them.",
+    )
+    parser.add_argument("--concurrency", type=int, default=DEFAULT_CONCURRENCY)
+    parser.add_argument("--limit", type=int, default=0, help="Probe at most N models.")
+    parser.add_argument(
+        "--model", action="append", default=[], help="Probe only these model ids."
+    )
+    args = parser.parse_args()
+
+    litellm.suppress_debug_info = True
+    return asyncio.run(run(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/surfsense_backend/tests/integration/artifacts/test_roster.py
+++ b/surfsense_backend/tests/integration/artifacts/test_roster.py
@@ -64,9 +64,7 @@ async def test_roster_resolves_each_chat_from_live_config(
     monkeypatch.setattr(
         artifact_roster,
         "get_config",
-        lambda: {
-            "configurable": {"thread_id": f"{first_thread.id}::task:call-a"}
-        },
+        lambda: {"configurable": {"thread_id": f"{first_thread.id}::task:call-a"}},
     )
     first_result = await middleware.abefore_agent(state, SimpleNamespace())
     first_roster = first_result["messages"][0].content
@@ -76,9 +74,7 @@ async def test_roster_resolves_each_chat_from_live_config(
     monkeypatch.setattr(
         artifact_roster,
         "get_config",
-        lambda: {
-            "configurable": {"thread_id": f"{second_thread.id}::task:call-b"}
-        },
+        lambda: {"configurable": {"thread_id": f"{second_thread.id}::task:call-b"}},
     )
     second_result = await middleware.abefore_agent(state, SimpleNamespace())
     second_roster = second_result["messages"][0].content
@@ -122,9 +118,7 @@ async def test_roster_keeps_an_explicitly_mentioned_artifact_beyond_the_cap(
         artifact_roster,
         "get_config",
         lambda: {
-            "configurable": {
-                "thread_id": f"{artifact_thread.id}::task:call-roster"
-            }
+            "configurable": {"thread_id": f"{artifact_thread.id}::task:call-roster"}
         },
     )
     middleware = ArtifactRosterMiddleware(workspace_id=db_workspace.id)

--- a/surfsense_backend/tests/integration/artifacts/test_xlsx_artifacts.py
+++ b/surfsense_backend/tests/integration/artifacts/test_xlsx_artifacts.py
@@ -31,9 +31,7 @@ SECRET = "test-secret"
 
 MAIN_NS = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
 PKG_REL_NS = "http://schemas.openxmlformats.org/package/2006/relationships"
-OFFICE_REL_NS = (
-    "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
-)
+OFFICE_REL_NS = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
 
 
 def _xlsx_bytes(label: str) -> bytes:

--- a/surfsense_backend/tests/integration/knowledge_store/index/test_duplicate_content_convergence.py
+++ b/surfsense_backend/tests/integration/knowledge_store/index/test_duplicate_content_convergence.py
@@ -1,5 +1,4 @@
-"""Two git paths, identical bytes must converge into two rows.
-"""
+"""Two git paths, identical bytes must converge into two rows."""
 
 from __future__ import annotations
 

--- a/surfsense_backend/tests/unit/agents/multi_agent_chat/middleware/checkpointed_subagent_middleware/test_resume_decision_routing.py
+++ b/surfsense_backend/tests/unit/agents/multi_agent_chat/middleware/checkpointed_subagent_middleware/test_resume_decision_routing.py
@@ -113,14 +113,14 @@ class TestIdBasedRouting:
         decisions = [{"type": "approve", "tool_call_id": "tcid-ghost"}]
         pending = [("tcid-A", 1)]
 
-        with pytest.raises(ValueError, match="tcid-ghost|does not match"):
+        with pytest.raises(ValueError, match=r"tcid-ghost|does not match"):
             slice_decisions_by_tool_call(decisions, pending)
 
     def test_raises_on_missing_id(self):
         decisions = [{"type": "approve", "tool_call_id": "tcid-A"}]
         pending = [("tcid-A", 1), ("tcid-B", 1)]
 
-        with pytest.raises(ValueError, match="tcid-B|does not match"):
+        with pytest.raises(ValueError, match=r"tcid-B|does not match"):
             slice_decisions_by_tool_call(decisions, pending)
 
     def test_raises_on_per_id_count_mismatch(self):
@@ -130,7 +130,7 @@ class TestIdBasedRouting:
         ]
         pending = [("tcid-A", 1)]
 
-        with pytest.raises(ValueError, match="tcid-A|count"):
+        with pytest.raises(ValueError, match=r"tcid-A|count"):
             slice_decisions_by_tool_call(decisions, pending)
 
     def test_partial_ids_fall_back_to_positional(self):

--- a/surfsense_backend/tests/unit/agents/multi_agent_chat/middleware/shared/permissions/test_reject_emits_toolmessage.py
+++ b/surfsense_backend/tests/unit/agents/multi_agent_chat/middleware/shared/permissions/test_reject_emits_toolmessage.py
@@ -37,7 +37,12 @@ def _state() -> dict:
     ai = AIMessage(
         content="",
         tool_calls=[
-            {"name": "edit_file", "args": {"path": "/x"}, "id": "c1", "type": "tool_call"}
+            {
+                "name": "edit_file",
+                "args": {"path": "/x"},
+                "id": "c1",
+                "type": "tool_call",
+            }
         ],
     )
     return {"messages": [ai]}

--- a/surfsense_backend/tests/unit/agents/multi_agent_chat/middleware/test_continue_on_max_length.py
+++ b/surfsense_backend/tests/unit/agents/multi_agent_chat/middleware/test_continue_on_max_length.py
@@ -27,7 +27,7 @@ class _FakeRequest:
     model: _FakeModel
     messages: list[BaseMessage] = field(default_factory=list)
 
-    def override(self, **overrides: Any) -> "_FakeRequest":
+    def override(self, **overrides: Any) -> _FakeRequest:
         return replace(self, **overrides)
 
 
@@ -41,7 +41,11 @@ def _ai(text: str, *, out: int, finish: str | None, tool_calls=None) -> AIMessag
     return AIMessage(
         content=text,
         tool_calls=tool_calls or [],
-        usage_metadata={"input_tokens": 5, "output_tokens": out, "total_tokens": 5 + out},
+        usage_metadata={
+            "input_tokens": 5,
+            "output_tokens": out,
+            "total_tokens": 5 + out,
+        },
         response_metadata={"finish_reason": finish} if finish else {},
     )
 
@@ -110,9 +114,7 @@ async def test_truncated_tool_call_is_not_continued():
 @pytest.mark.asyncio
 async def test_respects_continuation_cap_when_model_keeps_truncating():
     mw = ContinueOnMaxLengthMiddleware(max_continuations=2)
-    handler, calls = _handler_from(
-        [_ai(c, out=24, finish="length") for c in "abcd"]
-    )
+    handler, calls = _handler_from([_ai(c, out=24, finish="length") for c in "abcd"])
     req = _FakeRequest(model=_FakeModel(max_tokens=24), messages=[HumanMessage("hi")])
 
     resp = await mw.awrap_model_call(req, handler)
@@ -170,4 +172,6 @@ async def test_continuation_context_includes_partial_and_nudge():
     resp = await mw.awrap_model_call(req, handler)
 
     assert _text(resp) == "START END"
-    assert any(isinstance(m, AIMessage) and "START" in m.content for m in seen["messages"])
+    assert any(
+        isinstance(m, AIMessage) and "START" in m.content for m in seen["messages"]
+    )

--- a/surfsense_backend/tests/unit/artifacts/test_media_record.py
+++ b/surfsense_backend/tests/unit/artifacts/test_media_record.py
@@ -28,9 +28,9 @@ def test_primary_filename_sanitizes_and_forces_extension():
     assert "\\" not in evil
     assert ".." not in evil
     assert primary_filename("  ", extension="mp3", fallback="podcast") == "podcast.mp3"
-    assert primary_filename("foo.bar baz", extension="mp3", fallback="podcast").endswith(
-        ".mp3"
-    )
+    assert primary_filename(
+        "foo.bar baz", extension="mp3", fallback="podcast"
+    ).endswith(".mp3")
     messy = primary_filename("a/b\\c:d", extension="mp3", fallback="x")
     assert "/" not in messy and "\\" not in messy and ":" not in messy
     assert messy.endswith(".mp3")
@@ -81,11 +81,7 @@ def test_image_type_follows_the_bytes_not_the_request():
 
 def test_explicit_format_beats_filename_extension():
     files = _validated_files(
-        [
-            ArtifactFileInput(
-                b"x", "clip.mp3", "audio/mpeg", ArtifactFileRole.PRIMARY
-            )
-        ]
+        [ArtifactFileInput(b"x", "clip.mp3", "audio/mpeg", ArtifactFileRole.PRIMARY)]
     )
     assert _artifact_format(files) == "mp3"
     assert _artifact_format(files, explicit=ArtifactFormat.PODCAST) == "podcast"

--- a/surfsense_backend/tests/unit/artifacts/test_media_record.py
+++ b/surfsense_backend/tests/unit/artifacts/test_media_record.py
@@ -33,9 +33,9 @@ def test_primary_filename_sanitizes_and_forces_extension():
     assert "\\" not in evil
     assert ".." not in evil
     assert primary_filename("  ", extension="mp3", fallback="podcast") == "podcast.mp3"
-    assert primary_filename("foo.bar baz", extension="mp3", fallback="podcast").endswith(
-        ".mp3"
-    )
+    assert primary_filename(
+        "foo.bar baz", extension="mp3", fallback="podcast"
+    ).endswith(".mp3")
     messy = primary_filename("a/b\\c:d", extension="mp3", fallback="x")
     assert "/" not in messy and "\\" not in messy and ":" not in messy
     assert messy.endswith(".mp3")
@@ -86,11 +86,7 @@ def test_image_type_follows_the_bytes_not_the_request():
 
 def test_explicit_format_beats_filename_extension():
     files = _validated_files(
-        [
-            ArtifactFileInput(
-                b"x", "clip.mp3", "audio/mpeg", ArtifactFileRole.PRIMARY
-            )
-        ]
+        [ArtifactFileInput(b"x", "clip.mp3", "audio/mpeg", ArtifactFileRole.PRIMARY)]
     )
     assert _artifact_format(files) == "mp3"
     assert _artifact_format(files, explicit=ArtifactFormat.PODCAST) == "podcast"

--- a/surfsense_backend/tests/unit/artifacts/test_xlsx_verification.py
+++ b/surfsense_backend/tests/unit/artifacts/test_xlsx_verification.py
@@ -16,9 +16,7 @@ WORKSPACE_ID = 7
 
 MAIN_NS = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
 PKG_REL_NS = "http://schemas.openxmlformats.org/package/2006/relationships"
-OFFICE_REL_NS = (
-    "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
-)
+OFFICE_REL_NS = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
 
 
 def _xlsx(*, sheet_body: str, sheet_count: int = 1) -> bytes:
@@ -70,9 +68,7 @@ def test_clean_xlsx_and_registry():
 
 
 def test_formula_with_cached_value_passes():
-    result = check_xlsx(
-        _xlsx(sheet_body='<c r="B1"><f>SUM(A1)</f><v>10</v></c>')
-    )
+    result = check_xlsx(_xlsx(sheet_body='<c r="B1"><f>SUM(A1)</f><v>10</v></c>'))
     assert result.clean
 
 
@@ -137,9 +133,7 @@ async def test_verify_xlsx_structural_only_skips_render_and_vision():
         vision_llm=object(),
         secret_key=SECRET,
     )
-    receipt = await read_receipt(
-        session, SECRET, workspace_id=WORKSPACE_ID
-    )
+    receipt = await read_receipt(session, SECRET, workspace_id=WORKSPACE_ID)
 
     assert result.verified
     assert result.preview_path is None

--- a/surfsense_backend/tests/unit/services/test_auto_pin_dead_model_simulation.py
+++ b/surfsense_backend/tests/unit/services/test_auto_pin_dead_model_simulation.py
@@ -1,0 +1,143 @@
+"""Auto must never pin a model that cannot serve a chat completion.
+
+This drives the real selection path — ``_generate_configs`` ->
+``materialize_global_model_catalog`` -> ``_global_candidates`` ->
+``_select_pin`` — across thousands of synthetic thread ids, and counts how
+many threads land on a ``:batch`` variant.
+
+Two scenarios, because the failure is episodic rather than constant.
+``_select_pin`` is lock-first: it only considers Tier B (dynamic OpenRouter)
+when no Tier A (operator-curated YAML) config is eligible. So Tier A healthy
+hides the bug entirely, and Tier A in runtime cooldown exposes it. That is why
+production saw multi-day quiet gaps between bursts of MODEL_NOT_FOUND.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.auto_model_pin_service import _global_candidates, _select_pin
+from app.services.global_model_catalog import materialize_global_model_catalog
+from app.services.openrouter_integration_service import _generate_configs
+
+pytestmark = pytest.mark.unit
+
+THREAD_COUNT = 2_000
+
+# Frontier ids with their real shape: a `:batch` twin priced at half the
+# base model. Both carry identical capability metadata upstream, which is
+# what lets the batch variant tie with its twin and share the shortlist.
+_FRONTIER = [
+    ("anthropic/claude-sonnet-4.5", "0.000003", "0.000015"),
+    ("google/gemini-3.6-flash", "0.0000003", "0.0000025"),
+    ("openai/gpt-5.6-terra", "0.00000125", "0.00001"),
+    ("x-ai/grok-4", "0.000003", "0.000015"),
+]
+
+
+def _or_model(model_id: str, prompt: str, completion: str) -> dict:
+    return {
+        "id": model_id,
+        "name": model_id,
+        "architecture": {"output_modalities": ["text"], "input_modalities": ["text"]},
+        "supported_parameters": ["tools", "structured_outputs", "reasoning"],
+        "context_length": 1_000_000,
+        "pricing": {"prompt": prompt, "completion": completion},
+    }
+
+
+def _openrouter_payload() -> list[dict]:
+    payload: list[dict] = []
+    for model_id, prompt, completion in _FRONTIER:
+        payload.append(_or_model(model_id, prompt, completion))
+        payload.append(
+            _or_model(
+                f"{model_id}:batch",
+                str(float(prompt) / 2),
+                str(float(completion) / 2),
+            )
+        )
+    return payload
+
+
+def _yaml_configs() -> list[dict]:
+    """Stand-ins for the operator-curated Azure entries that hold Tier A."""
+    return [
+        {
+            "id": -1 - index,
+            "name": model_name,
+            "provider": "azure",
+            "model_name": model_name,
+            "api_key": "azure-key",
+            "api_base": "https://example.openai.azure.com",
+            "billing_tier": "premium",
+            "auto_pin_tier": "A",
+            "quality_score": 85,
+            "quality_score_static": 85,
+            "supports_tools": True,
+            "supports_image_input": True,
+        }
+        for index, model_name in enumerate(
+            ("azure/gpt-5.4", "azure/gpt-5.4-mini", "azure/gpt-5.3")
+        )
+    ]
+
+
+@pytest.fixture
+def catalogue(monkeypatch):
+    """Install a realistic mixed catalogue into the config globals."""
+    from app.config import config as app_config
+
+    chat_configs = _yaml_configs() + _generate_configs(
+        _openrouter_payload(),
+        {
+            "api_key": "sk-or-test",
+            "id_offset": -10_000,
+            "rpm": 200,
+            "tpm": 1_000_000,
+            "quota_reserve_tokens": 4000,
+        },
+    )
+    connections, models = materialize_global_model_catalog(
+        chat_configs=chat_configs, image_configs=[]
+    )
+    monkeypatch.setattr(app_config, "GLOBAL_LLM_CONFIGS", chat_configs)
+    monkeypatch.setattr(app_config, "GLOBAL_CONNECTIONS", connections)
+    monkeypatch.setattr(app_config, "GLOBAL_MODELS", models)
+    return chat_configs
+
+
+def _simulate(*, cooled_down_ids: set[int]) -> list[str]:
+    """Return the model id pinned for each of ``THREAD_COUNT`` new threads."""
+    candidates = _global_candidates(
+        capability="chat", shared_cooled_down_ids=cooled_down_ids
+    )
+    assert candidates, "fixture produced no Auto candidates"
+    return [
+        _select_pin(candidates, thread_id)[0]["model_id"]
+        for thread_id in range(1, THREAD_COUNT + 1)
+    ]
+
+
+def _batch_share(picks: list[str]) -> float:
+    return sum(1 for pick in picks if pick.endswith(":batch")) / len(picks)
+
+
+def test_no_batch_pin_when_tier_a_is_healthy(catalogue):
+    picks = _simulate(cooled_down_ids=set())
+
+    assert _batch_share(picks) == 0.0
+
+
+def test_no_batch_pin_when_tier_a_is_cooled_down(catalogue):
+    """The fallthrough case: every curated config is in runtime cooldown."""
+    tier_a_ids = {
+        int(cfg["id"]) for cfg in catalogue if cfg.get("auto_pin_tier") == "A"
+    }
+
+    picks = _simulate(cooled_down_ids=tier_a_ids)
+
+    assert _batch_share(picks) == 0.0, (
+        f"{_batch_share(picks):.0%} of threads pinned a `:batch` variant, "
+        "which OpenRouter answers with 404"
+    )

--- a/surfsense_backend/tests/unit/services/test_blocklist_surfaces.py
+++ b/surfsense_backend/tests/unit/services/test_blocklist_surfaces.py
@@ -1,0 +1,82 @@
+"""A blocklisted model must be unreachable from every surface a user has.
+
+The compatibility sweep is only worth running if its verdict actually removes
+the model. There are three ways a user reaches one — the generated catalogue,
+Auto's candidate pool, and the model picker payload — and all three read from
+the same globals, so this asserts each one independently rather than trusting
+that they stay wired together.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.routes.model_connections_routes import list_global_connections
+from app.services.auto_model_pin_service import _global_candidates
+from app.services.global_model_catalog import materialize_global_model_catalog
+from app.services.openrouter_integration_service import _generate_configs
+
+pytestmark = pytest.mark.unit
+
+BLOCKED_ID = "some-provider/rejects-tool-results"
+HEALTHY_ID = "anthropic/claude-sonnet-4.5"
+
+_SETTINGS = {
+    "api_key": "sk-or-test",
+    "id_offset": -10_000,
+    "rpm": 200,
+    "tpm": 1_000_000,
+    "quota_reserve_tokens": 4000,
+}
+
+
+def _or_model(model_id: str) -> dict:
+    return {
+        "id": model_id,
+        "name": model_id,
+        "architecture": {"output_modalities": ["text"], "input_modalities": ["text"]},
+        "supported_parameters": ["tools"],
+        "context_length": 1_000_000,
+        "pricing": {"prompt": "0.000003", "completion": "0.000015"},
+    }
+
+
+@pytest.fixture
+def catalogue(monkeypatch):
+    """Build the live globals from a payload with one blocklisted model."""
+    from app.config import config as app_config
+
+    chat_configs = _generate_configs(
+        [_or_model(HEALTHY_ID), _or_model(BLOCKED_ID)],
+        _SETTINGS,
+        {BLOCKED_ID},
+    )
+    connections, models = materialize_global_model_catalog(
+        chat_configs=chat_configs, image_configs=[]
+    )
+    monkeypatch.setattr(app_config, "GLOBAL_LLM_CONFIGS", chat_configs)
+    monkeypatch.setattr(app_config, "GLOBAL_CONNECTIONS", connections)
+    monkeypatch.setattr(app_config, "GLOBAL_MODELS", models)
+    return chat_configs
+
+
+def test_blocked_model_is_absent_from_the_generated_catalogue(catalogue):
+    model_names = {cfg["model_name"] for cfg in catalogue}
+
+    assert HEALTHY_ID in model_names, "fixture removed the wrong model"
+    assert BLOCKED_ID not in model_names
+
+
+def test_blocked_model_is_absent_from_auto_candidates(catalogue):
+    candidates = _global_candidates(capability="chat", shared_cooled_down_ids=set())
+
+    assert {c["model_id"] for c in candidates} == {HEALTHY_ID}
+
+
+@pytest.mark.asyncio
+async def test_blocked_model_is_absent_from_the_picker_payload(catalogue):
+    connections = await list_global_connections(auth=None)
+
+    offered = {model.model_id for conn in connections for model in (conn.models or [])}
+    assert HEALTHY_ID in offered
+    assert BLOCKED_ID not in offered

--- a/surfsense_backend/tests/unit/services/test_model_compatibility.py
+++ b/surfsense_backend/tests/unit/services/test_model_compatibility.py
@@ -1,0 +1,100 @@
+"""Golden cases for the compatibility sweep's verdict.
+
+The sweep decides which models users are allowed to reach, so it needs its own
+tests before it is trusted to blocklist anything: wrongly marking a working
+model dead is worse than not sweeping at all.
+
+The error bodies below are verbatim from live OpenRouter responses captured by
+``scripts/probe_openrouter_dead_models.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.model_compatibility import (
+    CompatibilityStatus,
+    ProbeStage,
+    classify_probe_failure,
+    verdict_from_stages,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class _ProviderError(Exception):
+    """Stands in for the litellm exception, which carries the body in str()."""
+
+
+BATCH_404 = _ProviderError(
+    '{"error":{"message":"This model is only available through the Batch API. '
+    'Use the /api/beta/batches endpoint instead.","code":404}}'
+)
+DELISTED_404 = _ProviderError(
+    '{"error":{"message":"No endpoints found for poolside/laguna-m.1.","code":404}}'
+)
+RATE_LIMITED = _ProviderError('{"error":{"message":"Rate limit exceeded","code":429}}')
+UPSTREAM_502 = _ProviderError('{"error":{"message":"Bad gateway","code":502}}')
+BAD_KEY_401 = _ProviderError(
+    '{"error":{"message":"No auth credentials found","code":401}}'
+)
+
+
+def test_batch_variant_is_blocked():
+    status, code = classify_probe_failure(BATCH_404)
+
+    assert status is CompatibilityStatus.BLOCKED
+    assert code == "model_not_found"
+
+
+def test_delisted_model_is_blocked():
+    status, _ = classify_probe_failure(DELISTED_404)
+
+    assert status is CompatibilityStatus.BLOCKED
+
+
+@pytest.mark.parametrize("exc", [RATE_LIMITED, UPSTREAM_502])
+def test_transient_failures_never_blocklist(exc):
+    """A busy or briefly broken provider must not cost a model its listing."""
+    status, _ = classify_probe_failure(exc)
+
+    assert status is CompatibilityStatus.UNKNOWN
+
+
+def test_auth_failure_never_blocklists():
+    """A bad key fails every model at once; blocklisting on it empties the
+    catalogue in one sweep."""
+    status, _ = classify_probe_failure(BAD_KEY_401)
+
+    assert status is CompatibilityStatus.UNKNOWN
+
+
+def test_known_good_model_passes_every_stage():
+    verdict = verdict_from_stages(dict.fromkeys(ProbeStage))
+
+    assert verdict.status is CompatibilityStatus.OK
+    assert verdict.failure_stage is None
+    assert verdict.error_code is None
+
+
+def test_verdict_reports_the_first_failing_stage():
+    verdict = verdict_from_stages(
+        {
+            ProbeStage.STREAM: None,
+            ProbeStage.TOOL_BIND: BATCH_404,
+            ProbeStage.TOOL_RESULT: None,
+        }
+    )
+
+    assert verdict.status is CompatibilityStatus.BLOCKED
+    assert verdict.failure_stage is ProbeStage.TOOL_BIND
+    assert "Batch API" in (verdict.error_excerpt or "")
+
+
+def test_unknown_at_any_stage_does_not_become_ok():
+    verdict = verdict_from_stages(
+        {ProbeStage.STREAM: RATE_LIMITED, ProbeStage.TOOL_BIND: None}
+    )
+
+    assert verdict.status is CompatibilityStatus.UNKNOWN
+    assert verdict.failure_stage is ProbeStage.STREAM

--- a/surfsense_backend/tests/unit/services/test_openrouter_catalogue_integrity.py
+++ b/surfsense_backend/tests/unit/services/test_openrouter_catalogue_integrity.py
@@ -1,0 +1,129 @@
+"""Guard the two ways a user can reach a model that cannot answer.
+
+Both were confirmed live against OpenRouter (see
+``scripts/probe_openrouter_dead_models.py``):
+
+- ``*:batch`` ids are listed in ``/models`` with full chat metadata but reject
+  chat completions with ``404 "This model is only available through the Batch
+  API"``. 59 of the 61 batch variants in the live catalogue passed our filter.
+- ``refresh()`` rewrites ``GLOBAL_LLM_CONFIGS`` but never re-materializes
+  ``GLOBAL_MODELS``, which is what the picker and ``load_llm_bundle`` actually
+  read, so a model delisted upstream stays selectable until the next restart.
+
+These assert on the generated catalogue rather than on the filter helpers,
+because an earlier fix edited a filter that nothing calls and looked correct.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.openrouter_integration_service import (
+    OpenRouterIntegrationService,
+    _generate_configs,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def _model(model_id: str, *, name: str | None = None) -> dict:
+    """A synthetic ``/api/v1/models`` entry that passes every other filter."""
+    return {
+        "id": model_id,
+        "name": name or model_id,
+        "architecture": {"output_modalities": ["text"], "input_modalities": ["text"]},
+        "supported_parameters": ["tools"],
+        "context_length": 200_000,
+        "pricing": {"prompt": "0.000003", "completion": "0.000015"},
+    }
+
+
+_SETTINGS: dict = {
+    "api_key": "sk-or-test",
+    "id_offset": -10_000,
+    "rpm": 200,
+    "tpm": 1_000_000,
+    "free_rpm": 20,
+    "free_tpm": 100_000,
+    "quota_reserve_tokens": 4000,
+}
+
+
+def test_generate_configs_excludes_batch_variants():
+    """A ``:batch`` id must never become a config; its full-price twin must."""
+    raw = [
+        _model("anthropic/claude-sonnet-4.5"),
+        _model("anthropic/claude-sonnet-4.5:batch"),
+        _model("google/gemini-3.6-flash:batch"),
+    ]
+
+    model_names = {c["model_name"] for c in _generate_configs(raw, dict(_SETTINGS))}
+
+    assert model_names == {"anthropic/claude-sonnet-4.5"}
+
+
+def test_generate_configs_keeps_free_variant():
+    """``:free`` is a real routable variant — the batch filter must not eat it."""
+    raw = [
+        _model("meta-llama/llama-3.3-70b-instruct:free"),
+        _model("meta-llama/llama-3.3-70b-instruct:batch"),
+    ]
+
+    model_names = {c["model_name"] for c in _generate_configs(raw, dict(_SETTINGS))}
+
+    assert model_names == {"meta-llama/llama-3.3-70b-instruct:free"}
+
+
+@pytest.mark.asyncio
+async def test_refresh_rematerializes_global_models(monkeypatch):
+    """After ``refresh()``, GLOBAL_MODELS must track GLOBAL_LLM_CONFIGS.
+
+    A model delisted upstream has to disappear from the catalogue the picker
+    reads, and a newly listed one has to appear, without waiting for a restart.
+    """
+    from app.config import config as app_config, refresh_global_model_catalog
+
+    service = OpenRouterIntegrationService()
+    service._settings = dict(_SETTINGS)
+
+    async def _no_health(*_args, **_kwargs) -> None:
+        return None
+
+    monkeypatch.setattr(service, "_enrich_health_safely", _no_health)
+    monkeypatch.setattr(
+        "app.services.pricing_registration.register_pricing_from_global_configs",
+        lambda *a, **kw: None,
+    )
+    monkeypatch.setattr(
+        "app.services.llm_router_service.LLMRouterService.rebuild",
+        lambda *a, **kw: None,
+    )
+
+    # Boot state: two models live, catalogue materialized as it is at startup.
+    boot = [_model("openai/gpt-4o"), _model("poolside/laguna-m.1")]
+    monkeypatch.setattr(app_config, "GLOBAL_LLM_CONFIGS", [])
+    monkeypatch.setattr(app_config, "GLOBAL_IMAGE_GEN_CONFIGS", [])
+    monkeypatch.setattr(app_config, "GLOBAL_CONNECTIONS", [])
+    monkeypatch.setattr(app_config, "GLOBAL_MODELS", [])
+    app_config.GLOBAL_LLM_CONFIGS = _generate_configs(boot, dict(_SETTINGS))
+    refresh_global_model_catalog()
+
+    assert {m["model_id"] for m in app_config.GLOBAL_MODELS} == {
+        "openai/gpt-4o",
+        "poolside/laguna-m.1",
+    }
+
+    # Upstream drops laguna and lists a new model.
+    async def _fetch(*_args, **_kwargs):
+        return [_model("openai/gpt-4o"), _model("x-ai/grok-4")]
+
+    monkeypatch.setattr(
+        "app.services.openrouter_integration_service._fetch_models_async", _fetch
+    )
+
+    await service.refresh()
+
+    assert {m["model_id"] for m in app_config.GLOBAL_MODELS} == {
+        "openai/gpt-4o",
+        "x-ai/grok-4",
+    }

--- a/surfsense_backend/tests/unit/services/test_supports_image_input.py
+++ b/surfsense_backend/tests/unit/services/test_supports_image_input.py
@@ -21,7 +21,9 @@ import pytest
 from app.services.openrouter_integration_service import (
     _OPENROUTER_DYNAMIC_MARKER,
     _generate_configs,
-    _supports_image_input,
+)
+from app.services.openrouter_model_normalizer import (
+    supports_image_input as _supports_image_input,
 )
 
 pytestmark = pytest.mark.unit

--- a/surfsense_backend/tests/unit/services/test_vercel_interrupt_id.py
+++ b/surfsense_backend/tests/unit/services/test_vercel_interrupt_id.py
@@ -23,8 +23,11 @@ def _payload(frame: str) -> dict:
 
 def test_interrupt_id_present_when_supplied() -> None:
     frame = VercelStreamingService().format_interrupt_request(
-        {"type": "permission_ask", "action": {"tool": "search", "params": {}},
-         "context": {"permission": "doom_loop"}},
+        {
+            "type": "permission_ask",
+            "action": {"tool": "search", "params": {}},
+            "context": {"permission": "doom_loop"},
+        },
         interrupt_id="int_7",
     )
     assert _payload(frame)["interrupt_id"] == "int_7"

--- a/surfsense_backend/tests/unit/tasks/chat/streaming/flows/resume_chat/test_resume_routing.py
+++ b/surfsense_backend/tests/unit/tasks/chat/streaming/flows/resume_chat/test_resume_routing.py
@@ -40,9 +40,7 @@ def _doom_loop_interrupt(interrupt_id: str):
 async def test_parent_side_doom_loop_interrupt_is_routable():
     """Decision routes to the doom-loop's ``Interrupt.id`` as a raw dict, not a bundle."""
     decision = {"type": "reject"}
-    agent = _FakeAgent(
-        SimpleNamespace(interrupts=(_doom_loop_interrupt("i-doom"),))
-    )
+    agent = _FakeAgent(SimpleNamespace(interrupts=(_doom_loop_interrupt("i-doom"),)))
 
     routing = await build_resume_routing(agent, chat_id=42, decisions=[decision])
 

--- a/surfsense_backend/tests/unit/tasks/chat/streaming/test_interrupt_inspector_all.py
+++ b/surfsense_backend/tests/unit/tasks/chat/streaming/test_interrupt_inspector_all.py
@@ -9,6 +9,8 @@ that contract against a **real** paused parent graph built via
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 from langchain.tools import ToolRuntime
 from langchain_core.messages import AIMessage, HumanMessage
@@ -21,8 +23,6 @@ from typing_extensions import TypedDict
 from app.agents.chat.multi_agent_chat.main_agent.middleware.checkpointed_subagent_middleware.task_tool import (
     build_task_tool_with_parent_config,
 )
-from types import SimpleNamespace
-
 from app.tasks.chat.streaming.helpers.interrupt_inspector import (
     all_interrupt_entries,
     all_interrupt_values,
@@ -85,7 +85,9 @@ class TestAllInterruptEntries:
     def test_pairs_value_with_id_from_state_interrupts(self):
         state = SimpleNamespace(
             interrupts=(
-                SimpleNamespace(id="i-1", value={"context": {"permission": "doom_loop"}}),
+                SimpleNamespace(
+                    id="i-1", value={"context": {"permission": "doom_loop"}}
+                ),
                 SimpleNamespace(id="i-2", value={"tool_call_id": "tcid-A"}),
             )
         )
@@ -98,7 +100,9 @@ class TestAllInterruptEntries:
     def test_prefers_task_bucket_interrupts(self):
         state = SimpleNamespace(
             tasks=(
-                SimpleNamespace(interrupts=(SimpleNamespace(id="t-1", value={"a": 1}),)),
+                SimpleNamespace(
+                    interrupts=(SimpleNamespace(id="t-1", value={"a": 1}),)
+                ),
             ),
             interrupts=(SimpleNamespace(id="ignored", value={"b": 2}),),
         )
@@ -118,9 +122,7 @@ class TestAllInterruptEntries:
         assert all_interrupt_entries(state) == [({"a": 1}, None)]
 
     def test_values_helper_derives_from_entries(self):
-        state = SimpleNamespace(
-            interrupts=(SimpleNamespace(id="i-1", value={"a": 1}),)
-        )
+        state = SimpleNamespace(interrupts=(SimpleNamespace(id="i-1", value={"a": 1}),))
 
         assert all_interrupt_values(state) == [{"a": 1}]
 

--- a/surfsense_backend/tests/unit/tasks/chat/streaming/test_pin_missing_from_catalogue.py
+++ b/surfsense_backend/tests/unit/tasks/chat/streaming/test_pin_missing_from_catalogue.py
@@ -1,0 +1,219 @@
+"""A pin this worker cannot resolve must not end the turn.
+
+Production runs ``UVICORN_WORKERS=4``. Uvicorn preforks, so each worker runs
+``lifespan`` independently: four separate OpenRouter fetches at boot, four
+24h refresh loops drifting by boot time, four in-memory catalogues. Pins live
+in Postgres and are shared, so worker A can pin a config id that is missing
+from worker B's ``GLOBAL_MODELS`` — either because B's boot fetch failed and
+left it with YAML configs only, or because the two workers refreshed either
+side of an upstream delisting.
+
+These drive the orchestrator's real sequence (resolve the pin, then load the
+bundle) against a catalogue that is missing the pinned id.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+import app.tasks.chat.streaming.flows.shared.llm_bundle as llm_bundle
+from app.services.auto_model_pin_service import (
+    clear_healthy,
+    clear_runtime_cooldown,
+)
+from app.tasks.chat.streaming.flows.new_chat.auto_pin import resolve_initial_auto_pin
+
+pytestmark = pytest.mark.unit
+
+WORKSPACE_ID = 10
+# Pinned by another worker, absent from this worker's catalogue.
+FOREIGN_PIN_ID = -4242
+
+
+class _FakeRedis:
+    def set(self, *_args, **_kwargs):
+        return True
+
+    def mget(self, keys: list[str]):
+        return [None for _ in keys]
+
+    def delete(self, *_keys):
+        return 0
+
+    def scan_iter(self, _pattern: str):
+        return iter(())
+
+
+class _FakeExecResult:
+    def __init__(self, *, thread=None, scalars=None):
+        self._thread = thread
+        self._scalars = scalars or []
+
+    def unique(self):
+        return self
+
+    def scalar_one_or_none(self):
+        return self._thread
+
+    def scalars(self):
+        return SimpleNamespace(all=lambda: self._scalars, first=lambda: None)
+
+
+class _FakeSession:
+    """Returns the thread for the first query, no DB models for the rest."""
+
+    def __init__(self, thread):
+        self.thread = thread
+        self.executes = 0
+
+    async def execute(self, _stmt):
+        self.executes += 1
+        if self.executes == 1:
+            return _FakeExecResult(thread=self.thread)
+        return _FakeExecResult(scalars=[])
+
+    async def commit(self):
+        return None
+
+
+@pytest.fixture(autouse=True)
+def _catalogue(monkeypatch):
+    """This worker's catalogue: two healthy models, neither is the pin."""
+    import app.services.auto_model_pin_service as pin_service
+    from app.config import config as app_config
+
+    monkeypatch.setattr(pin_service, "_runtime_cooldown_redis", _FakeRedis())
+    clear_runtime_cooldown()
+    clear_healthy()
+
+    configs = [
+        {
+            "id": -1,
+            "name": "Curated Premium",
+            "provider": "azure",
+            "model_name": "azure/gpt-5.4",
+            "api_key": "azure-key",
+            "billing_tier": "premium",
+            "auto_pin_tier": "A",
+            "quality_score": 90,
+        },
+        {
+            "id": -2,
+            "name": "Curated Free",
+            "provider": "azure",
+            "model_name": "azure/gpt-5.4-mini",
+            "api_key": "azure-key-2",
+            "billing_tier": "free",
+            "auto_pin_tier": "A",
+            "quality_score": 70,
+        },
+    ]
+    connections = [
+        {
+            "id": -100 - index,
+            "provider": cfg["provider"],
+            "api_key": cfg["api_key"],
+            "base_url": None,
+            "extra": {},
+            "scope": "GLOBAL",
+            "enabled": True,
+        }
+        for index, cfg in enumerate(configs)
+    ]
+    models = [
+        {
+            "id": cfg["id"],
+            "connection_id": -100 - index,
+            "model_id": cfg["model_name"],
+            "display_name": cfg["name"],
+            "supports_chat": True,
+            "supports_tools": True,
+            "supports_image_input": True,
+            "supports_image_generation": False,
+            "capabilities_override": {},
+            "enabled": True,
+            "billing_tier": cfg["billing_tier"],
+            "catalog": {},
+        }
+        for index, cfg in enumerate(configs)
+    ]
+
+    monkeypatch.setattr(app_config, "GLOBAL_LLM_CONFIGS", configs)
+    monkeypatch.setattr(app_config, "GLOBAL_CONNECTIONS", connections)
+    monkeypatch.setattr(app_config, "GLOBAL_MODELS", models)
+
+    async def _fake_workspace(_session: Any, _workspace_id: int):
+        return SimpleNamespace(id=WORKSPACE_ID, user_id="user-1")
+
+    monkeypatch.setattr(llm_bundle, "_load_workspace", _fake_workspace)
+    monkeypatch.setattr(llm_bundle, "register_model_usage_metadata", lambda **_kw: None)
+    monkeypatch.setattr(
+        llm_bundle, "to_litellm", lambda _conn, model_id: (model_id, {"api_key": "k"})
+    )
+
+    yield
+
+    clear_runtime_cooldown()
+    clear_healthy()
+
+
+async def _resolve_and_load(*, selected_llm_config_id: int):
+    """Mirror the orchestrator: resolve the pin, then load the bundle."""
+    session = _FakeSession(
+        SimpleNamespace(
+            id=1,
+            workspace_id=WORKSPACE_ID,
+            pinned_llm_config_id=FOREIGN_PIN_ID,
+        )
+    )
+    pin_result = await resolve_initial_auto_pin(
+        session,
+        chat_id=1,
+        workspace_id=WORKSPACE_ID,
+        user_id="00000000-0000-0000-0000-000000000001",
+        selected_llm_config_id=selected_llm_config_id,
+        requires_image_input=False,
+        requested_llm_config_id=selected_llm_config_id,
+    )
+    if pin_result.error is not None:
+        return pin_result.error[0], None
+    _, _, load_error = await llm_bundle.load_llm_bundle(
+        session,
+        config_id=pin_result.llm_config_id,
+        workspace_id=WORKSPACE_ID,
+    )
+    return load_error, pin_result.llm_config_id
+
+
+async def test_auto_repins_when_the_pin_is_missing_here(monkeypatch):
+    """Auto already self-heals: an unresolvable pin drops out of the pool."""
+    monkeypatch.setattr(
+        "app.services.auto_model_pin_service.TokenQuotaService.credit_get_usage",
+        lambda *_a, **_kw: _allowed(),
+    )
+
+    error, resolved_id = await _resolve_and_load(selected_llm_config_id=0)
+
+    assert error is None
+    assert resolved_id in {-1, -2}
+
+
+async def test_explicit_selection_of_a_missing_model_recovers():
+    """The gap Auto does not cover.
+
+    A workspace-level ``chat_model_id`` bypasses the Auto pool entirely, so a
+    config id this worker never materialized used to go straight to the bundle
+    loader and end the turn with SERVER_ERROR — while the identical request
+    succeeded on a sibling worker, which is what made it look intermittent.
+    """
+    error, resolved_id = await _resolve_and_load(selected_llm_config_id=FOREIGN_PIN_ID)
+
+    assert error is None, f"turn ended with {error!r} instead of recovering"
+    assert resolved_id in {-1, -2}
+
+
+async def _allowed():
+    return SimpleNamespace(allowed=True)

--- a/surfsense_mcp/tests/test_update_document.py
+++ b/surfsense_mcp/tests/test_update_document.py
@@ -21,9 +21,7 @@ from mcp_server.features.knowledge_base import document_tools
 def _client_recording(calls: list[dict]) -> SurfSenseClient:
     async def handler(request: httpx.Request) -> httpx.Response:
         body = request.content.decode() or ""
-        calls.append(
-            {"method": request.method, "path": request.url.path, "body": body}
-        )
+        calls.append({"method": request.method, "path": request.url.path, "body": body})
         if request.method == "GET":
             return httpx.Response(
                 200,

--- a/surfsense_web/atoms/user/user-query.atoms.ts
+++ b/surfsense_web/atoms/user/user-query.atoms.ts
@@ -13,7 +13,9 @@ export const currentUserAtom = atomWithQuery(() => {
 		// needs to fire once per session for the static profile fields.
 		staleTime: Infinity,
 		enabled: isAuthenticated(),
-		retry: false,
+		// No `retry: false` here: paired with `staleTime: Infinity`, one dropped
+		// connection would leave the profile blank for the whole session. The
+		// shared predicate already refuses to retry a 401.
 		queryFn: userQueryFn,
 	};
 });

--- a/surfsense_web/lib/apis/base-api.service.ts
+++ b/surfsense_web/lib/apis/base-api.service.ts
@@ -40,17 +40,40 @@ function blockRefreshRetry(key: string): void {
 	refreshRetryBlockedUntil.set(key, Date.now() + REFRESH_RETRY_BLOCK_MS);
 }
 
+// One dropped connection fails every in-flight request and each query retry,
+// so an unthrottled capture reports a single blip as dozens of events. Keeping
+// the first per endpoint per window preserves which endpoints were affected
+// while making the per-session count mean something.
+const CAPTURE_DEDUPE_MS = 30_000;
+const lastCapturedAt = new Map<string, number>();
+
+function isDuplicateCapture(key: string): boolean {
+	const now = Date.now();
+	const previous = lastCapturedAt.get(key);
+	if (previous !== undefined && now - previous < CAPTURE_DEDUPE_MS) return true;
+	lastCapturedAt.set(key, now);
+	return false;
+}
+
 /**
  * Send an API failure to PostHog error tracking. Scoped by the caller to only
  * 5xx server faults + network outages — 4xx responses are expected behavior.
  * Lazy-imports posthog-js so an ad-blocker can never break the request path.
  */
 function captureApiException(error: unknown, url: string, method?: RequestOptions["method"]): void {
+	const code = error instanceof AppError ? error.code : undefined;
+	if (code === "NETWORK_ERROR" && isDuplicateCapture(`${method ?? "GET"}:${url}`)) return;
+
 	import("posthog-js")
 		.then(({ default: posthog }) => {
 			posthog.captureException(error, {
 				api_url: url,
 				api_method: method ?? "GET",
+				// `api_url` is relative, so our own backend misconfiguration and a
+				// user simply being offline used to look identical in PostHog.
+				api_host: safeHost(buildBackendUrl(url)),
+				client_platform: typeof window === "undefined" ? "web" : getClientPlatform(),
+				navigator_online: typeof navigator === "undefined" ? null : navigator.onLine,
 				...(error instanceof AppError && {
 					status_code: error.status,
 					status_text: error.statusText,
@@ -62,6 +85,14 @@ function captureApiException(error: unknown, url: string, method?: RequestOption
 		.catch(() => {
 			console.error("Failed to capture exception in PostHog");
 		});
+}
+
+function safeHost(url: string): string | null {
+	try {
+		return new URL(url, typeof window === "undefined" ? undefined : window.location.origin).host;
+	} catch {
+		return null;
+	}
 }
 
 export type RequestOptions = {

--- a/surfsense_web/lib/auth-errors.ts
+++ b/surfsense_web/lib/auth-errors.ts
@@ -212,6 +212,11 @@ export function shouldRetry(errorCode: string): boolean {
 		"temporarily_unavailable",
 	];
 
+	// Callers pass `err.message` as often as `err.code`, and a NetworkError's
+	// message is a full sentence — so matching codes alone silently drops the
+	// retry button from exactly the failure retrying is for.
+	if (isNetworkError(errorCode)) return true;
+
 	return retryableCodes.some(
 		(code) => errorCode.includes(code) || errorCode.toUpperCase().includes(code)
 	);

--- a/surfsense_web/lib/error-toast.ts
+++ b/surfsense_web/lib/error-toast.ts
@@ -67,6 +67,10 @@ export function showErrorToast(error: unknown, fallbackMessage?: string) {
 	if (requestId) descParts.push(`ID: ${requestId}`);
 
 	toast.error(message, {
+		// A dropped connection fails every in-flight query at once, and each one
+		// lands here separately. A shared id makes sonner replace rather than
+		// stack, so one blip reads as one problem instead of ten.
+		id: code === "NETWORK_ERROR" ? "network-error" : undefined,
 		description: descParts.length > 0 ? descParts.join(" | ") : undefined,
 		duration: 8000,
 		action: {

--- a/surfsense_web/lib/query-client/client.ts
+++ b/surfsense_web/lib/query-client/client.ts
@@ -1,11 +1,13 @@
 import { MutationCache, QueryCache, QueryClient } from "@tanstack/react-query";
 import { showErrorToast } from "../error-toast";
+import { shouldRetryQuery } from "./retry";
 
 export const queryClient = new QueryClient({
 	defaultOptions: {
 		queries: {
 			staleTime: 30_000,
 			refetchOnWindowFocus: false,
+			retry: shouldRetryQuery,
 		},
 	},
 	queryCache: new QueryCache({

--- a/surfsense_web/lib/query-client/retry.ts
+++ b/surfsense_web/lib/query-client/retry.ts
@@ -1,0 +1,21 @@
+import { AppError } from "../error";
+
+/** Attempts after the first, so 2 means three tries in total. */
+export const MAX_QUERY_RETRIES = 2;
+
+/**
+ * Retry only failures a second attempt could plausibly fix.
+ *
+ * TanStack's default retries any error three times, which is wrong in both
+ * directions: a 403 or a validation error is retried pointlessly (delaying the
+ * message the user needs), while individual queries opting out with
+ * `retry: false` lose the one case retrying exists for — a dropped connection.
+ * A single blip then leaves that query permanently failed for the session.
+ */
+export function shouldRetryQuery(failureCount: number, error: unknown): boolean {
+	if (failureCount >= MAX_QUERY_RETRIES) return false;
+	if (!(error instanceof AppError)) return false;
+	// A NetworkError never reached a server, so it carries no status.
+	if (error.status === undefined) return error.code === "NETWORK_ERROR";
+	return error.status >= 500;
+}

--- a/surfsense_web/tests/smoke/network-error-burst.spec.ts
+++ b/surfsense_web/tests/smoke/network-error-burst.spec.ts
@@ -1,0 +1,70 @@
+import { expect, test } from "../fixtures";
+
+/**
+ * One network blip should cost the user one error, not a stack of them.
+ *
+ * A dashboard load fans out roughly ten parallel backend GETs. When the
+ * connection drops for a moment every one of them fails with the same
+ * `NetworkError`, and each failed query independently calls `showErrorToast`,
+ * so the user gets a column of identical red toasts describing a single event.
+ * PostHog measured 8.4 error captures per affected session across 5.2
+ * endpoints, all within the same second.
+ *
+ * These specs pin the two halves of that: a transient blip should end up
+ * costing nothing because TanStack Query already retries, and a sustained
+ * outage should surface exactly one toast rather than one per endpoint.
+ */
+
+const TOAST = "[data-sonner-toast]";
+const NETWORK_MESSAGE = /Unable to connect to the server/i;
+
+/**
+ * `llm-setup-status` gates the whole shell behind a full-page error card, so
+ * failing it would hide the very toasts under test. Let it through and break
+ * only the data queries that render behind it.
+ */
+const GATING_PATHS = ["/llm-setup-status", "/auth/session", "/zero/"];
+
+function isGating(url: string): boolean {
+	return GATING_PATHS.some((path) => url.includes(path));
+}
+
+test.describe("Network error burst", () => {
+	test("a sustained outage shows one error, not one per endpoint", async ({ page, workspace }) => {
+		await page.route("**/api/v1/**", async (route) => {
+			if (isGating(route.request().url()) || route.request().method() !== "GET") {
+				return route.continue();
+			}
+			return route.abort("connectionfailed");
+		});
+
+		await page.goto(`/dashboard/${workspace.id}/new-chat`);
+
+		const toasts = page.locator(TOAST).filter({ hasText: NETWORK_MESSAGE });
+		await expect(toasts.first()).toBeVisible();
+		// Let the whole fan-out settle, including TanStack's retry backoff, so
+		// this counts the steady state rather than whichever toast landed first.
+		await page.waitForTimeout(8_000);
+
+		expect(await toasts.count()).toBe(1);
+	});
+
+	test("a blip that recovers on retry is never shown to the user", async ({ page, workspace }) => {
+		const failedOnce = new Set<string>();
+
+		await page.route("**/api/v1/**", async (route) => {
+			const url = route.request().url();
+			if (isGating(url) || route.request().method() !== "GET" || failedOnce.has(url)) {
+				return route.continue();
+			}
+			failedOnce.add(url);
+			return route.abort("connectionfailed");
+		});
+
+		await page.goto(`/dashboard/${workspace.id}/new-chat`);
+		await page.waitForTimeout(8_000);
+
+		const toasts = page.locator(TOAST).filter({ hasText: NETWORK_MESSAGE });
+		expect(await toasts.count()).toBe(0);
+	});
+});

--- a/surfsense_web/tests/unit/network-errors.test.ts
+++ b/surfsense_web/tests/unit/network-errors.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { shouldRetry } from "@/lib/auth-errors";
+import { AppError, AuthenticationError, NetworkError, NotFoundError } from "@/lib/error";
+import { shouldRetryQuery } from "@/lib/query-client/retry";
+
+// Run with: pnpm exec tsx --test tests/unit/network-errors.test.ts
+
+test("a network failure offers the user a retry", () => {
+	// register/page.tsx passes `err.message`, not `err.code`, so the retry
+	// affordance only appears if the sentence itself is recognised.
+	const network = new NetworkError(
+		"Unable to connect to the server. Check your internet connection and try again."
+	);
+
+	assert.equal(shouldRetry(network.message), true);
+	assert.equal(shouldRetry(network.code ?? ""), true);
+});
+
+test("a rejected password does not offer a retry", () => {
+	assert.equal(shouldRetry("REGISTER_USER_ALREADY_EXISTS"), false);
+	assert.equal(shouldRetry("Password should be at least 8 characters"), false);
+});
+
+test("queries retry transient failures", () => {
+	const network = new NetworkError("Unable to connect to the server.");
+	const serverFault = new AppError("Something went wrong", 500, "Internal Server Error");
+
+	assert.equal(shouldRetryQuery(0, network), true);
+	assert.equal(shouldRetryQuery(0, serverFault), true);
+});
+
+test("queries give up rather than hammering a failing endpoint", () => {
+	const network = new NetworkError("Unable to connect to the server.");
+
+	assert.equal(shouldRetryQuery(2, network), false);
+});
+
+test("queries never retry an answer the server meant", () => {
+	// Retrying these delays the redirect or the error the user needs to see,
+	// and cannot change the outcome.
+	assert.equal(shouldRetryQuery(0, new AuthenticationError("Please login again.", 401)), false);
+	assert.equal(shouldRetryQuery(0, new NotFoundError("Resource not found", 404)), false);
+	assert.equal(shouldRetryQuery(0, new AppError("Forbidden", 403)), false);
+});


### PR DESCRIPTION
<!--- Summarize your pull request in a few sentences -->

## Description
<!--- Clearly describe what has changed in this pull request -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If this PR relates to an open issue, please link to the issue here: FIX #123 -->
FIX #


## Screenshots
<!-- If applicable, add screenshots or images to demonstrate the changes visually -->

## API Changes
<!-- Document any API changes if applicable -->
- [ ] This PR includes API changes

## Change Type
<!--- Indicate what kind(s) of changes this PR includes: -->
- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Dependency/Build system
- [ ] Breaking change
- [ ] Other (specify):

## Testing Performed
<!--- Briefly describe how you have tested these changes and what verification was performed -->
- [ ] Tested locally
- [ ] Manual/QA verification

## Checklist
<!--- Please confirm the following by marking with an 'x' as appropriate -->
- [ ] Follows project coding standards and conventions
- [ ] Documentation updated as needed
- [ ] Dependencies updated as needed
- [ ] No lint/build errors or new warnings
- [ ] All relevant tests are passing

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes Auto mode model selection by implementing a compatibility sweep system that probes OpenRouter models to ensure they can actually serve chat completions before being offered to users. The core issue was that some models (particularly `:batch` variants and delisted models) would pass metadata filters but fail with 404s when used. The fix adds a `model_compatibility` database table, a sweep mechanism that probes models through escalating stages (stream, tool binding, tool result), and blocklist integration into the model catalogue. Additionally, it improves network error handling on the frontend by deduplicating error toasts and implementing smart retry logic to prevent error spam during connection issues. The backend also handles the case where uvicorn workers have divergent catalogues due to independent refresh cycles.

⏱️ Estimated Review Time: 1-3 hours

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_backend/alembic/versions/184_add_model_compatibility.py` |
| 2 | `surfsense_backend/app/db.py` |
| 3 | `surfsense_backend/app/services/model_compatibility.py` |
| 4 | `surfsense_backend/app/services/model_compatibility_sweep.py` |
| 5 | `surfsense_backend/app/services/openrouter_model_normalizer.py` |
| 6 | `surfsense_backend/app/services/openrouter_integration_service.py` |
| 7 | `surfsense_backend/app/services/auto_model_pin_service.py` |
| 8 | `surfsense_backend/app/tasks/celery_tasks/model_compatibility_task.py` |
| 9 | `surfsense_backend/scripts/sweep_model_compatibility.py` |
| 10 | `surfsense_backend/scripts/probe_openrouter_dead_models.py` |
| 11 | `surfsense_backend/app/celery_app.py` |
| 12 | `surfsense_backend/tests/unit/services/test_model_compatibility.py` |
| 13 | `surfsense_backend/tests/unit/services/test_auto_pin_dead_model_simulation.py` |
| 14 | `surfsense_backend/tests/unit/services/test_blocklist_surfaces.py` |
| 15 | `surfsense_backend/tests/unit/services/test_openrouter_catalogue_integrity.py` |
| 16 | `surfsense_backend/tests/unit/tasks/chat/streaming/test_pin_missing_from_catalogue.py` |
| 17 | `surfsense_web/lib/query-client/retry.ts` |
| 18 | `surfsense_web/lib/query-client/client.ts` |
| 19 | `surfsense_web/lib/error-toast.ts` |
| 20 | `surfsense_web/lib/auth-errors.ts` |
| 21 | `surfsense_web/lib/apis/base-api.service.ts` |
| 22 | `surfsense_web/atoms/user/user-query.atoms.ts` |
| 23 | `surfsense_web/tests/smoke/network-error-burst.spec.ts` |
| 24 | `surfsense_web/tests/unit/network-errors.test.ts` |
| 25 | `surfsense_backend/app/services/model_list_service.py` |
| 26 | `surfsense_backend/alembic/env.py` |
| 27 | `surfsense_backend/app/agents/chat/multi_agent_chat/main_agent/middleware/continue_on_max_length.py` |
| 28 | `surfsense_backend/app/agents/chat/multi_agent_chat/subagents/builtins/deliverables/tools/generate_image.py` |
| 29 | `surfsense_backend/app/agents/chat/runtime/references/documents/resolver.py` |
| 30 | `surfsense_backend/app/agents/chat/runtime/references/folders.py` |
| 31 | `surfsense_backend/app/artifacts/media/podcast/record.py` |
| 32 | `surfsense_backend/app/artifacts/service.py` |
| 33 | `surfsense_backend/app/artifacts/verification/formats/base.py` |
| 34 | `surfsense_backend/app/artifacts/verification/formats/docx.py` |
| 35 | `surfsense_backend/app/artifacts/verification/formats/ooxml.py` |
| 36 | `surfsense_backend/app/artifacts/verification/formats/pptx.py` |
| 37 | `surfsense_backend/app/artifacts/verification/formats/registry.py` |
| 38 | `surfsense_backend/app/artifacts/verification/formats/xlsx.py` |
| 39 | `surfsense_backend/app/routes/artifacts_routes.py` |
| 40 | `surfsense_backend/app/sandbox/registry.py` |
| 41 | `surfsense_backend/scripts/check_migration_flow.py` |
| 42 | `surfsense_backend/scripts/create_sandbox_snapshot.py` |
| 43 | `surfsense_backend/tests/integration/artifacts/test_roster.py` |
| 44 | `surfsense_backend/tests/integration/artifacts/test_xlsx_artifacts.py` |
| 45 | `surfsense_backend/tests/integration/knowledge_store/index/test_duplicate_content_convergence.py` |
| 46 | `surfsense_backend/tests/unit/agents/multi_agent_chat/middleware/checkpointed_subagent_middleware/test_resume_decision_routing.py` |
| 47 | `surfsense_backend/tests/unit/agents/multi_agent_chat/middleware/shared/permissions/test_reject_emits_toolmessage.py` |
| 48 | `surfsense_backend/tests/unit/agents/multi_agent_chat/middleware/test_continue_on_max_length.py` |
| 49 | `surfsense_backend/tests/unit/artifacts/test_media_record.py` |
| 50 | `surfsense_backend/tests/unit/artifacts/test_xlsx_verification.py` |
| 51 | `surfsense_backend/tests/unit/services/test_supports_image_input.py` |
| 52 | `surfsense_backend/tests/unit/services/test_vercel_interrupt_id.py` |
| 53 | `surfsense_backend/tests/unit/tasks/chat/streaming/flows/resume_chat/test_resume_routing.py` |
| 54 | `surfsense_backend/tests/unit/tasks/chat/streaming/test_interrupt_inspector_all.py` |
| 55 | `surfsense_mcp/tests/test_update_document.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->