### PR TITLE
fix(chat): honor provider Retry-After headers on rate limits

### DIFF
--- a/surfsense_backend/app/agents/chat/shared/middleware/retry_after.py
+++ b/surfsense_backend/app/agents/chat/shared/middleware/retry_after.py
@@ -16,7 +16,8 @@ Behaviour:
 - Extracts ``Retry-After`` / ``retry-after-ms`` from
   ``litellm.exceptions.RateLimitError.response.headers`` (or any exception
   exposing a similar shape).
-- Sleeps ``max(exponential_backoff, header_delay)`` between retries.
+- Sleeps ``max(exponential_backoff, header_delay)`` between retries,
+  capped at ``max_delay``.
 - Returns ``False`` from ``retry_on`` for context overflow so
   :class:`SurfSenseCompactionMiddleware` (or the LangChain summarization
   fallback path) handles it instead, and for the other categories a retry
@@ -33,7 +34,7 @@ import logging
 import random
 import re
 import time
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Mapping
 from typing import Any
 
 from langchain.agents.middleware.types import (
@@ -89,14 +90,18 @@ def _extract_retry_after_seconds(exc: BaseException) -> float | None:
     to a regex on the exception message for shapes like
     ``"Please retry after 30s"``.
     """
-    headers: dict[str, Any] | None = None
+    headers: Mapping[str, Any] | None = None
     response = getattr(exc, "response", None)
     if response is not None:
         headers = getattr(response, "headers", None)
     if headers is None:
         headers = getattr(exc, "headers", None)
 
-    if isinstance(headers, dict):
+    # ``Mapping``, not ``dict``: litellm rebuilds the error's ``response`` as an
+    # ``httpx.Response``, whose ``.headers`` is ``httpx.Headers`` -- a Mapping
+    # that is not a dict subclass. A ``dict`` check silently skips every real
+    # provider response.
+    if isinstance(headers, Mapping):
         # Normalize keys to lowercase for case-insensitive matching
         norm = {str(k).lower(): v for k, v in headers.items()}
         ms = norm.get("retry-after-ms")
@@ -197,7 +202,10 @@ class RetryAfterMiddleware(AgentMiddleware[AgentState[ResponseT], ContextT, Resp
             jitter=self.jitter,
         )
         header = _extract_retry_after_seconds(exc) or 0.0
-        return max(backoff, header)
+        # ``max_delay`` caps the header hint as well as the backoff: this loop
+        # runs inside the live turn, holding the SSE stream, the thread's busy
+        # lock and the DB session for whatever it sleeps.
+        return min(max(backoff, header), self.max_delay)
 
     def wrap_model_call(  # type: ignore[override]
         self,

--- a/surfsense_backend/tests/unit/agents/new_chat/test_retry_after.py
+++ b/surfsense_backend/tests/unit/agents/new_chat/test_retry_after.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+
+import httpx
 import pytest
+from litellm.exceptions import RateLimitError
 
 from app.agents.chat.shared.middleware.retry_after import (
     RetryAfterMiddleware,
@@ -14,15 +18,33 @@ pytestmark = pytest.mark.unit
 
 
 class _FakeResponse:
-    def __init__(self, headers: dict[str, str]) -> None:
+    def __init__(self, headers: Mapping[str, str]) -> None:
         self.headers = headers
 
 
 class _FakeRateLimitError(Exception):
-    def __init__(self, msg: str, headers: dict[str, str] | None = None) -> None:
+    def __init__(self, msg: str, headers: Mapping[str, str] | None = None) -> None:
         super().__init__(msg)
         if headers is not None:
             self.response = _FakeResponse(headers)
+
+
+def _litellm_rate_limit_error(**headers: str) -> RateLimitError:
+    """A rate-limit error shaped the way litellm actually raises one.
+
+    ``RateLimitError.__init__`` rebuilds ``self.response`` as an
+    ``httpx.Response``, so ``response.headers`` is always ``httpx.Headers``.
+    """
+    return RateLimitError(
+        message="rate limited",
+        llm_provider="openai",
+        model="gpt-4o",
+        response=httpx.Response(
+            429,
+            headers=headers,
+            request=httpx.Request("POST", "https://api.openai.com/v1/chat/completions"),
+        ),
+    )
 
 
 class TestExtractRetryAfter:
@@ -49,6 +71,19 @@ class TestExtractRetryAfter:
     def test_handles_missing_headers_attr(self) -> None:
         exc = ValueError("no headers")
         assert _extract_retry_after_seconds(exc) is None
+
+    def test_reads_headers_off_a_real_litellm_error(self) -> None:
+        """The shape production actually raises: ``httpx.Headers``.
+
+        The message carries no "retry after N", so this can only pass through
+        the header branch.
+        """
+        exc = _litellm_rate_limit_error(**{"Retry-After": "45"})
+        assert _extract_retry_after_seconds(exc) == 45.0
+
+    def test_reads_milliseconds_off_a_real_litellm_error(self) -> None:
+        exc = _litellm_rate_limit_error(**{"retry-after-ms": "1500"})
+        assert _extract_retry_after_seconds(exc) == 1.5
 
 
 class TestIsNonRetryable:
@@ -111,6 +146,19 @@ class TestDelayCalculation:
         )
         delay = mw._delay_for_attempt(5, RuntimeError("x"))
         assert delay <= 15.0
+
+    def test_caps_a_header_delay_at_max_delay(self) -> None:
+        """A provider hint is a hint, not a licence to hold the turn open.
+
+        The retry loop runs inside the live chat turn, so an hour-long
+        ``retry-after-ms`` would hold the SSE stream, the thread's busy lock
+        and the DB session for that hour.
+        """
+        mw = RetryAfterMiddleware(
+            max_retries=3, initial_delay=1.0, max_delay=30.0, jitter=False
+        )
+        exc = _litellm_rate_limit_error(**{"retry-after-ms": "3600000"})
+        assert mw._delay_for_attempt(0, exc) == pytest.approx(30.0)
 
 
 class TestShouldRetry:


### PR DESCRIPTION
`RetryAfterMiddleware` was written to obey a provider's `Retry-After` header instead of guessing with exponential backoff. The branch that reads the header is gated on `isinstance(headers, dict)`, but the header object litellm actually produces is `httpx.Headers` — a `Mapping` that is not a `dict` subclass — so that branch has never executed in production.

## Description

Two changes in `app/agents/chat/shared/middleware/retry_after.py`:

1. `_extract_retry_after_seconds` now tests `isinstance(headers, Mapping)` instead of `isinstance(headers, dict)`.
2. `_delay_for_attempt` caps the resulting delay at `max_delay`, which previously bounded only the exponential backoff.

### Symptom

A provider returns `429` with `Retry-After: 45`. SurfSense ignores it, sleeps its own `1s / 2s / 4s` backoff, burns all three retries inside roughly seven seconds, and fails the turn — the exact behaviour the module docstring says it was written to replace.

### Root cause

`_extract_retry_after_seconds` reads `exc.response.headers` and then gates on `isinstance(headers, dict)`. `litellm.exceptions.RateLimitError.__init__` rebuilds the error's response unconditionally:

```python
self.response = httpx.Response(
    status_code=429,
    headers=_response_headers,
    request=httpx.Request(method="POST", url=" https://cloud.google.com/vertex-ai/"),
)
```

so `.headers` is always `httpx.Headers`, which subclasses `MutableMapping`, not `dict`. Measured against the versions this repo pins:

```
litellm 1.88.1 | openai 2.24.0 | httpx 0.28.1
RateLimitError mro: ['RateLimitError', 'RateLimitError', 'APIStatusError', 'APIError', 'OpenAIError', 'Exception', 'BaseException']
exc.response: Response | headers: Headers
isinstance(headers, dict)    -> False
isinstance(headers, Mapping) -> True
```

The models are driven through `ChatLiteLLM` (`app/agents/chat/runtime/llm_config.py`, `app/services/llm_service.py`), so this is the only shape the middleware ever sees. With the branch skipped, the function falls through to its message regex, which does not match litellm's message (`"litellm.RateLimitError: ..."`), and returns `None`.

The existing tests did not catch this because their fixture builds the headers as a plain `dict[str, str]` (`tests/unit/agents/new_chat/test_retry_after.py`), so they exercise a branch production never reaches.

### The second defect, and why it belongs in the same PR

`_delay_for_attempt` did `return max(backoff, header)`. `max_delay` is documented as "Cap on per-attempt delay in seconds" but only ever constrained `backoff`. That was harmless while `header` was permanently `0.0`; fixing the first defect makes it reachable. A `retry-after-ms: 3600000` from a misconfigured gateway would become `await asyncio.sleep(3600)`, and this loop runs inside the live chat turn — it holds the SSE stream, the thread's busy-mutex lock and the DB session for the whole sleep. The delay is now `min(max(backoff, header), self.max_delay)`.

## Motivation and Context

No linked issue — found while auditing the retry path. The module's entire reason to exist is header-aware retry, and that path was dead.

## Screenshots

Not applicable — no UI change.

## API Changes

- [ ] This PR includes API changes

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Dependency/Build system
- [ ] Breaking change
- [ ] Other (specify):

## Testing Performed

- [x] Tested locally
- [ ] Manual/QA verification

Three tests were added to `tests/unit/agents/new_chat/test_retry_after.py`. Two build a real `litellm.exceptions.RateLimitError` rather than a hand-rolled fake, so they cover the shape production raises; the third pins the cap.

Run against the current `dev` code, before the fix:

```
FAILED tests/unit/agents/new_chat/test_retry_after.py::TestExtractRetryAfter::test_reads_headers_off_a_real_litellm_error
FAILED tests/unit/agents/new_chat/test_retry_after.py::TestExtractRetryAfter::test_reads_milliseconds_off_a_real_litellm_error
FAILED tests/unit/agents/new_chat/test_retry_after.py::TestDelayCalculation::test_caps_a_header_delay_at_max_delay
3 failed, 19 passed
```

After:

```
22 passed
```

No existing test changed. `test_takes_max_of_backoff_and_header` uses a 10s header under the default 60s cap, so the new clamp does not alter its result.

Full unit suite, before and after the change: `11 failed, 2997 passed, 1 skipped`. The eleven are pre-existing on `dev` (git-tree and knowledge-store tests plus `test_pat_fail_closed_static`) and reproduce on a clean `dev` checkout on this machine — they are unrelated to this diff.

`ruff check` and `ruff format --check` are clean on both changed files.

## What does not change

- Which exceptions are retried. `_NON_RETRYABLE_CATEGORIES`, `_is_non_retryable` and the `retry_on` hook are untouched.
- The exponential backoff formula, the jitter, the retry count, and the `max_delay` default of 60s.
- The `surfsense.retrying` custom event and its payload.
- Behaviour when a provider sends no header: `_extract_retry_after_seconds` still returns `None` and the backoff is used unchanged.

## Remaining risk

Turns can now take longer, because a hint that was previously discarded is obeyed. That is the intended behaviour, and `max_delay` is its ceiling. I did not change the default cap — 60s is the existing value and picking a different one is a product call.

## Checklist

- [x] Follows project coding standards and conventions
- [ ] Documentation updated as needed
- [ ] Dependencies updated as needed
- [x] No lint/build errors or new warnings
- [x] All relevant tests are passing

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a bug in the retry middleware that prevented it from honoring provider `Retry-After` headers. The `RetryAfterMiddleware` was designed to respect rate limit hints from LLM providers but has never worked in production because it checked for `dict` headers when `litellm` actually returns `httpx.Headers` (a `Mapping` that is not a `dict` subclass). The fix changes the type check from `isinstance(headers, dict)` to `isinstance(headers, Mapping)` so the header-reading branch can execute. Additionally, the `max_delay` cap now applies to provider-supplied delays as well as exponential backoff to prevent extremely long sleep periods from blocking the chat turn, SSE stream, and database session.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_backend/app/agents/chat/shared/middleware/retry_after.py` |
| 2 | `surfsense_backend/tests/unit/agents/new_chat/test_retry_after.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->