### PR TITLE
fix(retriever): return top_k documents from the chunk retriever

### DIFF
--- a/surfsense_backend/app/retriever/chunks_hybrid_search.py
+++ b/surfsense_backend/app/retriever/chunks_hybrid_search.py
@@ -10,6 +10,31 @@ from app.utils.perf import get_perf_logger
 _MAX_FETCH_CHUNKS_PER_DOC = 20
 
 
+def _cap_chunks_per_document(
+    chunks: list[dict], matched_ids: set[int], *, limit: int
+) -> list[dict]:
+    """Keep at most ``limit`` chunks for one document, matched ones first.
+
+    ``chunks`` arrives in reading order and the returned list preserves it;
+    only the selection is priority-ordered. Matched chunks are the citable
+    ones, so they are kept ahead of surrounding context.
+    """
+    if len(chunks) <= limit:
+        return chunks
+
+    keep: set[int] = set()
+    for chunk in chunks:
+        if len(keep) >= limit:
+            break
+        if chunk["chunk_id"] in matched_ids:
+            keep.add(chunk["chunk_id"])
+    for chunk in chunks:
+        if len(keep) >= limit:
+            break
+        keep.add(chunk["chunk_id"])
+    return [chunk for chunk in chunks if chunk["chunk_id"] in keep]
+
+
 def _instrument_search(mode: str):
     def _decorator(func):
         @functools.wraps(func)
@@ -344,7 +369,10 @@ class ChucksHybridSearchRetriever:
             )
             .options(joinedload(Chunk.document))
             .order_by(text("score DESC"))
-            .limit(top_k)
+            # Chunk rows, not documents: a chunk-dense document would otherwise
+            # fill a top_k-sized fusion window on its own and crowd every other
+            # document out. The document cap is applied after grouping, below.
+            .limit(n_results)
         )
 
         # Execute the RRF query
@@ -484,6 +512,20 @@ class ChucksHybridSearchRetriever:
         final_docs: list[dict] = []
         for doc_id in doc_ids:
             entry = doc_map[doc_id]
+            # The fusion window is sized in chunks, so a chunk-dense
+            # document can match far more passages than one prompt should
+            # carry. Bound what each document contributes, keeping the
+            # citable chunks first.
+            entry["chunks"] = _cap_chunks_per_document(
+                entry["chunks"],
+                matched_chunk_ids,
+                limit=_MAX_FETCH_CHUNKS_PER_DOC,
+            )
+            entry["matched_chunk_ids"] = [
+                chunk["chunk_id"]
+                for chunk in entry["chunks"]
+                if chunk["chunk_id"] in matched_chunk_ids
+            ]
             entry["content"] = "\n\n".join(
                 c["content"] for c in entry.get("chunks", []) if c.get("content")
             )

--- a/surfsense_backend/tests/integration/retriever/test_optimized_chunk_retriever.py
+++ b/surfsense_backend/tests/integration/retriever/test_optimized_chunk_retriever.py
@@ -114,3 +114,41 @@ async def test_score_is_positive_float(db_session, seed_large_doc):
     for result in results:
         assert isinstance(result["score"], float)
         assert result["score"] > 0
+
+
+async def test_top_k_counts_documents_not_chunks(db_session, seed_large_doc):
+    """``top_k`` is documented as a document count, so a chunk-dense document
+    must not be able to consume the whole result set.
+
+    ``large_doc`` has 35 matching chunks and ``small_doc`` has one. If the
+    fused query is capped at ``top_k`` *chunk* rows, the large document fills
+    that cap by itself and the second document never reaches the caller.
+    """
+    space_id = seed_large_doc["workspace"].id
+
+    retriever = ChucksHybridSearchRetriever(db_session)
+    results = await retriever.hybrid_search(
+        query_text="quarterly performance review",
+        top_k=10,
+        workspace_id=space_id,
+        query_embedding=DUMMY_EMBEDDING,
+    )
+
+    returned = {result["document"]["id"] for result in results}
+    assert seed_large_doc["large_doc"].id in returned
+    assert seed_large_doc["small_doc"].id in returned
+
+
+async def test_top_k_still_caps_the_number_of_documents(db_session, seed_large_doc):
+    """The cap itself keeps working: two matching documents, ``top_k=1``."""
+    space_id = seed_large_doc["workspace"].id
+
+    retriever = ChucksHybridSearchRetriever(db_session)
+    results = await retriever.hybrid_search(
+        query_text="quarterly performance review",
+        top_k=1,
+        workspace_id=space_id,
+        query_embedding=DUMMY_EMBEDDING,
+    )
+
+    assert len(results) == 1


