### PR TITLE
[Fix] Daytona read_file returns FileNotFoundError for missing files

### DIFF
--- a/surfsense_backend/app/sandbox/providers/daytona.py
+++ b/surfsense_backend/app/sandbox/providers/daytona.py
@@ -21,6 +21,7 @@ from daytona import (
     DaytonaConfig,
     SandboxState,
 )
+from daytona.common.errors import DaytonaError, DaytonaNotFoundError
 
 from app.config import config as app_config
 
@@ -30,6 +31,19 @@ logger = logging.getLogger(__name__)
 
 THREAD_LABEL_KEY = "surfsense_thread"
 _START_TIMEOUT = 60
+
+
+def _is_not_found(exc: DaytonaError) -> bool:
+    """Whether a Daytona failure means the file is absent.
+
+    The daemon returns a FILE_NOT_FOUND body as a plain DaytonaError rather than
+    the typed DaytonaNotFoundError, so match on both the subclass and the body.
+    """
+    return (
+        isinstance(exc, DaytonaNotFoundError)
+        or getattr(exc, "status_code", None) == 404
+        or "FILE_NOT_FOUND" in str(exc)
+    )
 
 
 def _wrap_as_python(code: str) -> str:
@@ -65,7 +79,12 @@ class DaytonaSession:
         return await asyncio.to_thread(_run)
 
     async def read_file(self, path: str) -> bytes:
-        data = await asyncio.to_thread(self._sandbox.fs.download_file, path)
+        try:
+            data = await asyncio.to_thread(self._sandbox.fs.download_file, path)
+        except DaytonaError as exc:
+            if _is_not_found(exc):
+                raise FileNotFoundError(path) from None
+            raise
         if data is None:
             raise FileNotFoundError(path)
         return data

--- a/surfsense_backend/tests/unit/sandbox/test_daytona_provider.py
+++ b/surfsense_backend/tests/unit/sandbox/test_daytona_provider.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock
 
 import pytest
 from daytona import Daytona, SandboxState
+from daytona.common.errors import DaytonaError
 
 from app.config import config as app_config
 from app.sandbox.providers.daytona import (
@@ -41,6 +42,36 @@ async def test_daytona_session_maps_command_and_binary_file_operations():
     assert downloaded == b"\x00binary"
     sandbox.fs.upload_file.assert_called_once_with(b"new", "/workspace/file.bin")
     client.delete.assert_called_once_with(sandbox)
+
+
+async def test_read_file_maps_missing_file_to_file_not_found():
+    """A FILE_NOT_FOUND body must surface as FileNotFoundError, not DaytonaError.
+
+    read_receipt only catches FileNotFoundError; a raw DaytonaError escapes and
+    crashes the stream on the first (receiptless) verification.
+    """
+    missing = DaytonaError(
+        'Failed to download file: {"code":"FILE_NOT_FOUND","statusCode":404}'
+    )
+    sandbox = SimpleNamespace(
+        id="daytona-1",
+        fs=SimpleNamespace(download_file=Mock(side_effect=missing)),
+    )
+    session = DaytonaSession(sandbox, SimpleNamespace(delete=Mock()))
+
+    with pytest.raises(FileNotFoundError):
+        await session.read_file("/tmp/receipt.json")
+
+
+async def test_read_file_propagates_non_not_found_errors():
+    sandbox = SimpleNamespace(
+        id="daytona-1",
+        fs=SimpleNamespace(download_file=Mock(side_effect=DaytonaError("boom"))),
+    )
+    session = DaytonaSession(sandbox, SimpleNamespace(delete=Mock()))
+
+    with pytest.raises(DaytonaError):
+        await session.read_file("/tmp/receipt.json")
 
 
 def _client(items: list[object]) -> Mock:


### PR DESCRIPTION
## Summary

- Map Daytona's `FILE_NOT_FOUND` failures in `read_file` to `FileNotFoundError`, matching the `SandboxSession` contract OpenSandbox already fulfills — a missing receipt no longer escapes as a raw `DaytonaError` and crashes the stream on the first verification
- Re-raise all other `DaytonaError`s unchanged

## Test plan

- [ ] `uv run pytest tests/unit/sandbox/test_daytona_provider.py`

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a bug in the Daytona sandbox provider where `read_file` operations for missing files were raising raw `DaytonaError` exceptions instead of the expected `FileNotFoundError`. The fix introduces a helper function `_is_not_found` that detects file-not-found conditions from Daytona errors (checking for `DaytonaNotFoundError` subclass, 404 status codes, and `FILE_NOT_FOUND` in the error message) and properly translates them to `FileNotFoundError` to match the `SandboxSession` contract. This prevents crashes during receipt verification when files are missing.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_backend/tests/unit/sandbox/test_daytona_provider.py` |
| 2 | `surfsense_backend/app/sandbox/providers/daytona.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->