### PR TITLE
fix(sandbox): activate image interpreter for Daytona office artifacts

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -378,6 +378,7 @@ STT_SERVICE=local/base
 # DAYTONA_API_KEY=
 # DAYTONA_API_URL=https://app.daytona.io/api
 # DAYTONA_TARGET=us
+# DAYTONA_SNAPSHOT_ID=surfsense-sandbox
 
 # --- OpenSandbox (self-hosted provider, default) ---
 # The opensandbox-server container runs the control plane and spawns sandbox

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -178,12 +178,12 @@ services:
       WHATSAPP_BRIDGE_URL: ${WHATSAPP_BRIDGE_URL:-http://whatsapp-bridge:9929}
       SEARXNG_URL: ${SEARXNG_URL:-http://searxng:8080}
       MAX_FILE_SIZE_MB: ${MAX_FILE_SIZE_MB:-500}
-      # Daytona – uncomment with SANDBOX_PROVIDER=daytona for cloud execution
-      # DAYTONA_API_KEY: ${DAYTONA_API_KEY:-}
-      # DAYTONA_API_URL: ${DAYTONA_API_URL:-https://app.daytona.io/api}
-      # DAYTONA_TARGET: ${DAYTONA_TARGET:-us}
       SANDBOX_ENABLED: ${SANDBOX_ENABLED:-TRUE}
       SANDBOX_PROVIDER: ${SANDBOX_PROVIDER:-opensandbox}
+      DAYTONA_API_KEY: ${DAYTONA_API_KEY:-}
+      DAYTONA_API_URL: ${DAYTONA_API_URL:-https://app.daytona.io/api}
+      DAYTONA_TARGET: ${DAYTONA_TARGET:-us}
+      DAYTONA_SNAPSHOT_ID: ${DAYTONA_SNAPSHOT_ID:-}
       OPENSANDBOX_DOMAIN: ${OPENSANDBOX_DOMAIN:-opensandbox-server:8080}
       OPENSANDBOX_API_KEY: ${OPENSANDBOX_API_KEY:-surfsense-dev-sandbox}
       SANDBOX_IMAGE: ${SANDBOX_IMAGE:-ghcr.io/modsetter/surfsense-sandbox:${SURFSENSE_VERSION:-latest}}

--- a/surfsense_backend/app/agents/chat/multi_agent_chat/subagents/builtins/deliverables/tools/sandbox.py
+++ b/surfsense_backend/app/agents/chat/multi_agent_chat/subagents/builtins/deliverables/tools/sandbox.py
@@ -55,6 +55,8 @@ async def _run_python_script(
         f"script={quoted_script}; "
         """trap 'rm -f -- "$script"' EXIT; """
         "cd -- /workspace && "
+        '. /opt/code-interpreter/code-interpreter-env.sh python '
+        '"${PYTHON_VERSION:-3.12}" >/dev/null 2>&1 && '
         "timeout --signal=TERM "
         f"--kill-after={_PROCESS_TERMINATION_GRACE_SECONDS}s {process_timeout}s "
         'python3 "$script"'

--- a/surfsense_backend/app/sandbox/providers/daytona.py
+++ b/surfsense_backend/app/sandbox/providers/daytona.py
@@ -49,7 +49,11 @@ def _is_not_found(exc: DaytonaError) -> bool:
 def _wrap_as_python(code: str) -> str:
     """Wrap code in a unique-sentinel heredoc for Daytona's command API."""
     sentinel = f"_PYEOF_{secrets.token_hex(8)}"
-    return f"python3 << '{sentinel}'\n{code}\n{sentinel}"
+    return (
+        ". /opt/code-interpreter/code-interpreter-env.sh python "
+        f'"${{PYTHON_VERSION:-3.12}}" >/dev/null 2>&1 && '
+        f"python3 << '{sentinel}'\n{code}\n{sentinel}"
+    )
 
 
 class DaytonaSession:

--- a/surfsense_backend/tests/unit/sandbox/test_daytona_provider.py
+++ b/surfsense_backend/tests/unit/sandbox/test_daytona_provider.py
@@ -34,7 +34,9 @@ async def test_daytona_session_maps_command_and_binary_file_operations():
 
     assert result.ok
     assert result.output == "ok"
-    assert "python3 <<" in sandbox.process.exec.call_args.args[0]
+    wrapped = sandbox.process.exec.call_args.args[0]
+    assert "code-interpreter-env.sh" in wrapped
+    assert "python3 <<" in wrapped
     assert (
         sandbox.process.exec.call_args.kwargs["timeout"]
         == app_config.SANDBOX_OPERATION_TIMEOUT_SECONDS

--- a/surfsense_backend/tests/unit/sandbox/test_deliverables_tools.py
+++ b/surfsense_backend/tests/unit/sandbox/test_deliverables_tools.py
@@ -641,6 +641,9 @@ async def test_execute_python_uses_unique_one_shot_scripts_and_cleans_up(monkeyp
     assert "/tmp/.surfsense-exec-second.py" in execution_commands[1]
     assert all("cd -- /workspace" in command for command in execution_commands)
     assert all(
+        "code-interpreter-env.sh" in command for command in execution_commands
+    )
+    assert all(
         "timeout --signal=TERM --kill-after=5s" in command
         for command in execution_commands
     )


### PR DESCRIPTION
## Summary
- Daytona boots the sandbox image with `sleep infinity`, overriding the image's `code-interpreter` entrypoint. So bare `python3` resolves to the Ubuntu system interpreter, which lacks the office wheels (`weasyprint`, `reportlab`, `xlsxwriter`, `python-pptx`, `python-docx`). OpenSandbox keeps that entrypoint and activates the 3.12 venv, so it never hit this.
- Net effect on Daytona: xlsx/pptx/docx generation silently produced no file (surfacing downstream as `FileNotFoundError` during verification); only pdf slipped through via the `soffice` system-binary fallback rather than the intended Python path.
- Fix: source `code-interpreter-env.sh` before invoking `python3` in both sandbox entry points (the deliverables `execute` tool and the Daytona `execute` heredoc). On OpenSandbox this re-activates the same interpreter, so it's a harmless no-op there.
- Ops: uncomment the `DAYTONA_*` passthrough on the backend service in `docker-compose.yml` and add `DAYTONA_SNAPSHOT_ID`, so a deployment with `SANDBOX_PROVIDER=daytona` actually forwards key/URL/target/snapshot into the container. Documented the snapshot name in the compose `.env.example`.

## Test plan
- [x] `test_daytona_provider.py` asserts the wrapped command sources `code-interpreter-env.sh` and runs `python3 <<`.
- [x] `test_deliverables_tools.py` asserts every execution command sources `code-interpreter-env.sh`.
- [ ] Prod smoke on Coolify (`SANDBOX_PROVIDER=daytona`): generate xlsx + pptx + pdf and confirm all three artifacts are written.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
Fixes sandbox execution on Daytona provider by ensuring the code interpreter virtual environment is activated before running Python scripts. Daytona overrides the sandbox image entrypoint with `sleep infinity`, which bypasses the image's built-in activation, causing office document generation tools (`weasyprint`, `reportlab`, `xlsxwriter`, `python-pptx`, `python-docx`) to be unavailable. The fix sources `code-interpreter-env.sh` in both the deliverables execute tool and Daytona's Python wrapper function, ensuring the correct interpreter with all dependencies is used. Additionally updates the Docker Compose configuration to properly pass through Daytona environment variables including the new `DAYTONA_SNAPSHOT_ID` setting.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `docker/.env.example` |
| 2 | `docker/docker-compose.yml` |
| 3 | `surfsense_backend/app/sandbox/providers/daytona.py` |
| 4 | `surfsense_backend/app/agents/chat/multi_agent_chat/subagents/builtins/deliverables/tools/sandbox.py` |
| 5 | `surfsense_backend/tests/unit/sandbox/test_daytona_provider.py` |
| 6 | `surfsense_backend/tests/unit/sandbox/test_deliverables_tools.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->