### PR DESCRIPTION
`ChucksHybridSearchRetriever.hybrid_search` documents `top_k` as "Number of documents to return", but the reciprocal-rank-fusion query is limited to `top_k` *chunk* rows. Those rows are then grouped by document, so a single chunk-dense document can consume the whole window and every other match is silently dropped before the caller sees it.

## Description

Two changes in `app/retriever/chunks_hybrid_search.py`, which have to land together.

1. The fused query is limited to `n_results` (`top_k * 5`, the candidate-pool size the function already computes) instead of `top_k`. The document cap is applied after grouping, where it always was.
2. A per-document chunk cap is enforced on the assembled result. The fusion window is measured in chunks, so widening it lets one document contribute far more passages than before; `_MAX_FETCH_CHUNKS_PER_DOC` previously bounded only the surrounding context chunks, never the matched ones.

### Symptom

Ask for ten documents, get one.

`ConnectorService._combined_rrf_search` calls this retriever with `retriever_top_k = top_k * 2` for every connector surface, so the loss scales with the request.

### Root cause

```python
n_results = top_k * 5   # "Fetch extra chunks for better document-level fusion"
...
semantic_search_cte  = ... .limit(n_results)
keyword_search_cte   = ... .limit(n_results)
...
final_query = ... .order_by(text("score DESC")).limit(top_k)   # chunk rows
...
doc_ids = doc_order[:top_k]   # "Keep only top_k documents"
```

Both CTE legs collect `top_k * 5` candidates, and then the fusion query throws that pool away by taking `top_k` rows. Those rows are chunks. Grouping N chunks yields at most N documents, so `doc_order[:top_k]` on the last line can never truncate anything: it runs, but the slice is always a no-op. The two comments describe an intent the code does not implement.

Three things in the tree say this is a mistake rather than a design choice:

- The sibling module `app/retriever/documents_hybrid_search.py:323` ends with the same `.limit(top_k)`, but there the rows *are* documents, so it is correct. The chunk retriever inherited a limit whose unit changed underneath it.
- The newer retrieval path does it the other way round: `app/agents/chat/multi_agent_chat/shared/retrieval/hybrid_search.py:194` limits the fused query to `candidate_pool` (`top_k * _CANDIDATE_MULTIPLIER`, also `× 5`) and truncates to `top_k` documents afterwards, at `:233`.
- That newer module has `test_top_k_caps_the_number_of_documents`. The legacy retriever has no equivalent — `test_optimized_chunk_retriever.py` only asserted `len(results) >= 1`.

This code is live: `ConnectorService` builds the retriever at `app/services/connector_service.py:28` and `:210`, `_combined_rrf_search` is the shared path behind roughly fifteen connector searches, and `ConnectorService` is constructed on the streaming chat path (`app/tasks/chat/streaming/flows/shared/pre_stream_setup.py:17`).

### Why the second change is required, not scope creep

With only the limit fixed, the existing test `test_per_doc_chunk_limit_respected` fails:

```
E   AssertionError: assert 35 <= 20
```

The per-document fetch filter is `rn <= _MAX_FETCH_CHUNKS_PER_DOC OR Chunk.id.in_(matched_chunk_ids)`, so matched chunks were always exempt from the cap. That was invisible while the fusion window held at most `top_k` chunks in total — the matched set was small enough to fit under `rn <= 20` on its own. Widen the window and a 35-chunk document returns all 35, which is a context-size regression rather than a fix.

