### PR TITLE
fix(e2e): probe the celery worker over the broker, not through the app

### DIFF
--- a/docker/docker-compose.e2e.yml
+++ b/docker/docker-compose.e2e.yml
@@ -22,28 +22,28 @@
 name: surfsense-e2e
 
 x-backend-env: &backend-env
-  DATABASE_URL: postgresql+asyncpg://postgres:postgres@db:5432/surfsense_e2e
+  DATABASE_URL: postgresql+asyncpg://postgres:postgres@db:5432/surfsense_e2e  # pragma: allowlist secret
   CELERY_BROKER_URL: redis://redis:6379/0
   CELERY_RESULT_BACKEND: redis://redis:6379/0
   REDIS_APP_URL: redis://redis:6379/0
   CELERY_TASK_DEFAULT_QUEUE: surfsense
-  SECRET_KEY: ci-test-secret-key-not-for-production
+  SECRET_KEY: ci-test-secret-key-not-for-production  # pragma: allowlist secret
   AUTH_TYPE: LOCAL
   REGISTRATION_ENABLED: "TRUE"
   ETL_SERVICE: DOCLING
   EMBEDDING_MODEL: sentence-transformers/all-MiniLM-L6-v2
   NEXT_FRONTEND_URL: http://host.docker.internal:3000
   # Sentinel keys — fakes never read them; turns leaked real calls into 401s.
-  COMPOSIO_API_KEY: e2e-deny-real-call-sentinel
+  COMPOSIO_API_KEY: e2e-deny-real-call-sentinel  # pragma: allowlist secret
   COMPOSIO_ENABLED: "TRUE"
-  OPENAI_API_KEY: e2e-deny-real-call-sentinel
-  ANTHROPIC_API_KEY: e2e-deny-real-call-sentinel
-  LITELLM_API_KEY: e2e-deny-real-call-sentinel
+  OPENAI_API_KEY: e2e-deny-real-call-sentinel  # pragma: allowlist secret
+  ANTHROPIC_API_KEY: e2e-deny-real-call-sentinel  # pragma: allowlist secret
+  LITELLM_API_KEY: e2e-deny-real-call-sentinel  # pragma: allowlist secret
   MICROSOFT_CLIENT_ID: fake-microsoft-client-id
-  MICROSOFT_CLIENT_SECRET: fake-microsoft-client-secret
+  MICROSOFT_CLIENT_SECRET: fake-microsoft-client-secret  # pragma: allowlist secret
   ONEDRIVE_REDIRECT_URI: http://localhost:8000/api/v1/auth/onedrive/connector/callback
   DROPBOX_APP_KEY: fake-dropbox-app-key
-  DROPBOX_APP_SECRET: fake-dropbox-app-secret
+  DROPBOX_APP_SECRET: fake-dropbox-app-secret  # pragma: allowlist secret
   DROPBOX_REDIRECT_URI: http://localhost:8000/api/v1/auth/dropbox/connector/callback
   # Defense-in-depth: even though L3 egress is denied for the worker via
   # `internal: true`, the backend still has a route via `ingress`. Setting
@@ -57,7 +57,7 @@ x-backend-env: &backend-env
   HF_HUB_OFFLINE: "1"
   TRANSFORMERS_OFFLINE: "1"
   # Test-only token-mint endpoint secret (see tests/e2e/run_backend.py).
-  E2E_MINT_SECRET: e2e-mint-secret-not-for-production
+  E2E_MINT_SECRET: e2e-mint-secret-not-for-production  # pragma: allowlist secret
 
 services:
   db:
@@ -69,7 +69,7 @@ services:
         -c max_replication_slots=10
     environment:
       POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
+      POSTGRES_PASSWORD: postgres  # pragma: allowlist secret
       POSTGRES_DB: surfsense_e2e
     # Ephemeral storage — every CI run gets a clean DB, no volume cleanup needed.
     tmpfs:

--- a/docker/docker-compose.e2e.yml
+++ b/docker/docker-compose.e2e.yml
@@ -154,13 +154,21 @@ services:
     depends_on:
       backend: { condition: service_healthy }
     healthcheck:
+      # Probe over the broker, not through the app. `-A app.celery_app` makes
+      # the CLI import the entire application before it can send a single
+      # ping -- embeddings, litellm, docling, the lot -- which takes ~40s in
+      # CI and can never finish inside `timeout`. Every probe was killed
+      # mid-import, so the worker was reported unhealthy while it was in fact
+      # up and serving. `-b` reaches the broadcast exchange directly and
+      # needs no import, so the probe costs ~3s.
       test:
         - CMD-SHELL
-        - "celery -A app.celery_app inspect ping --timeout 2 | grep -q pong"
+        - 'celery -b "$$CELERY_BROKER_URL" inspect ping --timeout 2 | grep -q pong'
       interval: 5s
-      timeout: 5s
+      timeout: 10s
       retries: 12
-      start_period: 20s
+      # The worker itself needs ~40s to import the app and report ready.
+      start_period: 45s
     networks: [internal]
 
 networks:


### PR DESCRIPTION
The `Journey` E2E job has not passed in the last 60 workflow runs — 25 failures, 24 skipped, 11 cancelled, zero successes — including runs on `dev` itself. Every one of them dies in *Build & start backend stack* with `container surfsense-e2e-celery_worker-1 is unhealthy`, before a single test executes. The worker is not actually unhealthy: its health probe cannot possibly finish inside its own timeout.

## Description

One healthcheck in `docker/docker-compose.e2e.yml`. The probe now talks to the broker instead of booting the application:

```diff
-        - "celery -A app.celery_app inspect ping --timeout 2 | grep -q pong"
+        - 'celery -b "$$CELERY_BROKER_URL" inspect ping --timeout 2 | grep -q pong'
```

plus `timeout: 5s` to `10s` and `start_period: 20s` to `45s`.

### Symptom

From the stack logs uploaded by the failing job itself (`backend-stack-logs`, run 32505236720):

```
celery_worker-1 | 17:00:26.962 [INFO/MainProcess] Connected to redis://redis:6379/0
celery_worker-1 | 17:00:26.991 [INFO/MainProcess] celery@2bf790540dd8 ready.
```

and `ps.txt` from the same artifact:

```
surfsense-e2e-backend-1        Up 3 minutes (healthy)
surfsense-e2e-celery_worker-1  Up 2 minutes (unhealthy)
surfsense-e2e-db-1             Up 3 minutes (healthy)
surfsense-e2e-redis-1          Up 3 minutes (healthy)
```

The worker reported `ready.` at 17:00:26 and the job aborted at 17:02:05. There is no error, no traceback and no further output in the worker log after it came up. It was serving the whole time.

### Root cause

`celery -A app.celery_app ...` makes the CLI **import the entire application** before it can send anything: `app.celery_app` pulls in `app.config`, which builds the sentence-transformers embedding instance, the chunkers, the LiteLLM router and the ETL stack at import time. Measured here, on a warm machine with a warm model cache:

| command | time |
| --- | --- |
| `celery --version` (bare CLI import) | 0.96 s |
| `python -c "import app.celery_app"` | **20.1 s** |
| `celery -A app.celery_app inspect ping --timeout 2` | **26.8 s** (broker refused instantly — the time is all import) |
| `celery -b <broker> inspect ping --timeout 2` | 3.1 s |

The healthcheck allows `timeout: 5s`. Docker kills the probe at five seconds, roughly fifteen seconds before the import would have finished, so **every** probe fails regardless of the worker's state. After `retries: 12` the container flips to unhealthy and `--wait` tears the job down.

The same worker log shows the import cost in CI directly: entrypoint at 16:59:44, `ready.` at 17:00:26 — about 42 s, on a cold container.

The `backend` service does not hit this because its probe is an HTTP GET against the already-running server (`urllib` only, sub-second), which is why one container is healthy and its twin — same image, same env — is not.

