### PR TITLE
fix(alembic): give the deliverable-job migrations unique revision ids

### DIFF
--- a/surfsense_backend/alembic/versions/187_add_deliverable_jobs.py
+++ b/surfsense_backend/alembic/versions/187_add_deliverable_jobs.py
@@ -1,15 +1,15 @@
 """Add generic queued deliverable jobs.
 
-Revision ID: 186
-Revises: 185
+Revision ID: 187
+Revises: 186
 """
 
 from collections.abc import Sequence
 
 from alembic import op
 
-revision: str = "186"
-down_revision: str | None = "185"
+revision: str = "187"
+down_revision: str | None = "186"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/surfsense_backend/alembic/versions/188_publish_deliverable_jobs_to_zero.py
+++ b/surfsense_backend/alembic/versions/188_publish_deliverable_jobs_to_zero.py
@@ -1,7 +1,7 @@
 """Publish the safe deliverable-job lifecycle projection to Zero.
 
-Revision ID: 187
-Revises: 186
+Revision ID: 188
+Revises: 187
 """
 
 from collections.abc import Sequence
@@ -9,8 +9,8 @@ from collections.abc import Sequence
 from alembic import op
 from app.zero_publication import apply_publication
 
-revision: str = "187"
-down_revision: str | None = "186"
+revision: str = "188"
+down_revision: str | None = "187"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 

--- a/surfsense_backend/tests/unit/test_zero_publication_deliverable_jobs.py
+++ b/surfsense_backend/tests/unit/test_zero_publication_deliverable_jobs.py
@@ -39,15 +39,15 @@ def test_deliverable_jobs_publish_only_public_lifecycle_columns(monkeypatch) -> 
         assert f'"{column}"' not in entry
 
 
-def test_migration_187_reconciles_canonical_publication() -> None:
+def test_migration_188_reconciles_canonical_publication() -> None:
     migration = (
         Path(__file__).resolve().parents[2]
         / "alembic"
         / "versions"
-        / "187_publish_deliverable_jobs_to_zero.py"
+        / "188_publish_deliverable_jobs_to_zero.py"
     ).read_text()
 
-    assert 'revision: str = "187"' in migration
-    assert 'down_revision: str | None = "186"' in migration
+    assert 'revision: str = "188"' in migration
+    assert 'down_revision: str | None = "187"' in migration
     assert "apply_publication(op.get_bind())" in migration
     assert "Historical publication shapes are immutable" in migration


### PR DESCRIPTION
Two migration files on `dev` declare the same `revision = "186"`, so `alembic upgrade head` fails with *"The script directory has multiple heads"* and the tree has no single head at all. The e2e `backend` container already dies of it, and so does any fresh deployment.

## Description

Three files, no behaviour change to any migration body:

| File | Was | Now |
| --- | --- | --- |
| `alembic/versions/186_add_deliverable_jobs.py` → `187_add_deliverable_jobs.py` | `revision = "186"`, `down_revision = "185"` | `revision = "187"`, `down_revision = "186"` |
| `alembic/versions/187_publish_deliverable_jobs_to_zero.py` → `188_publish_deliverable_jobs_to_zero.py` | `revision = "187"`, `down_revision = "186"` | `revision = "188"`, `down_revision = "187"` |
| `tests/unit/test_zero_publication_deliverable_jobs.py` | pins `revision: str = "187"` / `down_revision: str \| None = "186"` and the file name | pinned to the new pair |

The resulting chain is `185 → 186 (signup credit claims) → 187 (deliverable jobs) → 188 (publish to Zero)`.

### Symptom

The last `E2E Tests` run — on the merge ref that became `dev` — fails in *Build & start backend stack* with `dependency failed to start: container surfsense-e2e-backend-1 exited (255)`, before `celery_worker` is ever started. From the `backend-stack-logs` artifact that run uploaded (`backend.log`, run `32711664790`):

```
[e2e-entrypoint] db reachable after 1 attempts
[e2e-entrypoint] running alembic upgrade head
INFO  [alembic.env] Fresh database detected: creating head-shape schema via create_all and stamping head instead of replaying migration history.
alembic/script/revision.py:213: UserWarning: Revision 186 is present more than once
ERROR [alembic.util.messaging] The script directory has multiple heads (due to branching).
FAILED: The script directory has multiple heads (due to branching).
```