`_cap_chunks_per_document` bounds each document's contribution at `_MAX_FETCH_CHUNKS_PER_DOC`, keeping matched (citable) chunks ahead of surrounding context and preserving reading order. `matched_chunk_ids` is recomputed from what survives, so it never advertises a chunk that is not in the payload. This mirrors `_reading_order` in the newer module, which keeps `_MAX_PASSAGES_PER_DOC` chunks per document for the same reason.

## Motivation and Context

No linked issue — found while comparing the legacy retriever against the newer `shared/retrieval` path.

## Screenshots

Not applicable — no UI change.

## API Changes

- [ ] This PR includes API changes

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Dependency/Build system
- [ ] Breaking change
- [ ] Other (specify):

## Testing Performed

- [x] Tested locally
- [ ] Manual/QA verification

Two tests were added to `tests/integration/retriever/test_optimized_chunk_retriever.py`, using the existing `seed_large_doc` fixture (one document with 35 matching chunks, one with a single matching chunk):

- `test_top_k_counts_documents_not_chunks` — with `top_k=10`, both documents must come back.
- `test_top_k_still_caps_the_number_of_documents` — with `top_k=1`, exactly one comes back, so the cap itself is still exercised.

Against `dev`, the first one fails:

```
    assert seed_large_doc["large_doc"].id in returned
>   assert seed_large_doc["small_doc"].id in returned
E   assert 12 in {11}
```

The retriever's own perf log makes the change visible: `docs=1` before, `docs=2` after, from the same query and the same seed data.

Results on this branch:

- `tests/integration/retriever` + `tests/unit/retriever`: `12 passed`. No existing test was modified.
- Full unit suite: `11 failed, 2994 passed, 1 skipped`, identical to a clean `dev` checkout on this machine (git-tree and knowledge-store tests plus `test_pat_fail_closed_static`), so none of them come from this diff.
- `ruff check` and `ruff format --check` clean on both changed files.

## What does not change

- Scoring. The RRF constant, the two search legs, their `n_results` candidate pools and the `score DESC` ordering are untouched.
- Document ordering. Documents still come back in first-seen fusion-rank order.
- The result dict shape: `chunk_id`, `content`, `chunks`, `document`, `score`, `matched_chunk_ids`, `source`.
- Filters: `document_type`, the date range, workspace scoping, and the exclusion of documents in the `deleting` state.
- `documents_hybrid_search.py`, which is correct as it stands.
- `_MAX_FETCH_CHUNKS_PER_DOC` keeps its value of 20.

## Remaining risk

The fused query now returns up to `top_k * 5` rows instead of `top_k`, so it does more work — that is the cost of actually filling the window, and it is the same trade-off the newer `shared/retrieval` module already makes with an identical multiplier. Per-document payload size is bounded either way by the cap in change 2.

One behaviour genuinely changes: a document that matches more than 20 chunks now returns its 20 best-ranked matches instead of all of them. Before this PR that case could not arise in practice, because the fusion window was never wide enough to produce it.

## Checklist

- [x] Follows project coding standards and conventions
- [ ] Documentation updated as needed
- [ ] Dependencies updated as needed
- [x] No lint/build errors or new warnings
- [x] All relevant tests are passing

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a critical bug in `ChucksHybridSearchRetriever` where requesting N documents would often return fewer documents than expected. The issue occurred because the reciprocal-rank-fusion query was limited to `top_k` *chunk* rows instead of documents, allowing a single chunk-dense document to consume the entire result window and silently drop other matches. The fix widens the fusion window to `top_k * 5` (the existing candidate pool size) and applies the `top_k` limit after grouping chunks by document. Additionally, a per-document chunk cap (`_MAX_FETCH_CHUNKS_PER_DOC`) is enforced to prevent context-size regression when matched chunks exceed 20 per document.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_backend/tests/integration/retriever/test_optimized_chunk_retriever.py` |
| 2 | `surfsense_backend/app/retriever/chunks_hybrid_search.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->