### Why this solution

`-b` gives the CLI the broker URL directly, so no application import happens; `inspect ping` reaches the worker over Celery's broadcast (pidbox) exchange, which is app-name independent. The repo sets no custom `control_exchange` and uses the default JSON serializer, so nothing about SurfSense's Celery configuration blocks it.

Verified locally against a worker running the same relevant configuration (app name `surfsense`, `task_default_queue=surfsense`, JSON serializer) on redis:

```
$ celery -b redis://localhost:56379/0 inspect ping --timeout 2
->  celery@DESKTOP-CVV8E68: OK
        pong

1 node online.
```

`grep -q pong` exits 0, in 3.1 s. **The probe still detects a genuinely dead worker** — with the worker stopped and redis still up, `inspect ping` prints `Error: No nodes replied within time constraint` and the `grep` exits 1.

Compose's `$$` escaping was verified rather than assumed, with a throwaway service using the same `CMD-SHELL` form: the container went healthy on the first probe, so `$$CELERY_BROKER_URL` reaches the container shell as a single-dollar reference and expands there.

The two timing changes are margin, not the fix: `timeout: 10s` leaves room above the measured ~3 s probe, and `start_period: 45s` covers the ~42 s the worker legitimately needs to import the app, so startup no longer burns retries. Neither weakens the check — `--wait-timeout 300` in the workflow still bounds the whole bring-up.

### The second commit, and why it is here

Touching this file at all turns `Security Scan` red. `detect-secrets` reads the whole changed
file rather than the changed lines, and the repo's `.secrets.baseline` contains zero entries,
so ten pre-existing lines fail the gate: the container-local postgres DSN, the
`e2e-deny-real-call-sentinel` keys, `fake-microsoft-client-secret`, `fake-dropbox-app-secret`,
and two values whose own text ends in `-not-for-production`. None of them are secrets and none
are mine — they are all on `dev` today.

They are marked with inline `# pragma: allowlist secret` rather than by regenerating the
baseline, because which of the two you want is your call. Verified with the pinned
`detect-secrets v1.5.0` against the repo's own baseline: clean, exit 0. `docker compose config`
still parses afterwards.

Worth flagging separately: **the baseline is still empty and has not been regenerated since
`b82c24a` (2025-07-21)**, so the next PR that edits any file containing a localhost DSN hits
exactly this wall. Happy to regenerate it in a follow-up if you would rather have that than a
growing set of pragmas.

## Motivation and Context

No linked issue. Found while reading the red checks on my own PRs and noticing the same failure on `dev` and on other contributors' merged PRs.

## Screenshots

Not applicable.

## API Changes

- [ ] This PR includes API changes

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Dependency/Build system
- [ ] Breaking change
- [ ] Other (specify):

## Testing Performed

- [x] Tested locally
- [ ] Manual/QA verification

- `docker compose -f docker/docker-compose.e2e.yml config` parses and resolves cleanly.
- Probe verified positive and negative against a live worker over redis, as shown above.
- The `$$` expansion verified in a real container healthcheck.
- I did not build the full e2e image locally; the decisive numbers come from the job's own uploaded logs and from timing the exact commands. The real proof is this PR's own `Journey` run.

## What does not change

- The worker service, its image, command, environment, volumes, network or `depends_on`.
- What the probe means: it still requires a live worker to answer `pong` over the broker, and still fails when none does.
- Every other service's healthcheck, the workflow, and the test suite.
- `interval` and `retries`.

## Remaining risk

The probe no longer exercises the application import path, so a worker that boots into a broken app state would fail to answer at all rather than fail during the probe — which is the correct signal either way, and the previous probe never got far enough to test anything anyway.

If `Journey` still fails after this, it fails on something the stack could never reach before, and the logs will finally say what.

## Checklist

- [x] Follows project coding standards and conventions
- [ ] Documentation updated as needed
- [ ] Dependencies updated as needed
- [x] No lint/build errors or new warnings
- [x] All relevant tests are passing
