### PR TITLE
fix(web): use ES2022-safe array copies in client code

### DIFF
--- a/surfsense_web/app/(home)/free/[model_slug]/page.tsx
+++ b/surfsense_web/app/(home)/free/[model_slug]/page.tsx
@@ -195,8 +195,8 @@ export default async function FreeModelPage({ params }: PageProps) {
 						<header className="mb-6">
 							<h1 className="text-2xl font-bold mb-2">Chat with {model.name} Free, No Login</h1>
 							<p className="text-sm text-muted-foreground leading-relaxed">
-								Use <strong>{model.name}</strong> free online without login or sign-up. No account, no
-								email, no password needed. Powered by SurfSense.
+								Use <strong>{model.name}</strong> free online without login or sign-up. No account,
+								no email, no password needed. Powered by SurfSense.
 							</p>
 						</header>
 

--- a/surfsense_web/components/free-chat/free-model-selector.tsx
+++ b/surfsense_web/components/free-chat/free-model-selector.tsx
@@ -48,7 +48,7 @@ export function FreeModelSelector({ className }: { className?: string }) {
 
 	// Free models first, premium last; immutable sort to avoid mutating state.
 	const sortedModels = useMemo(
-		() => models.toSorted((a, b) => Number(a.is_premium) - Number(b.is_premium)),
+		() => [...models].sort((a, b) => Number(a.is_premium) - Number(b.is_premium)),
 		[models]
 	);
 

--- a/surfsense_web/components/layout/ui/sidebar/NotificationsDropdown.tsx
+++ b/surfsense_web/components/layout/ui/sidebar/NotificationsDropdown.tsx
@@ -124,7 +124,7 @@ export function NotificationsDropdown({
 
 		return sourceItems
 			.filter((item) => activeFilter !== "unread" || !item.read)
-			.toSorted((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
+			.sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime());
 	}, [activeFilter, notifications.comments.items, notifications.status.items]);
 
 	const loadMoreForActiveFilter = useCallback(() => {

--- a/surfsense_web/hooks/use-comments-sync.ts
+++ b/surfsense_web/hooks/use-comments-sync.ts
@@ -118,8 +118,8 @@ function transformComments(
 
 	for (const [messageId, group] of byMessage) {
 		const comments: Comment[] = group.topLevel.map((raw) => {
-			const replies = (group.replies.get(raw.id) ?? [])
-				.toSorted((a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime())
+			const replies = [...(group.replies.get(raw.id) ?? [])]
+				.sort((a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime())
 				.map((r) => transformReply(r, memberMap, currentUserId, isOwner));
 
 			return {

--- a/surfsense_web/lib/chat/activity-journal.ts
+++ b/surfsense_web/lib/chat/activity-journal.ts
@@ -89,7 +89,7 @@ export function compareActivities(a: ActivityData, b: ActivityData): number {
 }
 
 export function sortActivities(activities: Iterable<ActivityData>): ActivityData[] {
-	return [...activities].toSorted(compareActivities);
+	return [...activities].sort(compareActivities);
 }
 
 export function parseActivityData(value: unknown): ActivityData | null {

--- a/surfsense_web/lib/chat/message-utils.ts
+++ b/surfsense_web/lib/chat/message-utils.ts
@@ -206,7 +206,7 @@ export function reconcileInterruptedAssistantMessages<T extends AbortableMessage
 		const olderIdxs = mergeInto.get(i);
 		if (olderIdxs && olderIdxs.length > 0) {
 			let merged = messages[i];
-			for (const olderIdx of olderIdxs.toReversed()) {
+			for (const olderIdx of [...olderIdxs].reverse()) {
 				merged = mergeInterruptedIntoResume(messages[olderIdx], merged);
 			}
 			result.push(merged);


### PR DESCRIPTION
The dashboard throws `.filter(...).toSorted is not a function` on Chrome 109 and any other browser below the ES2023 line. `Array.prototype.toSorted` and `toReversed` shipped in Chrome/Edge 110, Safari 16.4 and Firefox 115, and nothing in the build adds them. This replaces the five client-side uses with ES2022-safe equivalents.

## Description

Five call sites in `surfsense_web`:

| File | Was | Now |
| --- | --- | --- |
| `components/layout/ui/sidebar/NotificationsDropdown.tsx:127` | `.filter(...).toSorted(cmp)` | `.filter(...).sort(cmp)` |
| `hooks/use-comments-sync.ts:122` | `(group.replies.get(raw.id) ?? []).toSorted(cmp)` | `[...(group.replies.get(raw.id) ?? [])].sort(cmp)` |
| `components/free-chat/free-model-selector.tsx:51` | `models.toSorted(cmp)` | `[...models].sort(cmp)` |
| `lib/chat/activity-journal.ts:92` | `[...activities].toSorted(cmp)` | `[...activities].sort(cmp)` |
| `lib/chat/message-utils.ts:209` | `olderIdxs.toReversed()` | `[...olderIdxs].reverse()` |

Where the receiver is already a fresh array — the `filter` result in `NotificationsDropdown`, the spread in `activity-journal` — sorting in place is safe and no extra copy is added. Everywhere else the receiver is state or a value held in a `Map`, so the copy is not optional; see below.

### Symptom

Two auto-filed bug reports carry the same diagnostics block:

```
(intermediate value)(intermediate value)(intermediate value).filter(...).toSorted is not a function
Page:       /dashboard/<id>/new-chat
User agent: Chrome/109
```

`#1645` and `#1644` are the same defect, four minutes apart, from the same reporter. The stack points at `NotificationsDropdown`, where the call is inside a `useMemo` — so it throws during render and takes the notifications dropdown down with it, rather than failing quietly.

### Root cause

`surfsense_web/tsconfig.json` sets `"target": "ES2017"`. That downlevels *syntax* only; it never adds built-in methods, and there is no polyfill in the app. TypeScript does not warn either, because `"lib"` includes `esnext`, which declares `toSorted`/`toReversed` as available. There is no `browserslist` key in `package.json` and no `.browserslistrc`, so the support floor is implicit and nothing enforces it.

### Two of these were also mutation bugs

- `hooks/use-comments-sync.ts:122` sorts `group.replies.get(raw.id)`, an array stored in a `Map` that the same pass reads again. A naive `.toSorted` → `.sort` swap there would reorder the stored array in place.
- `lib/chat/message-utils.ts:209` reverses `mergeInto.get(i)`, also a stored array.

Both now copy before sorting, so the shared arrays are left alone. That is a small behavioural improvement, not just a compatibility fix.

### What is deliberately not changed

`app/(home)/changelog/page.tsx:36` also calls `toSorted`, and it is left alone: that page renders on the server, where Node 20+ has the method. Including it would have widened the diff without fixing a user-visible failure. The same reasoning applies to `features/chat-messages/timeline/grouping.ts:168`, which uses `findLastIndex` — also ES2023, but supported since Chrome 97, so it is not part of this failure.

### One unrelated formatting fix, and why it is here

`app/(home)/free/[model_slug]/page.tsx` carries a `format` error that is already on `dev`:

```
Checked 1097 files in 2s. No fixes applied.
Found 1 error.
```

The `biome-check-web` hook in `.pre-commit-config.yaml` sets `always_run: true` with `pass_filenames: false`, so it checks the whole `surfsense_web` tree regardless of what a PR touched — the workflow's `--from-ref/--to-ref` narrowing does not reach it. That one error therefore fails `Frontend Quality` for every open PR, including backend-only ones. The fix is the unmodified output of `biome check --write` on that single file: a two-line reflow, no logic.

## Motivation and Context

FIX #1645

`#1644` is the same defect from the same reporter and is also resolved by this change. Since contributions merge into `dev` rather than the default branch, GitHub will not close either automatically.

## Screenshots

Not applicable — no visual change. Sort order and rendering are identical.

## API Changes

- [ ] This PR includes API changes

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Dependency/Build system
- [ ] Breaking change
- [ ] Other (specify):

## Testing Performed

- [x] Tested locally
- [ ] Manual/QA verification

- `biome check --diagnostic-level=error .` in `surfsense_web`, pinned 2.4.6: `Checked 1097 files. No fixes applied.` — zero errors, where `dev` reports one. Measured on an LF checkout, since a Windows working tree reports a format error on every file otherwise.
- `tsc --noEmit`: 19 errors, the same 19 as on a clean `dev` checkout, none of them in the six files this PR touches. I did not try to fix them; they are unrelated.
- Confirmed no `toSorted`/`toReversed` remains outside the server-rendered changelog page.

## What does not change

- Sort and reverse results. Every comparator is passed through unchanged, and `Array.prototype.sort` is stable in every engine this targets, so orderings are identical.
- Component structure, hook dependency arrays, and rendering.
- Type signatures: `[...arr].sort(cmp)` and `arr.toSorted(cmp)` both yield `T[]`.
- `tsconfig.json`. See below.

## Remaining risk

Small, but worth naming: this fixes the five sites that exist today and adds no guard against the sixth. The obvious guard would be narrowing `"lib"` from `esnext` to `es2022` in `tsconfig.json`, which turns any ES2023 built-in into a compile error. I did not include it, because it would also flag `findLastIndex`, which is fine on the browsers this bug is about, and the resulting rewrite would have nothing to do with the report. A `browserslist` entry documents intent but does not enforce it for built-ins. Happy to follow up with whichever you prefer.

## Checklist

- [x] Follows project coding standards and conventions
- [ ] Documentation updated as needed
- [ ] Dependencies updated as needed
- [x] No lint/build errors or new warnings
- [x] All relevant tests are passing

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes browser compatibility issues by replacing ES2023 methods (`toSorted` and `toReversed`) with ES2022-safe equivalents in client-side code. The changes prevent "is not a function" errors on Chrome 109 and other browsers that don't support ES2023 array methods. The fix converts five call sites to use array spread with `sort()` and `reverse()` instead, which also resolves two mutation bugs where shared arrays were being modified in place. An unrelated formatting fix in `page.tsx` is included to unblock CI checks.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/app/(home)/free/[model_slug]/page.tsx` |
| 2 | `surfsense_web/components/layout/ui/sidebar/NotificationsDropdown.tsx` |
| 3 | `surfsense_web/components/free-chat/free-model-selector.tsx` |
| 4 | `surfsense_web/lib/chat/activity-journal.ts` |
| 5 | `surfsense_web/hooks/use-comments-sync.ts` |
| 6 | `surfsense_web/lib/chat/message-utils.ts` |
</details>

<details>
<summary>⚠️ Inconsistent Changes Detected</summary>

| File Path | Warning |
|-----------|---------|
| `surfsense_web/app/(home)/free/[model_slug]/page.tsx` | This is a formatting-only change (text reflow) that is unrelated to the ES2022 compatibility fixes described in the PR. While the PR explains this was needed to fix CI, it's not part of the main bug fix. |
</details>

[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->