### PR TITLE
[Fix] Load react-json-view browser-only (SSR document crash)

### DIFF
--- a/surfsense_web/components/json-view.tsx
+++ b/surfsense_web/components/json-view.tsx
@@ -1,8 +1,15 @@
 "use client";
 
-import ReactJson, { type InteractionProps } from "@microlink/react-json-view";
+import type { InteractionProps } from "@microlink/react-json-view";
 import { useTheme } from "next-themes";
+import dynamic from "next/dynamic";
 import { useCallback, useMemo } from "react";
+
+// @microlink/react-json-view reads `document` at module-eval time, which throws
+// under SSR even though this is a client component. Load it browser-only.
+const ReactJson = dynamic(() => import("@microlink/react-json-view").then((m) => m.default), {
+	ssr: false,
+});
 
 /**
  * Shared JSON viewer/editor wrapper around @microlink/react-json-view.


### PR DESCRIPTION
## Summary
- `@microlink/react-json-view` reads `document` at module-eval time, throwing `ReferenceError: document is not defined` under SSR (via `json-view` -> citations panel / playground run-detail) despite `"use client"`.
- Load it through `next/dynamic` with `ssr: false`; `InteractionProps` becomes a type-only import. Single importer, so all consumers are covered.

## Test plan
- [ ] Open a chat/playground run with citations or JSON output — renders with no server console error
- [ ] `/dashboard/.../new-chat/*` returns 200 with no `document is not defined`

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a server-side rendering (SSR) crash caused by `@microlink/react-json-view` accessing the `document` object during module evaluation. The fix wraps the component import with Next.js's `dynamic()` function and disables SSR (`ssr: false`), ensuring the library only loads in the browser. The `InteractionProps` type is converted to a type-only import since it doesn't require runtime evaluation.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_web/components/json-view.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->