### PR TITLE
fix(crawler): refuse crawl targets that are not publicly routable

### DIFF
--- a/surfsense_backend/app/proprietary/web_crawler/connector.py
+++ b/surfsense_backend/app/proprietary/web_crawler/connector.py
@@ -43,7 +43,12 @@ from app.proprietary.web_crawler.stealth import (
 )
 from app.proprietary.web_crawler.url_policy import extract_link_records
 from app.utils.captcha import captcha_enabled, get_captcha_config
-from app.utils.crawl import BlockType, classify_block, extract_contacts
+from app.utils.crawl import (
+    BlockType,
+    classify_block,
+    extract_contacts,
+    is_publicly_routable,
+)
 from app.utils.proxy import get_proxy_url, is_pool_backed
 
 logger = logging.getLogger(__name__)
@@ -237,6 +242,18 @@ class WebCrawlerConnector:
                 return CrawlOutcome(
                     status=CrawlOutcomeStatus.FAILED,
                     error=f"Invalid URL: {url}",
+                    block_type=block_state["block_type"],
+                )
+
+            # ``validators.url`` only judges the spelling; it passes
+            # ``http://127.0.0.1:8000/`` and the cloud metadata endpoint alike.
+            # Resolving before any tier runs is what keeps those from being
+            # fetched from inside the backend's own network. DNS blocks, so it
+            # is offloaded the same way the browser tiers below are.
+            if not await asyncio.to_thread(is_publicly_routable, url):
+                return CrawlOutcome(
+                    status=CrawlOutcomeStatus.FAILED,
+                    error=f"Restricted URL (host is not publicly routable): {url}",
                     block_type=block_state["block_type"],
                 )
 

--- a/surfsense_backend/app/utils/crawl/__init__.py
+++ b/surfsense_backend/app/utils/crawl/__init__.py
@@ -12,11 +12,13 @@ the proprietary boundary in ``app/proprietary/web_crawler/`` (``stealth.py``).
 
 from app.utils.crawl.classifier import BlockType, classify_block
 from app.utils.crawl.contacts import Contacts, extract_contacts, is_social_host
+from app.utils.crawl.net_guard import is_publicly_routable
 
 __all__ = [
     "BlockType",
     "Contacts",
     "classify_block",
     "extract_contacts",
+    "is_publicly_routable",
     "is_social_host",
 ]

--- a/surfsense_backend/app/utils/crawl/net_guard.py
+++ b/surfsense_backend/app/utils/crawl/net_guard.py
@@ -1,0 +1,94 @@
+"""Destination guard — refuses crawl targets that are not publicly routable.
+
+``validators.url`` answers a syntactic question: is this a well-formed URL. It
+says nothing about *where* the URL points, so ``http://127.0.0.1:8000/`` and
+``http://169.254.169.254/latest/meta-data/`` (the cloud metadata endpoint) both
+pass it and are then fetched from inside the backend's network namespace. This
+module answers the other question — does the host resolve only to addresses the
+public internet can reach — and is the gate the crawler consults before any
+tier runs.
+
+Two details decide correctness here:
+
+* ``::ffff:127.0.0.1`` reports ``is_loopback == False``. The address flags only
+  read true on the mapped IPv4 form, so the mapping is unwrapped before the
+  address is judged; reading the flags off the IPv6 object admits loopback
+  under its v6 spelling.
+* ``is_global`` is the right primitive rather than a union of
+  ``is_private``/``is_loopback``/``is_link_local``/``is_reserved``: that union
+  admits carrier-grade NAT (``100.64.0.0/10``, RFC 6598), which is not
+  publicly routable. ``is_global`` does report ``True`` for multicast, which is
+  therefore excluded separately.
+
+Resolution failures refuse. A name that cannot be resolved is not a name that
+can be cleared, and failing open here would make an unreachable DNS server a
+way past the guard.
+
+This narrows the reachable surface; it is not a defence against DNS rebinding.
+The fetcher resolves the host again on its own, so a name that answers
+differently between this check and that fetch is out of scope for a
+resolve-then-fetch guard.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import socket
+from urllib.parse import urlsplit
+
+_ALLOWED_SCHEMES = frozenset({"http", "https"})
+
+
+def _resolve_host(host: str) -> list[str]:
+    """Every address ``host`` resolves to, across both families."""
+    return sorted(
+        {
+            info[4][0]
+            for info in socket.getaddrinfo(host, None, proto=socket.IPPROTO_TCP)
+        }
+    )
+
+
+def _is_public_address(raw: str) -> bool:
+    """True when ``raw`` parses as an address the public internet can route to."""
+    try:
+        address = ipaddress.ip_address(raw)
+    except ValueError:
+        # Includes scoped forms such as ``fe80::1%eth0``, which are link-local
+        # anyway; anything unparseable is refused rather than guessed at.
+        return False
+    mapped = getattr(address, "ipv4_mapped", None)
+    if mapped is not None:
+        address = mapped
+    return address.is_global and not address.is_multicast
+
+
+def is_publicly_routable(url: str) -> bool:
+    """True only when every address ``url``'s host resolves to is public.
+
+    A host with both a public and a private answer is refused: the fetcher
+    resolves independently and may pick either one.
+    """
+    parts = urlsplit(url)
+    if parts.scheme not in _ALLOWED_SCHEMES:
+        return False
+    host = parts.hostname
+    if not host:
+        return False
+
+    # An address literal needs no resolver, and asking one would let a
+    # nameserver answer for a host the URL already pinned.
+    try:
+        ipaddress.ip_address(host)
+    except ValueError:
+        pass
+    else:
+        return _is_public_address(host)
+
+    try:
+        addresses = _resolve_host(host)
+    except (OSError, UnicodeError):
+        return False
+    if not addresses:
+        return False
+    return all(_is_public_address(address) for address in addresses)

--- a/surfsense_backend/tests/unit/proprietary/web_crawler/test_connector.py
+++ b/surfsense_backend/tests/unit/proprietary/web_crawler/test_connector.py
@@ -12,9 +12,20 @@ from app.proprietary.web_crawler import (
     WebCrawlerConnector,
     connector as connector_module,
 )
-from app.utils.crawl import BlockType
+from app.utils.crawl import BlockType, net_guard
 
 pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def _stub_destination_resolver(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep the destination guard hermetic.
+
+    ``crawl_url`` now resolves the target host before running a tier. These
+    are unit tests, so the resolver answers with a fixed public address
+    instead of whatever DNS says about ``example.com`` today.
+    """
+    monkeypatch.setattr(net_guard, "_resolve_host", lambda _host: ["93.184.216.34"])
 
 
 def _result(tier: str) -> dict:
@@ -497,3 +508,48 @@ def test_build_result_ok_on_real_content() -> None:
     )
 
     assert block_state["block_type"] is BlockType.OK
+
+
+async def test_restricted_url_is_failed_before_any_tier(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A host that is not publicly routable never reaches a fetch tier.
+
+    ``validators.url`` passes the cloud metadata endpoint, so without the
+    destination guard this URL is fetched from inside the backend's network.
+    """
+    crawler = WebCrawlerConnector()
+    tiers: list[str] = []
+
+    async def _record_static(_url: str, *_args) -> None:
+        tiers.append("static")
+        return None
+
+    async def _record_dynamic(_url: str, *_args) -> None:
+        tiers.append("dynamic")
+        return None
+
+    async def _record_stealthy(_url: str, *_args) -> None:
+        tiers.append("stealthy")
+        return None
+
+    monkeypatch.setattr(crawler, "_crawl_with_async_fetcher", _record_static)
+    monkeypatch.setattr(crawler, "_crawl_with_dynamic", _record_dynamic)
+    monkeypatch.setattr(crawler, "_crawl_with_stealthy", _record_stealthy)
+
+    outcome = await crawler.crawl_url("http://169.254.169.254/latest/meta-data/")
+
+    assert outcome.status is CrawlOutcomeStatus.FAILED
+    assert outcome.result is None
+    assert "Restricted URL" in (outcome.error or "")
+    assert tiers == []
+
+
+async def test_restricted_url_is_reported_apart_from_a_malformed_one() -> None:
+    """The two refusals are different diagnoses and must not share a message."""
+    restricted = await WebCrawlerConnector().crawl_url("http://127.0.0.1:8000/health")
+    malformed = await WebCrawlerConnector().crawl_url("not a url")
+
+    assert "Restricted URL" in (restricted.error or "")
+    assert "Invalid URL" in (malformed.error or "")
+    assert (malformed.error or "") != (restricted.error or "")

--- a/surfsense_backend/tests/unit/utils/crawl/test_net_guard.py
+++ b/surfsense_backend/tests/unit/utils/crawl/test_net_guard.py
@@ -1,0 +1,125 @@
+"""``is_publicly_routable`` behavior: refuse URLs whose host is not public.
+
+The literal-address cases need no resolver at all, so they exercise the real
+code end to end; only the hostname cases stub ``_resolve_host``, because a unit
+test cannot depend on what DNS answers.
+"""
+
+from __future__ import annotations
+
+import socket
+
+import pytest
+
+from app.utils.crawl import is_publicly_routable, net_guard
+
+pytestmark = pytest.mark.unit
+
+
+def test_public_literal_is_allowed() -> None:
+    assert is_publicly_routable("https://8.8.8.8/") is True
+
+
+def test_loopback_literal_is_refused() -> None:
+    assert is_publicly_routable("http://127.0.0.1:8000/health") is False
+
+
+def test_cloud_metadata_literal_is_refused() -> None:
+    """169.254.169.254 is the AWS/GCP/Azure credential endpoint."""
+    assert is_publicly_routable("http://169.254.169.254/latest/meta-data/") is False
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://10.0.0.1/",
+        "http://172.16.0.1/",
+        "http://192.168.1.1/",
+        "http://0.0.0.0/",
+    ],
+)
+def test_private_and_unspecified_literals_are_refused(url: str) -> None:
+    assert is_publicly_routable(url) is False
+
+
+def test_ipv6_loopback_literal_is_refused() -> None:
+    assert is_publicly_routable("http://[::1]:8000/") is False
+
+
+def test_ipv4_mapped_ipv6_literal_is_refused() -> None:
+    """``::ffff:127.0.0.1`` reports ``is_loopback == False``; only the mapped
+    IPv4 form does, so a guard that reads the flags off the IPv6 object alone
+    lets loopback through under its v6 spelling."""
+    assert is_publicly_routable("http://[::ffff:127.0.0.1]/") is False
+
+
+def test_carrier_grade_nat_literal_is_refused() -> None:
+    """100.64.0.0/10 (RFC 6598) is none of private/loopback/link-local/reserved
+    /multicast, so a guard built from those five flags admits it — but it is
+    carrier-internal and not publicly routable."""
+    assert is_publicly_routable("http://100.64.0.1/") is False
+
+
+def test_multicast_literal_is_refused() -> None:
+    """224.0.0.1 reports ``is_global == True``, so the routability check alone
+    is not enough to exclude it."""
+    assert is_publicly_routable("http://224.0.0.1/") is False
+
+
+@pytest.mark.parametrize(
+    "url",
+    ["file:///etc/passwd", "gopher://127.0.0.1/", "ftp://example.com/", "not a url"],
+)
+def test_non_http_scheme_is_refused(url: str) -> None:
+    assert is_publicly_routable(url) is False
+
+
+def test_hostname_resolving_to_a_private_address_is_refused(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(net_guard, "_resolve_host", lambda _host: ["10.1.2.3"])
+
+    assert is_publicly_routable("https://internal.example.com/") is False
+
+
+def test_hostname_is_refused_when_any_answer_is_private(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A host with both a public and a private answer must not be crawled: the
+    fetcher resolves independently and may pick either."""
+    monkeypatch.setattr(
+        net_guard, "_resolve_host", lambda _host: ["93.184.216.34", "192.168.0.7"]
+    )
+
+    assert is_publicly_routable("https://split-horizon.example.com/") is False
+
+
+def test_hostname_resolving_only_to_public_addresses_is_allowed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        net_guard,
+        "_resolve_host",
+        lambda _host: ["93.184.216.34", "2606:2800:220:1:248:1893:25c8:1946"],
+    )
+
+    assert is_publicly_routable("https://example.com/page") is True
+
+
+def test_unresolvable_hostname_is_refused(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Fail closed: a name we cannot resolve is not a name we can clear."""
+
+    def _boom(_host: str) -> list[str]:
+        raise socket.gaierror("Name or service not known")
+
+    monkeypatch.setattr(net_guard, "_resolve_host", _boom)
+
+    assert is_publicly_routable("https://does-not-exist.example/") is False
+
+
+def test_hostname_resolving_to_nothing_is_refused(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(net_guard, "_resolve_host", lambda _host: [])
+
+    assert is_publicly_routable("https://empty.example/") is False


### PR DESCRIPTION
`WebCrawlerConnector.crawl_url` validated its input with `validators.url` alone. That answers a syntactic question and says nothing about where the URL points, so loopback, private, link-local and cloud-metadata targets passed and were fetched from inside the backend's own network namespace.

## Description

Resolve the target host before any tier runs, and refuse it unless **every** address it answers with is publicly routable.

The guard is a new `app/utils/crawl/net_guard.py` (`is_publicly_routable`), placed beside the existing generic crawler helpers rather than in `url_policy.py`, whose docstring states it holds pure functions with no I/O.

`crawl_url` is the single choke point, so one gate covers both entry paths: the spider reaches it through `_ConnectorSession.fetch`, which matters because a public page linking to an internal address would otherwise be followed.

Two details the obvious implementation gets wrong, both covered by tests:

- **`::ffff:127.0.0.1` reports `is_loopback == False`.** The address flags only read true on the mapped IPv4 form, so the mapping is unwrapped before the address is judged. Reading the flags off the IPv6 object admits loopback under its v6 spelling.
- **A union of `is_private` / `is_loopback` / `is_link_local` / `is_reserved` / `is_multicast` admits carrier-grade NAT** (`100.64.0.0/10`, RFC 6598), which is not publicly routable. `is_global` covers that case, but reports `True` for multicast, so multicast is excluded separately.

Resolution failures refuse, so an unreachable resolver is not a way past the guard. A host answering with both a public and a private address is refused, because the fetcher resolves independently and may pick either.

The malformed-URL and restricted-URL refusals carry distinct messages so the two diagnoses stay apart, which also keeps the existing `test_invalid_url_is_failed` assertion meaningful.

DNS blocks, so it is offloaded with `asyncio.to_thread`, the same way the browser tiers already are.

### Scope

This narrows the reachable surface; it is **not** a defence against DNS rebinding. The fetcher resolves the host again on its own, so a name that answers differently between this check and that fetch is out of scope for any resolve-then-fetch guard. Worth stating plainly rather than implying the hole is closed.

## Motivation and Context

FIX #1709

Reproduced on `dev` before the change. With the tier stubs removed, all three tiers actually attempt the connection:

```
ERROR  scrapling:static.py:490       Failed after 3 attempts: Failed to perform, curl: (7)
                                     Failed to connect to 127.0.0.1 port 8000
WARNING scrapling:_controllers.py:204 Attempt 1 failed: Page.goto: net::ERR_CONNECTION_REFUSED
                                      at http://127.0.0.1:8000/health
WARNING scrapling:_stealth.py:292     Attempt 1 failed: Page.goto: net::ERR_CONNECTION_REFUSED
                                      at http://127.0.0.1:8000/health
```

and `http://169.254.169.254/latest/meta-data/` reached the tiers and returned `EMPTY` — it was fetched, not refused:

```
AssertionError: assert <CrawlOutcomeStatus.EMPTY: 'empty'> is <CrawlOutcomeStatus.FAILED: 'failed'>
```

Both new connector tests fail on the parent commit and pass with the change.

## API Changes

- [ ] This PR includes API changes

`CrawlOutcome` for a restricted target is `FAILED` with a new `Restricted URL (host is not publicly routable): <url>` message. No signature changes.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Dependency/Build system
- [ ] Breaking change
- [ ] Other (specify):

## Testing Performed

- [x] Tested locally
- [x] Manual/QA verification

**New coverage.** `tests/unit/utils/crawl/test_net_guard.py` — 20 cases. The literal-address cases need no resolver, so they exercise the real code end to end; only the hostname cases stub `_resolve_host`, since a unit test cannot depend on what DNS answers. Includes the IPv4-mapped-IPv6, CGNAT and multicast cases named above, plus fail-closed on resolution error, empty answer, and mixed public/private answers.

`tests/unit/proprietary/web_crawler/test_connector.py` — two cases: the restricted target is `FAILED` and reaches **no** tier, and the two refusal messages stay distinct.

**Test hygiene.** `crawl_url` now resolves, so the 13 existing tests calling it with `https://example.com` would have started doing live DNS. An autouse fixture in that module stubs the resolver, keeping them hermetic.

**Results.** Crawler + capability suites: `110 passed`. Full unit suite: `2757 passed, 10 failed`. Those 10 are pre-existing on a clean `dev` checkout — same 10, in `knowledge_store/engines/test_git.py`, `knowledge_store/test_import_boundary.py`, `middleware/test_git_tree_backend.py` and `test_pat_fail_closed_static.py` — and are unrelated to this change (verified by running them on `upstream/dev`).

Verified against the real resolver as a sanity check: `example.com`, `github.com` and `www.google.com` are allowed; `127.0.0.1`, `localhost`, `169.254.169.254`, `[::1]`, `[::ffff:127.0.0.1]`, `100.64.0.1` and `224.0.0.1` are refused.

`ruff check` and `ruff format --check` are clean on every touched file.

## Checklist

- [x] Follows project coding standards and conventions
- [x] Documentation updated as needed
- [x] Dependencies updated as needed
- [x] No lint/build errors or new warnings
- [x] All relevant tests are passing

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a security vulnerability where the web crawler could be tricked into accessing internal network resources like loopback addresses (`127.0.0.1`), private networks, link-local addresses, and cloud metadata endpoints (`169.254.169.254`). The fix adds a DNS resolution check that validates every IP address a target URL resolves to is publicly routable before any crawling tier executes. The implementation handles edge cases like IPv4-mapped IPv6 addresses and carrier-grade NAT, and fails closed when DNS resolution fails to prevent bypassing the guard.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_backend/app/utils/crawl/net_guard.py` |
| 2 | `surfsense_backend/tests/unit/utils/crawl/test_net_guard.py` |
| 3 | `surfsense_backend/app/utils/crawl/__init__.py` |
| 4 | `surfsense_backend/app/proprietary/web_crawler/connector.py` |
| 5 | `surfsense_backend/tests/unit/proprietary/web_crawler/test_connector.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->