### PR TITLE
fix(sandbox): activate image interpreter for Daytona office artifacts

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -378,6 +378,7 @@ STT_SERVICE=local/base
 # DAYTONA_API_KEY=
 # DAYTONA_API_URL=https://app.daytona.io/api
 # DAYTONA_TARGET=us
+# DAYTONA_SNAPSHOT_ID=surfsense-sandbox
 
 # --- OpenSandbox (self-hosted provider, default) ---
 # The opensandbox-server container runs the control plane and spawns sandbox

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -178,12 +178,12 @@ services:
       WHATSAPP_BRIDGE_URL: ${WHATSAPP_BRIDGE_URL:-http://whatsapp-bridge:9929}
       SEARXNG_URL: ${SEARXNG_URL:-http://searxng:8080}
       MAX_FILE_SIZE_MB: ${MAX_FILE_SIZE_MB:-500}
-      # Daytona – uncomment with SANDBOX_PROVIDER=daytona for cloud execution
-      # DAYTONA_API_KEY: ${DAYTONA_API_KEY:-}
-      # DAYTONA_API_URL: ${DAYTONA_API_URL:-https://app.daytona.io/api}
-      # DAYTONA_TARGET: ${DAYTONA_TARGET:-us}
       SANDBOX_ENABLED: ${SANDBOX_ENABLED:-TRUE}
       SANDBOX_PROVIDER: ${SANDBOX_PROVIDER:-opensandbox}
+      DAYTONA_API_KEY: ${DAYTONA_API_KEY:-}
+      DAYTONA_API_URL: ${DAYTONA_API_URL:-https://app.daytona.io/api}
+      DAYTONA_TARGET: ${DAYTONA_TARGET:-us}
+      DAYTONA_SNAPSHOT_ID: ${DAYTONA_SNAPSHOT_ID:-}
       OPENSANDBOX_DOMAIN: ${OPENSANDBOX_DOMAIN:-opensandbox-server:8080}
       OPENSANDBOX_API_KEY: ${OPENSANDBOX_API_KEY:-surfsense-dev-sandbox}
       SANDBOX_IMAGE: ${SANDBOX_IMAGE:-ghcr.io/modsetter/surfsense-sandbox:${SURFSENSE_VERSION:-latest}}

--- a/surfsense_backend/app/agents/chat/multi_agent_chat/subagents/builtins/deliverables/tools/sandbox.py
+++ b/surfsense_backend/app/agents/chat/multi_agent_chat/subagents/builtins/deliverables/tools/sandbox.py
@@ -55,6 +55,8 @@ async def _run_python_script(
         f"script={quoted_script}; "
         """trap 'rm -f -- "$script"' EXIT; """
         "cd -- /workspace && "
+        '. /opt/code-interpreter/code-interpreter-env.sh python '
+        '"${PYTHON_VERSION:-3.12}" >/dev/null 2>&1 && '
         "timeout --signal=TERM "
         f"--kill-after={_PROCESS_TERMINATION_GRACE_SECONDS}s {process_timeout}s "
         'python3 "$script"'

--- a/surfsense_backend/app/sandbox/providers/daytona.py
+++ b/surfsense_backend/app/sandbox/providers/daytona.py
@@ -49,7 +49,11 @@ def _is_not_found(exc: DaytonaError) -> bool:
 def _wrap_as_python(code: str) -> str:
     """Wrap code in a unique-sentinel heredoc for Daytona's command API."""
     sentinel = f"_PYEOF_{secrets.token_hex(8)}"
-    return f"python3 << '{sentinel}'\n{code}\n{sentinel}"
+    return (
+        ". /opt/code-interpreter/code-interpreter-env.sh python "
+        f'"${{PYTHON_VERSION:-3.12}}" >/dev/null 2>&1 && '
+        f"python3 << '{sentinel}'\n{code}\n{sentinel}"
+    )
 
 
 class DaytonaSession:

--- a/surfsense_backend/tests/unit/sandbox/test_daytona_provider.py
+++ b/surfsense_backend/tests/unit/sandbox/test_daytona_provider.py
@@ -34,7 +34,9 @@ async def test_daytona_session_maps_command_and_binary_file_operations():
 
     assert result.ok
     assert result.output == "ok"
-    assert "python3 <<" in sandbox.process.exec.call_args.args[0]
+    wrapped = sandbox.process.exec.call_args.args[0]
+    assert "code-interpreter-env.sh" in wrapped
+    assert "python3 <<" in wrapped
     assert (
         sandbox.process.exec.call_args.kwargs["timeout"]
         == app_config.SANDBOX_OPERATION_TIMEOUT_SECONDS

--- a/surfsense_backend/tests/unit/sandbox/test_deliverables_tools.py
+++ b/surfsense_backend/tests/unit/sandbox/test_deliverables_tools.py
@@ -641,6 +641,9 @@ async def test_execute_python_uses_unique_one_shot_scripts_and_cleans_up(monkeyp
     assert "/tmp/.surfsense-exec-second.py" in execution_commands[1]
     assert all("cd -- /workspace" in command for command in execution_commands)
     assert all(
+        "code-interpreter-env.sh" in command for command in execution_commands
+    )
+    assert all(
         "timeout --signal=TERM --kill-after=5s" in command
         for command in execution_commands
     )


### PR DESCRIPTION
Promotes #1698 from `dev` to `main`.

## Summary
- Daytona boots the sandbox image with `sleep infinity`, overriding the image's `code-interpreter` entrypoint, so bare `python3` is the Ubuntu system interpreter without the office wheels (`weasyprint`, `reportlab`, `xlsxwriter`, `python-pptx`, `python-docx`). OpenSandbox keeps that entrypoint (activates the 3.12 venv), so it never hit this.
- Net effect on Daytona: xlsx/pptx/docx produced no file (surfacing as `FileNotFoundError`); only pdf slipped through via the `soffice` fallback.
- Fix: source `code-interpreter-env.sh` before `python3` in both sandbox entry points; harmless no-op on OpenSandbox.
- Ops: forward `DAYTONA_*` (incl. `DAYTONA_SNAPSHOT_ID`) to the backend service in `docker-compose.yml`; document the snapshot name in the compose `.env.example`.

## Test plan
- [x] `test_daytona_provider.py` / `test_deliverables_tools.py` assert the interpreter is sourced before `python3`.
- [ ] Prod smoke on Coolify (`SANDBOX_PROVIDER=daytona`): generate xlsx + pptx + pdf and confirm all three artifacts are written.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
Fixes a critical bug in the Daytona sandbox provider where office document generation (xlsx, pptx, docx) failed because the Python interpreter wasn't using the correct virtual environment with required office libraries (`weasyprint`, `reportlab`, `xlsxwriter`, `python-pptx`, `python-docx`). The fix ensures that `code-interpreter-env.sh` is sourced before executing Python scripts in both Daytona sandbox entry points, activating the Python 3.12 venv with the necessary wheels. Additionally, the Docker configuration is updated to forward all `DAYTONA_*` environment variables (including `DAYTONA_SNAPSHOT_ID`) to the backend service.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_backend/app/sandbox/providers/daytona.py` |
| 2 | `surfsense_backend/app/agents/chat/multi_agent_chat/subagents/builtins/deliverables/tools/sandbox.py` |
| 3 | `surfsense_backend/tests/unit/sandbox/test_daytona_provider.py` |
| 4 | `surfsense_backend/tests/unit/sandbox/test_deliverables_tools.py` |
| 5 | `docker/docker-compose.yml` |
| 6 | `docker/.env.example` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Daytona sandbox configuration options for API access, target selection, and snapshot selection.
  * Python code execution now uses the configured Python version, defaulting to Python 3.12.
  * Sandbox execution initializes the code-interpreter environment before running scripts.

* **Tests**
  * Added coverage confirming the sandbox environment is initialized before Python execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->