### PR TITLE
fix(chat-streaming): handle non-object tool outputs safely & reasoning steps UI change

### DIFF
--- a/surfsense_backend/app/tasks/chat/streaming/handlers/tool_end.py
+++ b/surfsense_backend/app/tasks/chat/streaming/handlers/tool_end.py
@@ -111,7 +111,11 @@ def iter_tool_end_frames(
         holder["value"] = state.lc_tool_call_id_by_run[run_id]
 
     failed = tool_output_has_error(tool_output)
-    raw_status = str(tool_output.get("status") or "").lower()
+    raw_status = (
+        str(tool_output.get("status") or "").lower()
+        if isinstance(tool_output, dict)
+        else ""
+    )
     terminal_status: ActivityStatus = (
         "cancelled"
         if raw_status in {"cancelled", "canceled", "rejected"}

--- a/surfsense_backend/tests/unit/tasks/chat/test_activity_contract.py
+++ b/surfsense_backend/tests/unit/tasks/chat/test_activity_contract.py
@@ -293,6 +293,81 @@ def test_backend_owns_activity_copy_and_phase_lifecycle() -> None:
     assert tool_part["metadata"]["activityId"] == "act_turn_1"
 
 
+@pytest.mark.parametrize(
+    ("content", "expected", "expected_status"),
+    [
+        (
+            '{"status":"completed","value":1}',
+            {"status": "completed", "value": 1},
+            "completed",
+        ),
+        ('{"status":"cancelled"}', {"status": "cancelled"}, "cancelled"),
+        ("[]", {"result": []}, "completed"),
+        ('[{"id":1}]', {"result": [{"id": 1}]}, "completed"),
+        ('"done"', {"result": "done"}, "completed"),
+        ('"Error: failed"', {"result": "Error: failed"}, "error"),
+        ("42", {"result": 42}, "completed"),
+        ("true", {"result": True}, "completed"),
+        ("null", {"result": None}, "completed"),
+        ("not-json", {"result": "not-json"}, "completed"),
+        ("Error: failed", {"result": "Error: failed"}, "error"),
+    ],
+)
+def test_tool_end_handles_json_content_shapes(
+    content: str,
+    expected: dict,
+    expected_status: str,
+) -> None:
+    service = VercelStreamingService()
+    builder = AssistantContentBuilder()
+    state = AgentEventRelayState()
+    result = SimpleNamespace(write_attempted=False)
+
+    list(
+        iter_tool_start_frames(
+            {
+                "name": "create_calendar_event",
+                "run_id": "tool-1",
+                "data": {"input": {}},
+            },
+            state=state,
+            streaming_service=service,
+            content_builder=builder,
+            result=result,
+            step_prefix="turn",
+        )
+    )
+
+    frames = [
+        _payload(frame)
+        for frame in iter_tool_end_frames(
+            {
+                "name": "create_calendar_event",
+                "run_id": "tool-1",
+                "data": {
+                    "output": SimpleNamespace(
+                        content=content,
+                        tool_call_id="lc-tool-1",
+                    )
+                },
+            },
+            state=state,
+            streaming_service=service,
+            content_builder=builder,
+            result=result,
+            step_prefix="turn",
+            config={},
+        )
+    ]
+
+    output = next(frame for frame in frames if frame["type"] == "tool-output-available")
+    assert output["output"] == expected
+    activity_part = next(
+        part for part in builder.snapshot() if part["type"] == "data-activities"
+    )
+    assert activity_part["data"]["activities"][0]["status"] == expected_status
+
+
 def test_unknown_tools_are_generic_and_internal_tools_are_hidden() -> None:
     service = VercelStreamingService()
     result = SimpleNamespace(write_attempted=False)

--- a/surfsense_web/features/chat-messages/timeline/interleaved-trace.tsx
+++ b/surfsense_web/features/chat-messages/timeline/interleaved-trace.tsx
@@ -47,6 +47,7 @@ import {
 import { getActivityIcon, getActivityPresentation, getConnectorLogo } from "./presentation";
 import { AssistantTurnTiming, useAssistantTurnTiming } from "./turn-timing";
 import type { TurnTimingDisplay } from "./turn-timing-state";
+import { useReasoningAutoScroll } from "./use-reasoning-auto-scroll";
 
 const noopSubmit = () => {};
 const TEXT_PART_COMPONENTS = { Text: MarkdownText };
@@ -148,27 +149,42 @@ export const TraceItemRow: FC<{
 	</div>
 );
 
-const ReasoningEpisode: FC<{ text: string; running: boolean }> = ({ text, running }) => (
-	<TraceItemRow
-		icon={History}
-		status="reasoning"
-		title={
-			running ? (
-				<TextShimmerLoader text="Reasoning" size="md" className="font-normal!" />
-			) : (
-				"Reasoning"
-			)
-		}
-	>
-		<NestedScroll
-			role="region"
-			aria-label="Provider reasoning"
-			className="mt-2 max-h-52 overflow-y-auto overscroll-contain rounded-lg border border-border/60 bg-muted/20 px-3 py-2 text-sm leading-6 whitespace-pre-wrap wrap-break-word text-muted-foreground scrollbar-thin"
+const ReasoningEpisode: FC<{ text: string; running: boolean }> = ({ text, running }) => {
+	const { scrollRef, scrollMode, handleKeyDown, handlePointerDown, handleScroll, handleWheel } =
+		useReasoningAutoScroll(text, running);
+
+	return (
+		<TraceItemRow
+			icon={History}
+			status="reasoning"
+			title={
+				running ? (
+					<TextShimmerLoader text="Reasoning" size="md" className="font-normal!" />
+				) : (
+					"Reasoning"
+				)
+			}
 		>
-			{text}
-		</NestedScroll>
-	</TraceItemRow>
-);
+			<NestedScroll
+				ref={scrollRef}
+				onKeyDown={handleKeyDown}
+				onPointerDown={handlePointerDown}
+				onScroll={handleScroll}
+				onWheel={handleWheel}
+				role="region"
+				aria-label="Provider reasoning"
+				aria-busy={running}
+				tabIndex={0}
+				className={cn(
+					"mt-2 max-h-52 overflow-y-auto overscroll-contain rounded-lg border border-border/60 bg-muted/20 px-3 py-2 text-sm leading-6 whitespace-pre-wrap wrap-break-word text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
+					scrollMode === "following" ? "scrollbar-hide" : "scrollbar-thin"
+				)}
+			>
+				{text}
+			</NestedScroll>
+		</TraceItemRow>
+	);
+};
 
 const ActivityRow: FC<{ activity: ActivityData; threadRunning: boolean }> = ({
 	activity,

--- a/surfsense_web/features/chat-messages/timeline/interleaved-trace.tsx
+++ b/surfsense_web/features/chat-messages/timeline/interleaved-trace.tsx
@@ -150,8 +150,16 @@ export const TraceItemRow: FC<{
 );
 
 const ReasoningEpisode: FC<{ text: string; running: boolean }> = ({ text, running }) => {
-	const { scrollRef, scrollMode, handleKeyDown, handlePointerDown, handleScroll, handleWheel } =
-		useReasoningAutoScroll(text, running);
+	const {
+		scrollRef,
+		hasContentAbove,
+		hasContentBelow,
+		scrollMode,
+		handleKeyDown,
+		handlePointerDown,
+		handleScroll,
+		handleWheel,
+	} = useReasoningAutoScroll(text, running);
 
 	return (
 		<TraceItemRow
@@ -165,23 +173,39 @@ const ReasoningEpisode: FC<{ text: string; running: boolean }> = ({ text, runnin
 				)
 			}
 		>
-			<NestedScroll
-				ref={scrollRef}
-				onKeyDown={handleKeyDown}
-				onPointerDown={handlePointerDown}
-				onScroll={handleScroll}
-				onWheel={handleWheel}
-				role="region"
-				aria-label="Provider reasoning"
-				aria-busy={running}
-				tabIndex={0}
-				className={cn(
-					"mt-2 max-h-52 overflow-y-auto overscroll-contain rounded-lg border border-border/60 bg-muted/20 px-3 py-2 text-sm leading-6 whitespace-pre-wrap wrap-break-word text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
-					scrollMode === "following" ? "scrollbar-hide" : "scrollbar-thin"
-				)}
-			>
-				{text}
-			</NestedScroll>
+			<div className="relative mt-2">
+				<NestedScroll
+					ref={scrollRef}
+					onKeyDown={handleKeyDown}
+					onPointerDown={handlePointerDown}
+					onScroll={handleScroll}
+					onWheel={handleWheel}
+					role="region"
+					aria-label="Provider reasoning"
+					aria-busy={running}
+					tabIndex={0}
+					className={cn(
+						"max-h-52 overflow-y-auto overscroll-contain rounded-lg border border-border/60 bg-muted/20 px-3 py-2 text-sm leading-6 whitespace-pre-wrap wrap-break-word text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
+						scrollMode === "following" ? "scrollbar-hide" : "scrollbar-thin"
+					)}
+				>
+					{text}
+				</NestedScroll>
+				<div
+					aria-hidden="true"
+					className={cn(
+						"pointer-events-none absolute inset-x-px top-px h-4 rounded-t-lg bg-gradient-to-b from-muted/80 to-transparent transition-opacity",
+						hasContentAbove ? "opacity-100" : "opacity-0"
+					)}
+				/>
+				<div
+					aria-hidden="true"
+					className={cn(
+						"pointer-events-none absolute inset-x-px bottom-px h-4 rounded-b-lg bg-gradient-to-t from-muted/80 to-transparent transition-opacity",
+						hasContentBelow ? "opacity-100" : "opacity-0"
+					)}
+				/>
+			</div>
 		</TraceItemRow>
 	);
 };

--- a/surfsense_web/features/chat-messages/timeline/use-reasoning-auto-scroll.ts
+++ b/surfsense_web/features/chat-messages/timeline/use-reasoning-auto-scroll.ts
@@ -33,7 +33,11 @@ export function useReasoningAutoScroll(text: string, running: boolean) {
 	const followsBottomRef = useRef(true);
 	const wasRunningRef = useRef(running);
 	const programmaticScrollRef = useRef(false);
+	const hasContentAboveRef = useRef(false);
+	const hasContentBelowRef = useRef(false);
 	const [scrollMode, setScrollMode] = useState<ReasoningScrollMode>("following");
+	const [hasContentAbove, setHasContentAbove] = useState(false);
+	const [hasContentBelow, setHasContentBelow] = useState(false);
 	const reducedMotion = useReducedMotion();
 
 	const updateScrollMode = useCallback((mode: ReasoningScrollMode) => {
@@ -42,8 +46,23 @@ export function useReasoningAutoScroll(text: string, running: boolean) {
 		setScrollMode(mode);
 	}, []);
 
+	const updateScrollEdges = useCallback((element: HTMLDivElement) => {
+		const nextHasContentAbove = element.scrollTop > 0;
+		if (hasContentAboveRef.current !== nextHasContentAbove) {
+			hasContentAboveRef.current = nextHasContentAbove;
+			setHasContentAbove(nextHasContentAbove);
+		}
+
+		const nextHasContentBelow = !isReasoningAtBottom(element);
+		if (hasContentBelowRef.current !== nextHasContentBelow) {
+			hasContentBelowRef.current = nextHasContentBelow;
+			setHasContentBelow(nextHasContentBelow);
+		}
+	}, []);
+
 	const handleScroll = useCallback<UIEventHandler<HTMLDivElement>>(
 		(event) => {
+			updateScrollEdges(event.currentTarget);
 			updateScrollMode(
 				resolveReasoningScrollMode(
 					followsBottomRef.current ? "following" : "manual",
@@ -52,7 +71,7 @@ export function useReasoningAutoScroll(text: string, running: boolean) {
 				)
 			);
 		},
-		[updateScrollMode]
+		[updateScrollEdges, updateScrollMode]
 	);
 
 	const handleWheel = useCallback<WheelEventHandler<HTMLDivElement>>(
@@ -99,6 +118,8 @@ export function useReasoningAutoScroll(text: string, running: boolean) {
 	useEffect(() => {
 		const shouldFollow = running || wasRunningRef.current;
 		wasRunningRef.current = running;
+		const element = scrollRef.current;
+		if (element) updateScrollEdges(element);
 		if (text.length === 0 || !shouldFollow || !followsBottomRef.current) return;
 
 		const frame = requestAnimationFrame(() => {
@@ -112,10 +133,12 @@ export function useReasoningAutoScroll(text: string, running: boolean) {
 		});
 
 		return () => cancelAnimationFrame(frame);
-	}, [reducedMotion, running, text]);
+	}, [reducedMotion, running, text, updateScrollEdges]);
 
 	return {
 		scrollRef,
+		hasContentAbove,
+		hasContentBelow,
 		scrollMode,
 		handleKeyDown,
 		handlePointerDown,

--- a/surfsense_web/features/chat-messages/timeline/use-reasoning-auto-scroll.ts
+++ b/surfsense_web/features/chat-messages/timeline/use-reasoning-auto-scroll.ts
@@ -1,0 +1,125 @@
+"use client";
+
+import { useReducedMotion } from "motion/react";
+import {
+	type KeyboardEventHandler,
+	type PointerEventHandler,
+	type UIEventHandler,
+	useCallback,
+	useEffect,
+	useRef,
+	useState,
+	type WheelEventHandler,
+} from "react";
+
+type ScrollMetrics = Pick<HTMLElement, "clientHeight" | "scrollHeight" | "scrollTop">;
+export type ReasoningScrollMode = "following" | "manual";
+
+export function isReasoningAtBottom(element: ScrollMetrics, threshold = 8): boolean {
+	return element.scrollHeight - element.clientHeight - element.scrollTop <= threshold;
+}
+
+export function resolveReasoningScrollMode(
+	currentMode: ReasoningScrollMode,
+	element: ScrollMetrics,
+	programmatic: boolean
+): ReasoningScrollMode {
+	if (programmatic) return currentMode;
+	return isReasoningAtBottom(element) ? "following" : "manual";
+}
+
+export function useReasoningAutoScroll(text: string, running: boolean) {
+	const scrollRef = useRef<HTMLDivElement>(null);
+	const followsBottomRef = useRef(true);
+	const wasRunningRef = useRef(running);
+	const programmaticScrollRef = useRef(false);
+	const [scrollMode, setScrollMode] = useState<ReasoningScrollMode>("following");
+	const reducedMotion = useReducedMotion();
+
+	const updateScrollMode = useCallback((mode: ReasoningScrollMode) => {
+		if (followsBottomRef.current === (mode === "following")) return;
+		followsBottomRef.current = mode === "following";
+		setScrollMode(mode);
+	}, []);
+
+	const handleScroll = useCallback<UIEventHandler<HTMLDivElement>>(
+		(event) => {
+			updateScrollMode(
+				resolveReasoningScrollMode(
+					followsBottomRef.current ? "following" : "manual",
+					event.currentTarget,
+					programmaticScrollRef.current
+				)
+			);
+		},
+		[updateScrollMode]
+	);
+
+	const handleWheel = useCallback<WheelEventHandler<HTMLDivElement>>(
+		(event) => {
+			programmaticScrollRef.current = false;
+			if (event.deltaY < 0 && event.currentTarget.scrollTop > 0) {
+				updateScrollMode("manual");
+			}
+		},
+		[updateScrollMode]
+	);
+
+	const handlePointerDown = useCallback<PointerEventHandler<HTMLDivElement>>(() => {
+		programmaticScrollRef.current = false;
+	}, []);
+
+	const handleKeyDown = useCallback<KeyboardEventHandler<HTMLDivElement>>(
+		(event) => {
+			switch (event.key) {
+				case "ArrowUp":
+				case "Home":
+				case "PageUp":
+					programmaticScrollRef.current = false;
+					if (event.currentTarget.scrollTop > 0) updateScrollMode("manual");
+					return;
+				case " ":
+					programmaticScrollRef.current = false;
+					if (event.shiftKey && event.currentTarget.scrollTop > 0) {
+						updateScrollMode("manual");
+					}
+					return;
+				case "ArrowDown":
+				case "End":
+				case "PageDown":
+					programmaticScrollRef.current = false;
+					return;
+				default:
+					return;
+			}
+		},
+		[updateScrollMode]
+	);
+
+	useEffect(() => {
+		const shouldFollow = running || wasRunningRef.current;
+		wasRunningRef.current = running;
+		if (text.length === 0 || !shouldFollow || !followsBottomRef.current) return;
+
+		const frame = requestAnimationFrame(() => {
+			const element = scrollRef.current;
+			if (!element || !followsBottomRef.current) return;
+			programmaticScrollRef.current = true;
+			element.scrollTo({
+				top: element.scrollHeight,
+				behavior: reducedMotion ? "auto" : "smooth",
+			});
+		});
+
+		return () => cancelAnimationFrame(frame);
+	}, [reducedMotion, running, text]);
+
+	return {
+		scrollRef,
+		scrollMode,
+		handleKeyDown,
+		handlePointerDown,
+		handleScroll,
+		handleWheel,
+	};
+}


### PR DESCRIPTION
<!--- Summarize your pull request in a few sentences -->

## Description
<!--- Clearly describe what has changed in this pull request -->
- Prevent chat crashes when tool outputs contain JSON lists or scalar values instead of objects.
- Enhanced the reasoning steps container with smooth auto-follow scrolling, user-controlled pause/resume, cross-platform hidden scrollbars, and dynamic top/bottom overflow fades.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If this PR relates to an open issue, please link to the issue here: FIX #123 -->
FIX #


## Screenshots
<!-- If applicable, add screenshots or images to demonstrate the changes visually -->

## API Changes
<!-- Document any API changes if applicable -->
- [ ] This PR includes API changes

## Change Type
<!--- Indicate what kind(s) of changes this PR includes: -->
- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Dependency/Build system
- [ ] Breaking change
- [ ] Other (specify):

## Testing Performed
<!--- Briefly describe how you have tested these changes and what verification was performed -->
- [ ] Tested locally
- [ ] Manual/QA verification

## Checklist
<!--- Please confirm the following by marking with an 'x' as appropriate -->
- [ ] Follows project coding standards and conventions
- [ ] Documentation updated as needed
- [ ] Dependencies updated as needed
- [ ] No lint/build errors or new warnings
- [ ] All relevant tests are passing

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a crash issue in the chat streaming system that occurred when tool outputs contained non-dictionary values like JSON lists or scalar types. The fix adds a type check before accessing the `status` field to ensure `tool_output` is a dictionary before calling `.get()`, preventing AttributeError exceptions. Comprehensive test coverage has been added with 11 parameterized test cases covering various JSON shapes including lists, strings, numbers, booleans, null values, and malformed JSON.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_backend/app/tasks/chat/streaming/handlers/tool_end.py` |
| 2 | `surfsense_backend/tests/unit/tasks/chat/test_activity_contract.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->