### PR TITLE
fix: make reranker propely optional

### DIFF
--- a/surfsense_backend/app/agents/chat/multi_agent_chat/subagents/builtins/knowledge_base/tools/search_knowledge_base.py
+++ b/surfsense_backend/app/agents/chat/multi_agent_chat/subagents/builtins/knowledge_base/tools/search_knowledge_base.py
@@ -11,6 +11,7 @@ subagent boundary (reducer-backed, forwarded by ``task``/``ask_knowledge_base``)
 
 from __future__ import annotations
 
+import asyncio
 import time
 from typing import Annotated, Any
 
@@ -30,6 +31,7 @@ from app.agents.chat.multi_agent_chat.shared.state.filesystem_state import (
 )
 from app.agents.chat.runtime.references import referenced_document_ids
 from app.db import shielded_async_session
+from app.services.reranker_service import RerankerService
 from app.utils.perf import get_perf_logger
 
 _perf_log = get_perf_logger()
@@ -153,7 +155,14 @@ def create_search_knowledge_base_tool(
                 scope=scope,
                 top_k=clamped_top_k,
             )
-            rendered = build_context(cleaned_query, hits, registry)
+
+            reranker = RerankerService.get_reranker_instance()
+            if reranker is not None:
+                rendered = await asyncio.to_thread(
+                    build_context, cleaned_query, hits, registry, reranker=reranker
+                )
+            else:
+                rendered = build_context(cleaned_query, hits, registry)
 
         _perf_log.info(
             "[search_knowledge_base] tool query=%r sources=%d in %.3fs",

--- a/surfsense_backend/app/agents/chat/multi_agent_chat/subagents/builtins/knowledge_base/tools/search_knowledge_base.py
+++ b/surfsense_backend/app/agents/chat/multi_agent_chat/subagents/builtins/knowledge_base/tools/search_knowledge_base.py
@@ -121,6 +121,7 @@ def create_search_knowledge_base_tool(
 
     _space_id = workspace_id
     _document_types = _search_types(available_connectors, available_document_types)
+    reranker = RerankerService.get_reranker_instance()
 
     async def _impl(
         query: Annotated[
@@ -156,13 +157,14 @@ def create_search_knowledge_base_tool(
                 top_k=clamped_top_k,
             )
 
-            reranker = RerankerService.get_reranker_instance()
             if reranker is not None:
                 rendered = await asyncio.to_thread(
                     build_context, cleaned_query, hits, registry, reranker=reranker
                 )
             else:
-                rendered = build_context(cleaned_query, hits, registry)
+                rendered = build_context(
+                    cleaned_query, hits, registry, reranker=reranker
+                )
 
         _perf_log.info(
             "[search_knowledge_base] tool query=%r sources=%d in %.3fs",


### PR DESCRIPTION
## Summary

`RERANKERS_ENABLED` is documented in both `.env.example` files and `config` builds a live `Reranker` when it's set, but `search_knowledge_base` calls `build_context(query, hits, registry)` without the `reranker` argument. So `rerank_hits` always receives `None` and returns hits untouched. The switch exists and does nothing.

This wires it through. `rank()` is a blocking cross-encoder call, so the enabled path goes through `asyncio.to_thread` to keep it off the event loop. The disabled path stays exactly as it is today.

```python
reranker = RerankerService.get_reranker_instance()
if reranker is not None:
    rendered = await asyncio.to_thread(
        build_context, cleaned_query, hits, registry, reranker=reranker
    )
else:
    rendered = build_context(cleaned_query, hits, registry)
```

`get_reranker_instance()` returns `None` whenever `RERANKERS_ENABLED` is off, so nothing changes for anyone who doesn't opt in: same call, same code path, no thread. The default stays FALSE, so cloud is unaffected. What changes is that self-hosted operators can now actually turn it on, and cloud operators can actually test and measure metrics if wanted.

## Testing

Measured on the dev stack against a real indexed workspace. 
* **Flag OFF:** `build_context` costs ~2 ms. 
* **Flag ON:** Reranking adds 0.8 to 2.1 s per search depending on document count. 

A typical turn in my logs spends 46 to 72 seconds, almost all of it in LLM calls, so reranking lands around 5% of turn time.

## Open Questions (Not in this PR)

Wiring the reranker up surfaced two things that affect how it performs. Both are judgment calls that depend on knowing the cloud setup, so I've left them out and am raising them here instead.

1. **The default model:** `.env.example` suggests `ms-marco-MiniLM-L-12-v2` via flashrank. `ms-marco-MiniLM-L-6-v2` scores the same on MS MARCO (74.30 vs 74.31 NDCG@10) and was consistently faster in my measurements: roughly 3x on small result sets, narrowing to 1.4x once documents get large enough that both truncate. The catch is that FlashRank doesn't ship L-6, so using it means switching `RERANKERS_MODEL_TYPE` to cross-encoder, which means PyTorch instead of ONNX.
2. **Concurrency:** The agent fires searches in parallel. Since the cross-encoder releases the GIL and runs in native code, those genuinely compete for cores. Without a limit they all finish at the slowest one's pace. A semaphore around the reranking call gave each search predictable latency, and at higher concurrency it improved wall-clock time too. Whether that helps at all depends on whether reranking threads actually exceed available cores on your infrastructure. Sizing it also needs to account for worker count, since this optimization is targeting cloud, and I can't tell how the cloud deployment handles that.

### Trade-off Summary

| Decision | Upside | Cost |
| :--- | :--- | :--- |
| **Switch default to L-6** | 1.4 to 3x faster, same benchmark quality | Needs cross-encoder backend (PyTorch, not ONNX); +24 MB RSS; 1.4 s model load vs 0.2 s |
| **Keep L-12 / flashrank** | ONNX runtime purpose-built for inference; faster startup | Roughly half the throughput for no measurable quality gain |
| **Add a concurrency limit** | Predictable per-search latency; better wall-clock under load | Adds queueing when cores are free; sizing depends on cores and worker count |
| **No limit (today)** | No queueing when capacity is free | Parallel searches contend; all finish at the slowest one's pace |

Happy to open follow-ups for either once you've had a look. You'd know better than I would whether the cloud hits the concurrency case at all.

Note: `build_context` only touches plain dataclasses, so no lazy load can cross into the worker thread.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes the reranker feature to actually work when enabled. Previously, the `RERANKERS_ENABLED` configuration flag existed but was never used because the `reranker` argument was not passed to `build_context()`, causing search results to never be reranked. The fix conditionally retrieves the reranker instance and, when enabled, wraps the `build_context()` call in `asyncio.to_thread()` to prevent blocking the event loop during the CPU-intensive cross-encoder operation. When the flag is disabled (the default), behavior remains identical to the current implementation.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_backend/app/agents/chat/multi_agent_chat/subagents/builtins/knowledge_base/tools/search_knowledge_base.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->