### PR TITLE
[Fix] Signup credit backfill dies on a create_all-built table

### DIFF
--- a/surfsense_backend/alembic/versions/186_add_signup_credit_claims.py
+++ b/surfsense_backend/alembic/versions/186_add_signup_credit_claims.py
@@ -70,13 +70,14 @@ def _claim_existing_google_identities() -> None:
     )
 
     # Claim dates are this migration's own timestamp: "user" has no created_at
-    # to copy, and a shared one marks exactly which claims were inferred.
+    # to copy. NOW() is explicit: a create_all-built table has no DB default.
     for start in range(0, len(subjects), _BACKFILL_BATCH):
         bind.execute(
             sa.text(
                 """
-                INSERT INTO signup_credit_claims (identity_kind, identity_fingerprint)
-                VALUES (:identity_kind, :identity_fingerprint)
+                INSERT INTO signup_credit_claims
+                    (identity_kind, identity_fingerprint, created_at)
+                VALUES (:identity_kind, :identity_fingerprint, NOW())
                 ON CONFLICT (identity_kind, identity_fingerprint) DO NOTHING
                 """
             ),


### PR DESCRIPTION
Migration 186's backfill omitted `created_at`, relying on the `DEFAULT NOW()` in its own `CREATE TABLE`. Any deployment that boots before it migrates gets that table from `create_all` instead — where the timestamp default is Python-side only — so `IF NOT EXISTS` skips the DDL and the insert hits the not-null constraint. Pass `NOW()` explicitly.

Hit in prod on 0.0.38; unblocked there by hand, so this is for self-hosters and fresh installs.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
Fixes a database migration bug where the signup credit claims backfill failed on deployments using `create_all` instead of running the migration's DDL. The issue occurred because the `created_at` column wasn't explicitly set in the INSERT statement, relying on a database-level `DEFAULT NOW()` that only exists when the table is created via migration. The fix explicitly passes `NOW()` in the INSERT to ensure compatibility with tables created through SQLAlchemy's `create_all` method, which only defines Python-side defaults.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_backend/alembic/versions/186_add_signup_credit_claims.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->