`ps.txt` from the same artifact shows `db` and `redis` healthy and nothing else left standing. The fast-forward path in `alembic/env.py` needs a single head to stamp, so this is not specific to e2e: a fresh database anywhere reaches the same line.

### Root cause

Two PRs added a migration numbered `186` independently, and neither touched the other's file, so there was no textual conflict for git or for review to show:

| file | revision | down_revision | from |
| --- | --- | --- | --- |
| `185_drop_legacy_reports.py` | `185` | `184` | earlier |
| `186_add_signup_credit_claims.py` | `186` | `185` | #1704, merged 2026-08-21 |
| `186_add_deliverable_jobs.py` | `186` | `185` | #1712, merged 2026-08-24 |
| `187_publish_deliverable_jobs_to_zero.py` | `187` | **`186`** | #1712 |

Two revisions share an id *and* a parent, and `187` then chains onto the ambiguous `"186"`. Measured with alembic's own script directory, before and after this change:

```
# origin/dev
UserWarning: Revision 186 is present more than once
HEADS: ['186', '187']

# this branch
HEADS: ['188']
walk 185..heads: ['188', '187', '186', '185']
```

### Why the newer pair is the one that moves

`186_add_signup_credit_claims.py` landed on 2026-08-21 and has been the only `186` for three days, so a database that upgraded in that window has `186` stamped meaning *that* migration. Renumbering it would silently re-run it, or skip it, depending on where a deployment stands.

The `#1712` pair has never been applicable anywhere: the tree has had two heads since the moment it merged, so `alembic upgrade head` has not succeeded once against it. Moving it is free.

`alembic merge` is not the tool here. It resolves *branching*, but the duplicate revision **id** would remain and `Revision 186 is present more than once` with it; revision ids have to be unique for `alembic_version` to mean anything.

### One observation, not a change

`scripts/check_migration_flow.py` already exists and reproduces this in one command — its `assert_at_head` calls `get_current_head()`, which is exactly the call that raises on multiple heads. No CI job runs it. Whether it belongs in a workflow (or a cheap head-count check that needs no database) is a maintainer's decision, so this PR does not add one.

## Motivation and Context

No linked issue — found while re-measuring `dev` after #1708 merged. The e2e stack has been
failing on it since #1712 landed.

## Screenshots

Not applicable — no UI change.

## API Changes

- [ ] This PR includes API changes

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Dependency/Build system
- [ ] Breaking change
- [ ] Other (specify):

## Testing Performed

- [x] Tested locally
- [x] Manual/QA verification

- `alembic` head measurement quoted above, taken on `origin/dev` and on this branch with the same interpreter.
- `scripts/check_migration_flow.py` against a throwaway `pgvector/pgvector:pg17` container, all four scenarios:

```
OK: fresh DB fast-forwards to head
OK: bootstrap-created schema adopted (stamped head)
OK: pre-rename stuck revision adopted (stamped head)
OK: repeat upgrade is a no-op
```

- `tests/unit/test_zero_publication_deliverable_jobs.py` and `tests/unit/db/test_relax_revision_fks_migration.py`: `6 passed`.
- Full backend unit suite, measured on `origin/dev` and on this branch with the same interpreter:
  `15 failed, 4079 passed, 3 skipped, 13 errors` on both. The failures and the 13 collection
  errors (`tests/unit/platforms/google_maps/*`, missing optional deps in this environment) are
  identical before and after; none of them touch migrations.

## Checklist

- [x] Follows project coding standards and conventions
- [ ] Documentation updated as needed
- [ ] Dependencies updated as needed
- [x] No lint/build errors or new warnings
- [x] All relevant tests are passing

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
Resolves a database migration conflict where two migration files incorrectly declared the same revision ID `186`, causing `alembic upgrade head` to fail with multiple heads. The fix renumbers the deliverable-job migrations from `186→187` to `187→188`, establishing a linear chain `185 → 186 (signup credit claims) → 187 (deliverable jobs) → 188 (publish to Zero)`. The test file is updated to reference the new revision IDs. No migration logic is changed, only metadata.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_backend/tests/unit/test_zero_publication_deliverable_jobs.py` |
| 2 | `surfsense_backend/alembic/versions/187_add_deliverable_jobs.py` |
| 3 | `surfsense_backend/alembic/versions/188_publish_deliverable_jobs_to_zero.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->