### PR TITLE
feat(artifacts): add first-class interactive HTML artifacts

### DIFF
--- a/docker/sandbox/Dockerfile
+++ b/docker/sandbox/Dockerfile
@@ -82,10 +82,12 @@ COPY skills /tmp/surfsense-skills
 RUN set -euo pipefail \
     && mkdir -p /opt/skills \
     && for skill in /tmp/surfsense-skills/*; do \
+        test -f "${skill}/SKILL.md" || continue; \
         name="${skill##*/}"; \
         rm -rf "/opt/skills/${name}"; \
         cp -a "${skill}" "/opt/skills/${name}"; \
         rm -rf "/opt/skills/${name}/scripts"; \
+        cat /tmp/surfsense-skills/frontend-design/DESIGN.md >> "/opt/skills/${name}/SKILL.md"; \
     done \
     && rm -rf /tmp/surfsense-skills
 

--- a/docker/sandbox/skills/frontend-design/DESIGN.md
+++ b/docker/sandbox/skills/frontend-design/DESIGN.md
@@ -1,0 +1,70 @@
+# Frontend Design
+Act as a design lead, not a template assembler. Root each brief's identity in
+its subject, audience, and purpose; choose color, type, composition, motion,
+interaction, and language deliberately.
+
+## Start with the subject
+
+Name the concrete subject, intended audience, and primary job. Draw visual
+ideas from that world's materials, tools, culture, data, and vocabulary.
+
+Use realistic content; filler conceals wrapping, density, hierarchy, overflow,
+and tone problems.
+
+## Establish a direction
+
+Work in two passes. First, define a compact design plan:
+
+- Color: choose 4–6 named hex colors with clear roles and sufficient contrast.
+- Type: choose one or two purposeful families and assign display, body, and
+  utility roles with an intentional scale.
+- Layout: describe the organizing idea, alignment, density, and responsive
+  behavior; sketch alternatives with a small ASCII wireframe when useful.
+- Signature: choose one memorable interaction or visual move tied to the
+  subject, then keep the surrounding design disciplined.
+
+Second, challenge the plan. If it could be reused unchanged for an unrelated
+brief, revise the generic parts before building.
+
+## Compose with intent
+
+- Lead with the most characteristic element: a strong headline, live result,
+  image, demonstration, or interaction—not an automatic hero formula.
+- Keep body lines readable, hierarchy obvious, and heading levels meaningful.
+- Use cards, borders, labels, dividers, and numbering only when they explain
+  grouping, sequence, priority, or state.
+- Let one family or two clearly contrasting families carry the personality;
+  avoid isolated italic words, decorative all-caps labels, and needless
+  eyebrow text.
+- Prefer motion that explains an action or change. Avoid animating every card
+  or repeating the same fade-and-slide entrance across the page.
+
+## Avoid generated-looking defaults
+
+Do not reflexively use purple gradients, warm cream with terracotta, black with
+acid accents, newspaper grids, identical rounded cards, uniform soft shadows,
+monospace metadata, oversized empty spacing, or decorative arrows. Any of
+these can work when the subject genuinely calls for it; none is a default.
+
+## Build to a quality floor
+
+- Use semantic structure and native controls. Give every input and icon-only
+  action an accessible name and every interaction visible keyboard focus.
+- Meet readable contrast, never communicate state through color alone, and
+  respect `prefers-reduced-motion`.
+- Verify narrow and wide layouts, long text, touch targets, sticky elements,
+  tables, and overflow—not merely whether columns stack.
+- Design loading, error, empty, and success states together. Make failures
+  explain recovery and empty states invite a useful next action.
+- Keep CSS selectors local and predictable; avoid specificity collisions.
+
+## Write as part of the interface
+
+Use direct, conversational language from the user's perspective. Controls say
+what happens, labels only label, and helper text only helps. Keep action names
+consistent through confirmations and errors. Never use cleverness where a
+specific explanation would be clearer.
+
+## Critique the result
+Review at multiple sizes. Confirm the signature serves the subject, then remove
+one accessory that weakens hierarchy.

--- a/docker/sandbox/skills/html/SKILL.md
+++ b/docker/sandbox/skills/html/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: html
+description: Create interactive calculators, configurators, dashboards, widgets, and prototypes as self-contained HTML artifacts.
+---
+
+# Interactive HTML
+
+Create one interactive HTML fragment in `/workspace`. Everything required is
+available in the browser; never install or download dependencies.
+
+## Authoring contract
+
+- Emit a fragment only. Do not include `<!DOCTYPE>`, `<html>`, `<head>`, or
+  `<body>`; the artifact viewer supplies the document shell and security policy.
+- Put all CSS in `<style>` and all behavior in inline `<script>`.
+- Keep state in memory. The sandboxed viewer does not provide application APIs,
+  cookies, or durable browser storage.
+- Do not call `fetch`, XMLHttpRequest, WebSocket, or application APIs.
+- Images must be `data:` URIs. The only external resources the viewer permits
+  are stylesheets and fonts from `fonts.googleapis.com` and
+  `fonts.gstatic.com`.
+- Use semantic HTML and native controls. Every input needs an accessible label,
+  keyboard focus must be visible, and motion must respect
+  `prefers-reduced-motion`.
+- Make the layout responsive without horizontal page overflow.
+
+## Web design requirements
+
+- Design mobile-first and verify narrow and wide layouts without horizontal
+  overflow.
+- Use one `h1`, ordered heading levels, native controls, and explicit labels.
+- Keep CSS selectors local and simple to avoid specificity conflicts.
+- Make touch targets usable and provide `:focus-visible` styles.
+- Respect `prefers-reduced-motion`; do not animate every section or card.
+
+## Revisions
+
+Start an in-place revision with `load_artifact_for_revision`. Edit
+`primary_path` directly, or regenerate the fragment from `markdown_path` plus
+the user's instruction, and write it to `expected_output_path`. Keep the
+output a self-contained fragment. Do not use vision to reconstruct the current
+page.
+
+Save the verified revision with the returned `artifact_id` and
+`expected_generation`. A changed title or design remains the same artifact
+unless the user explicitly asks for a separate copy.
+
+## Verify and save
+
+Call `verify_artifact(path=output_path)`. HTML verification is structural only:
+there is no PDF preview or vision pass. Warnings identify resources the viewer
+will block and do not require regeneration. If verification reports blocking
+findings, fix all blockers together, regenerate once at the same output path,
+and reverify. If a blocker remains, stop and explain it instead of looping.
+
+Then call `save_artifact(path=output_path, title="...",
+markdown_representation="...")`. Working files may use any paths; no source
+file, preview file, or matching filename stem is part of the publication
+contract.
+
+The Markdown representation must faithfully summarize the artifact's purpose,
+controls, outputs, and important content for accessibility and search. Do not
+paste the raw HTML into it.

--- a/docs/adr/0003-artifacts-as-documents.md
+++ b/docs/adr/0003-artifacts-as-documents.md
@@ -22,7 +22,7 @@ Shape 1 is the natural read of "artifacts are not documents", and it is what the
 
 **An artifact's searchable body is a `Document` with `document_type = ARTIFACT`. `Artifact`/`ArtifactFile` are sidecars.**
 
-- `Document` owns title, path (`documents/Artifacts/<title>.md`), Markdown, content hash, folder, and indexing status.
+- `Document` owns title, path (`documents/<title>.md`), Markdown, content hash, folder, and indexing status.
 - `Artifact` owns `format`, `generation`, provenance, verification metadata, and `document_id` — a non-null unique cascading key. It owns **no** title, path, body, hash, or indexing state.
 - `ArtifactFile` owns one immutable blob per durable role: `primary` or `preview`. Generation source files are transient sandbox inputs, not persisted artifact files. Binary bytes never enter git and never become `DocumentFile` rows.
 - One projected git root, one `Chunk` table, one search leg, one citation namespace.

--- a/plans/artifacts/artifacts-overhaul.md
+++ b/plans/artifacts/artifacts-overhaul.md
@@ -1,7 +1,7 @@
 # Artifacts Overhaul — Authoritative Architecture
 
-**Status:** Sandbox generation, backend verification, PDF, DOCX, PPTX, XLSX, and phase 6 legacy demolition are implemented. Unified indexing and search remain under implementation. Phase 7 will complete generic-format handling, public artifact access, and XLSX hardening.
-**Scope:** Generated non-media deliverables. Media generation remains on its existing pipelines.
+**Status:** Sandbox generation, backend verification, PDF, DOCX, PPTX, XLSX, unified indexing/search, and phase 6 legacy demolition are implemented. Phase 7 will complete generic-format handling, public artifact access, and XLSX hardening.
+**Scope:** Generated deliverables. Media generation remains on its existing pipelines, while current image, podcast, and video flows may record artifact sidecars.
 **Shape:** [ADR 0003](../../docs/adr/0003-artifacts-as-documents.md) records why a deliverable's body is a document type rather than a second corpus, and the obligations that creates.
 
 This document describes the intended architecture. The phase documents record delivery scope and must not override these contracts.
@@ -12,7 +12,7 @@ An artifact is a document plus the things a document has no concept of: rendered
 
 - `Document` with `document_type = ARTIFACT` owns the artifact's searchable Markdown, title, stable Git path, folder placement, content hash, indexing status, and chunks. It is an ordinary row in the ordinary corpus.
 - `Artifact` owns what the document model does not model: adapter `format`, `generation`, workspace/thread/user provenance, the tool-call ids that wrote it, verification metadata, and timestamps. `artifact.document_id` is a non-null unique foreign key with `ON DELETE CASCADE`.
-- `ArtifactFile` owns one immutable blob for role `primary`, `preview`, or `source`. `(artifact_id, role)` is unique.
+- `ArtifactFile` owns one immutable blob for durable role `primary` or `preview`. Generation sources are transient sandbox inputs. `(artifact_id, role)` is unique.
 - `Chunk` is the only passage table. There is no artifact chunk table, no artifact embedding column, and no artifact search index.
 
 Single ownership is the point. Title, path, body, and indexing state exist once — on the document — so a rename is one write with one outcome instead of two rows that can disagree. Format, generation, roles, and receipts exist once, on the artifact, because no plain document needs them. Type is the only discriminator: it selects a badge, participates in the type filter, and gates the editor's read-only guard. Nothing in storage, indexing, retrieval, or citation branches on it.
@@ -49,10 +49,10 @@ Create omits both revision fields. Revision requires both `artifact_id` and `exp
 ```
 
 - Markdown artifacts have no blob rows; the document's Markdown is their complete deliverable and download source.
-- Binary artifacts require a primary and persisted generation source; a verification-produced preview is included when the adapter has a rendered policy.
-- Source files never appear in tool results, manifests, immutable file routes, or user downloads.
-- A revision locks the row, compares `expected_generation`, and increments `generation`. A stale writer fails with an instruction to load the source again. A failed revision leaves the current generation intact.
-- `load_artifact_source(artifact_id)` returns the stored source and current generation. The next save must pass both identity and generation.
+- Binary artifacts require a primary; a verification-produced preview is included when the adapter has a rendered policy.
+- Generation sources are not persisted as artifact files and never appear in tool results, manifests, immutable file routes, or user downloads.
+- A revision locks the row, compares `expected_generation`, and increments `generation`. A stale writer fails with an instruction to load the latest revision workspace again. A failed revision leaves the current generation intact.
+- `load_artifact_for_revision(artifact_id)` restores the current primary, when present, plus Markdown context and the current generation. The next save must pass both identity and generation.
 - Failures return a visible failed tool result. There is no end-of-turn persistence promise for metadata or blobs.
 
 ### 2.2 Manifest
@@ -98,8 +98,8 @@ The artifact storage service reuses configured local/Azure backend interfaces, n
 - Deletion is the document deletion path. The route marks the document `deleting`; the purge task records the Git removal before the row disappears, then cascades chunks, the artifact, and its file rows, and purges every reachable blob. Marking first drops the artifact out of search immediately, and removing the file before the row is the only safe order — a committed file that outlives its row is read back on the next rebuild as a document nobody asked for.
 - Blob purge covers artifact roles as well as document files: the purge query collects `DocumentFile` keys for the document and `ArtifactFile` keys through `artifact.document_id`, so no reachable blob depends on the caller knowing which kind of document it deleted.
 - A blob deletion failure leaves an unreachable blob and a warning; deletion still proceeds. Blob storage cannot enlist in the database transaction, so repair is operational rather than rollback.
-- Per-file size limits apply independently to primary, preview, and source.
-- Only PDF may use inline `Content-Disposition`; all other bytes are attachments. Immutable file routes use checksum ETags and private immutable caching. The stable current download uses `private, no-store`.
+- Per-file size limits apply independently to primary and preview.
+- PDF and MP4 may use inline `Content-Disposition` on immutable content routes; all other bytes are attachments. The stable current download is always an attachment and uses `private, no-store`.
 - Markdown downloads are generated from the document's current Markdown.
 
 ## 4. Git integration and indexing
@@ -110,9 +110,9 @@ Git has one projected root:
 /documents/**  ->  Document + Chunk
 ```
 
-An artifact create allocates `/documents/Artifacts/<normalized title>.md` through the shared path allocator, so it obeys the same filename rules and collision suffixes as any document. The path is authored once; revisions and retitles reuse it. A user who renames or moves the file relocates it through the ordinary document move, which preserves the document id and therefore the artifact. The path stores only the searchable Markdown; binary artifact bytes remain in blob storage.
+An artifact create allocates `/documents/<normalized title>.md` through the shared path allocator, so it obeys the same filename rules and collision suffixes as any document. The path is authored once; revisions and retitles reuse it. A user who renames or moves the file relocates it through the ordinary document move, which preserves the document id and therefore the artifact. The path stores only the searchable Markdown; binary artifact bytes remain in blob storage.
 
-The `Artifacts/` folder is a normal visible folder. Artifacts appear in the document list with an artifact badge, are filterable by type, and are `@`-mentionable, because they are documents.
+Artifacts live in the normal visible document tree. They appear in the document list with an artifact badge, are filterable by type, and are `@`-mentionable, because they are documents.
 
 ### Git-backed workspaces
 
@@ -150,7 +150,7 @@ Dedicated routes are mounted under `/api/v1/workspaces/{workspace_id}/artifacts`
 
 Citation context comes from the existing document chunk route, which already returns the document type and metadata the frontend needs to route an artifact citation. Artifacts need no chunk lookup of their own.
 
-Routes enforce workspace-scoped `ARTIFACTS_READ` or `ARTIFACTS_DELETE`. IDs must belong to the requested workspace and file IDs must belong to the requested artifact. Source-role files always resolve as not found on user-facing content routes.
+Routes enforce workspace-scoped `ARTIFACTS_READ` or `ARTIFACTS_DELETE`. IDs must belong to the requested workspace and file IDs must belong to the requested artifact. Only durable primary/preview roles can exist on user-facing content routes.
 
 `DELETE /{artifact_id}` authorizes as an artifact operation and executes as a document deletion, so Git removal, chunk cascade, blob purge, and Zero-visible row state are handled once, by the code that already owns them.
 
@@ -164,10 +164,10 @@ Persistence remains format-blind:
 
 - `Artifact.format` is an adapter-owned string, not a database enum.
 - Primary MIME comes from the selected adapter.
-- Source MIME validation is role-specific and source remains private.
+- Generation sources remain transient sandbox inputs rather than a persistence role.
 - The manifest and viewer registry degrade unknown or unviewable formats to download.
 
-Shipped formats are Markdown, PDF, DOCX, PPTX, and XLSX. XLSX uses programmatic verification, primary + private source persistence, no preview, and a native read-only grid. Phase 7 adds the generic adapter for bounded unknown binaries and uses `application/octet-stream` with attachment-only delivery.
+Shipped deliverable formats are Markdown, PDF, DOCX, PPTX, and XLSX. XLSX uses programmatic verification, primary-only persistence, no preview, and a native read-only grid. Image, podcast, and video flows can also record artifact sidecars through their existing media pipelines. Phase 7 adds the generic adapter for bounded unknown binaries and uses `application/octet-stream` with attachment-only delivery.
 
 ## 8. Rendering and revision UX
 
@@ -179,13 +179,13 @@ The artifact panel and caches are keyed by `artifact_id`. It fetches the dedicat
 - XLSX -> primary in the native grid;
 - unknown/missing preview/oversized/parse failure -> unviewable state with download.
 
-All viewers are read-only. Revisions return to the deliverables agent, which loads the stored source and saves with `artifact_id + expected_generation`. The current manifest is the only product-visible generation; prior file rows/blobs are purged. Git may retain Markdown history, but it is not an artifact restoration mechanism.
+All viewers are read-only. Revisions return to the deliverables agent, which loads the current primary plus Markdown context and saves with `artifact_id + expected_generation`. The current manifest is the only product-visible generation; prior file rows/blobs are purged. Git may retain Markdown history, but it is not an artifact restoration mechanism.
 
 ## 9. Delivery status
 
 | Phase | Status | Scope |
 |---|---|---|
-| 1 | In progress | Artifact/file schema and storage, document-backed markdown save, artifact routes, panel, unified indexing, search, and citations |
+| 1 | Complete | Artifact/file schema and storage, document-backed markdown save, artifact routes, panel, unified indexing, search, and citations |
 | 2 | Shipped | Sandbox and PDF |
 | 3 | Shipped | Backend verification service and DOCX |
 | 4 | Shipped | PPTX and format-general rendered verification |
@@ -199,7 +199,7 @@ Phase 6 removed legacy `Report`, report/resume tools, Typst routes, old panels, 
 
 ## 11. Phase 7 boundary
 
-Phase 7 completes access and fallback behavior around the existing model. It adds token-scoped public reads, not public artifact copies; a generic adapter, not persistence suffix branches; and XLSX hardening, not spreadsheet editing. Public snapshots allowlist artifact IDs and resolve the current generation. Source-role files remain private on every route.
+Phase 7 completes access and fallback behavior around the existing model. A compatibility public primary-content route already serves current media cards; phase 7 adds token-scoped manifest, download, and per-file reads, not public artifact copies. It also adds a generic adapter, not persistence suffix branches, and XLSX hardening, not spreadsheet editing. Public snapshots allowlist artifact IDs and resolve the current generation. Generation sources remain transient and are never publicly readable.
 
 ## 12. Required invariants
 
@@ -213,6 +213,6 @@ Phase 7 completes access and fallback behavior around the existing model. It add
 8. One chunk table, one search leg, one global rank fusion.
 9. One citation namespace; document type decides which panel a citation opens.
 10. An artifact document is not editable through the editor, and the guard is enforced server-side.
-11. Source blobs are never user-readable.
+11. Generation sources are transient sandbox inputs and never become artifact blobs.
 12. New formats require an adapter and optional viewer, not a persistence or API schema change.
-13. Public artifact routes reuse the manifest model, expose only allowlisted primary/preview files, and never expose source.
+13. Public artifact routes reuse the manifest model and expose only allowlisted primary/preview files.

--- a/plans/artifacts/artifacts-overhaul.md
+++ b/plans/artifacts/artifacts-overhaul.md
@@ -1,6 +1,6 @@
 # Artifacts Overhaul — Authoritative Architecture
 
-**Status:** Sandbox generation, backend verification, PDF, DOCX, PPTX, XLSX, unified indexing/search, and phase 6 legacy demolition are implemented. Phase 7 will complete generic-format handling, public artifact access, and XLSX hardening.
+**Status:** Sandbox generation, backend verification, PDF, DOCX, PPTX, XLSX, unified indexing/search, and phase 7 legacy demolition are implemented. Phase 6 will add interactive HTML, and phase 8 will complete generic-format handling, public artifact access, and XLSX hardening.
 **Scope:** Generated deliverables. Media generation remains on its existing pipelines, while current image, podcast, and video flows may record artifact sidecars.
 **Shape:** [ADR 0003](../../docs/adr/0003-artifacts-as-documents.md) records why a deliverable's body is a document type rather than a second corpus, and the obligations that creates.
 
@@ -167,7 +167,7 @@ Persistence remains format-blind:
 - Generation sources remain transient sandbox inputs rather than a persistence role.
 - The manifest and viewer registry degrade unknown or unviewable formats to download.
 
-Shipped deliverable formats are Markdown, PDF, DOCX, PPTX, and XLSX. XLSX uses programmatic verification, primary-only persistence, no preview, and a native read-only grid. Image, podcast, and video flows can also record artifact sidecars through their existing media pipelines. Phase 7 adds the generic adapter for bounded unknown binaries and uses `application/octet-stream` with attachment-only delivery.
+Shipped deliverable formats are Markdown, PDF, DOCX, PPTX, and XLSX. XLSX uses programmatic verification, primary-only persistence, no preview, and a native read-only grid. Image, podcast, and video flows can also record artifact sidecars through their existing media pipelines. Phase 6 adds interactive HTML with programmatic verification and primary-only persistence, served attachment-only and rendered client-side in a sandboxed iframe. Phase 8 adds the generic adapter for bounded unknown binaries and uses `application/octet-stream` with attachment-only delivery.
 
 ## 8. Rendering and revision UX
 
@@ -177,6 +177,7 @@ The artifact panel and caches are keyed by `artifact_id`. It fetches the dedicat
 - PDF -> primary in the PDF viewer;
 - DOCX/PPTX -> receipt-bound PDF preview;
 - XLSX -> primary in the native grid;
+- HTML -> primary in a sandboxed iframe (phase 6);
 - unknown/missing preview/oversized/parse failure -> unviewable state with download.
 
 All viewers are read-only. Revisions return to the deliverables agent, which loads the current primary plus Markdown context and saves with `artifact_id + expected_generation`. The current manifest is the only product-visible generation; prior file rows/blobs are purged. Git may retain Markdown history, but it is not an artifact restoration mechanism.
@@ -190,16 +191,17 @@ All viewers are read-only. Revisions return to the deliverables agent, which loa
 | 3 | Shipped | Backend verification service and DOCX |
 | 4 | Shipped | PPTX and format-general rendered verification |
 | 5 | Complete | XLSX skill, programmatic verification, persistence, and authenticated native grid |
-| 6 | Complete | Legacy report/resume/Typst demolition and library repoint |
-| 7 | Planned | Generic formats, public artifact access, XLSX hardening, and end-to-end coverage |
+| 6 | Planned | Interactive HTML skill, programmatic verification, and a sandboxed-iframe panel viewer |
+| 7 | Complete | Legacy report/resume/Typst demolition and library repoint |
+| 8 | Planned | Generic formats, public artifact access, XLSX hardening, and end-to-end coverage |
 
 ## 10. Completed demolition boundary
 
-Phase 6 removed legacy `Report`, report/resume tools, Typst routes, old panels, and historical report rows without migrating them into `Artifact` or into artifact documents. Old tool parts now render static unavailable cards. This remains independent of the artifact architecture above.
+Phase 7 removed legacy `Report`, report/resume tools, Typst routes, old panels, and historical report rows without migrating them into `Artifact` or into artifact documents. Old tool parts now render static unavailable cards. This remains independent of the artifact architecture above.
 
-## 11. Phase 7 boundary
+## 11. Phase 8 boundary
 
-Phase 7 completes access and fallback behavior around the existing model. A compatibility public primary-content route already serves current media cards; phase 7 adds token-scoped manifest, download, and per-file reads, not public artifact copies. It also adds a generic adapter, not persistence suffix branches, and XLSX hardening, not spreadsheet editing. Public snapshots allowlist artifact IDs and resolve the current generation. Generation sources remain transient and are never publicly readable.
+Phase 8 completes access and fallback behavior around the existing model. A compatibility public primary-content route already serves current media cards; phase 8 adds token-scoped manifest, download, and per-file reads, not public artifact copies. It also adds a generic adapter, not persistence suffix branches, and XLSX hardening, not spreadsheet editing. Public snapshots allowlist artifact IDs and resolve the current generation. Generation sources remain transient and are never publicly readable.
 
 ## 12. Required invariants
 

--- a/plans/artifacts/phase-1-foundation.md
+++ b/plans/artifacts/phase-1-foundation.md
@@ -1,6 +1,6 @@
 # Phase 1 — Artifact Foundation
 
-**Status:** In progress on this branch.
+**Status:** Complete.
 **Parent spec:** [`artifacts-overhaul.md`](./artifacts-overhaul.md), which is authoritative.
 **Goal:** Establish artifact-owned delivery metadata on top of the document corpus — one chunk table, one search leg, one citation namespace — plus the artifact APIs, panel contract, and read-only guards.
 
@@ -20,13 +20,13 @@ Sandbox generation and per-format verification/viewers belong to later phases.
 
 ## 2. Persistence
 
-`Document` with `document_type = ARTIFACT` stores the artifact's title, searchable Markdown, `/documents/Artifacts/<title>.md` path, content hash, folder, and indexing status. `document_metadata` carries `artifact_id` so a search hit or citation can route without a second query.
+`Document` with `document_type = ARTIFACT` stores the artifact's title, searchable Markdown, `/documents/<title>.md` path, content hash, folder, and indexing status. `document_metadata` carries `artifact_id` so a search hit or citation can route without a second query.
 
 `Artifact` stores adapter `format`, `generation`, workspace/thread/user provenance, originating tool-call ids, verification metadata, timestamps, and `document_id`. It stores no title, path, body, hash, or indexing state — those exist once, on the document.
 
-`ArtifactFile` stores immutable primary/preview/source blob metadata with one row per role. Source is private.
+`ArtifactFile` stores immutable primary/preview blob metadata with one row per role. Generation sources remain transient sandbox inputs.
 
-Markdown artifacts have no file rows. Binary shapes have primary + source and optionally preview. The schema is format-independent; service coverage includes the XLSX-shaped primary + source case without shipping XLSX generation.
+Markdown artifacts have no file rows. Binary shapes have primary and optionally preview. The schema is format-independent.
 
 ### Migration 178
 
@@ -39,7 +39,7 @@ There is no artifact chunk table to create and no artifact search index to build
 
 ### Create and revise
 
-- Create allocates a collision-safe `/documents/Artifacts/<title>.md` path through the shared allocator, inserts the document, then the artifact.
+- Create allocates a collision-safe `/documents/<title>.md` path through the shared allocator, inserts the document, then the artifact.
 - The document is constructed directly rather than through connector preparation, whose corpus-wide content-hash dedup would drop a deliverable whose Markdown matches an existing document.
 - Retitle updates the document title and leaves the path alone. A user rename or move goes through the ordinary document move and preserves the document id.
 - Revision row-locks the artifact and rejects a missing or stale `expected_generation`.
@@ -57,7 +57,7 @@ Full-tree convergence has exactly one root and one ownership map. An artifact do
 
 ## 4. API, rendering, and permissions
 
-Artifact APIs live under `/workspaces/{workspace_id}/artifacts`. They enforce `ARTIFACTS_READ` and `ARTIFACTS_DELETE`, workspace ownership, file/artifact ownership, source-file privacy, PDF-only inline disposition, immutable file ETags, and no-store current downloads.
+Artifact APIs live under `/workspaces/{workspace_id}/artifacts`. They enforce `ARTIFACTS_READ` and `ARTIFACTS_DELETE`, workspace ownership, file/artifact ownership, PDF/MP4-only inline disposition on immutable content routes, immutable file ETags, and attachment-only no-store current downloads.
 
 The manifest joins the document for title and Markdown and returns `artifact_id`, `document_id`, generation, format, and visible files. `DELETE /{artifact_id}` authorizes as an artifact operation and delegates to document deletion, which owns Git removal, chunk cascade, blob purge, and Zero-visible row state.
 
@@ -82,7 +82,7 @@ An artifact passage cites as a knowledge-base chunk. Resolution returns the docu
 - Git projection and convergence preserve `document_type` across incremental and full-tree runs.
 - Non-git indexing failure leaves a durable artifact with a failed document that reindex repairs.
 - Deleting the artifact removes the Git file, the document, its chunks, the artifact, its file rows, and every reachable blob including artifact roles.
-- Artifact route RBAC/isolation, ETag/304, no-store download, PDF-only inline, and source rejection.
+- Artifact route RBAC/isolation, ETag/304, no-store attachment download, and PDF/MP4-only inline content.
 - `save_document` refuses an artifact document; rename and move still succeed.
 - An artifact passage ranks in the same fusion as documents and its citation opens the artifact panel.
 - Frontend queries/cards/panel identity use `artifact_id`.

--- a/plans/artifacts/phase-2-sandbox-pdf.md
+++ b/plans/artifacts/phase-2-sandbox-pdf.md
@@ -18,19 +18,19 @@ The measured OpenSandbox spike passed: metadata rediscovery, timeout renewal, bi
 
 ## 2. Current PDF flow
 
-1. The deliverables agent loads `/opt/skills/pdf/SKILL.md`.
+1. The deliverables agent calls `load_artifact_instructions("pdf")` to load the sandbox skill.
 2. Source code generates a deliverable-named PDF in the sandbox.
 3. `verify_artifact(path)` performs the current phase-3 verification service.
-4. `save_artifact(path, source_path, title, markdown_representation, ...)` validates the signed receipt and persists the artifact.
+4. `save_artifact(path, title, markdown_representation, ...)` validates the signed receipt and persists the artifact.
 5. The result returns `artifact_id` and `generation`.
 6. The artifact panel fetches the dedicated manifest and renders the primary PDF.
 
-For revision, the agent calls `load_artifact_source(artifact_id)`, edits the returned source, and saves with the same `artifact_id` and returned `expected_generation`. Missing or stale generation is rejected.
+For revision, the agent calls `load_artifact_for_revision(artifact_id)`, which restores the current PDF for reference plus Markdown context. The PDF is regenerated and saved with the same `artifact_id` and returned `expected_generation`. Missing or stale generation is rejected.
 
 ## 3. Persistence and search assumptions
 
 - Metadata and blobs are durable in the save tool call.
-- Binary keys are under the artifact storage namespace; source is an `ArtifactFile` role and is not user-readable.
+- Binary keys are under the artifact storage namespace; generation source remains a transient sandbox input rather than an `ArtifactFile` role.
 - The searchable Markdown is the artifact's `Document`, committed under `/documents/**` and indexed asynchronously on Git-backed workspaces.
 - Non-git workspaces index it through the document pipeline inside the save; an indexing failure leaves a durable artifact with a failed document for reindex.
 - Search and citations are the document ones; the artifact document type routes the citation to the panel.
@@ -53,7 +53,7 @@ The phase-2 sentinel, mtime ledger, model-facing image inspection, and skill scr
 ## 6. Exit criteria
 
 1. PDF creation has no Typst dependency.
-2. Generated PDF bytes and source persist as artifact files.
+2. Generated PDF bytes persist as the primary artifact file; generation source is transient.
 3. The primary renders via the artifact API with immutable caching and downloads with its generated filename.
 4. The artifact becomes searchable according to Git/non-git indexing timing.
 5. Revision updates one artifact under optimistic generation rather than producing a second deliverable.

--- a/plans/artifacts/phase-3-docx.md
+++ b/plans/artifacts/phase-3-docx.md
@@ -11,7 +11,7 @@
 - PDF migrated from model-sequenced scripts to the service.
 - DOCX skill and OOXML structural adapter.
 - DOCX canonical MIME and PDF rendered policy.
-- Primary + preview + source artifact-file shape.
+- Primary + preview artifact-file shape.
 - `PdfPreviewViewer` with missing-preview fallback.
 
 ## 2. Verification architecture
@@ -33,21 +33,20 @@ The service emits progress for checking, converting, rendering, and reviewing. A
 
 The DOCX adapter uses the shared OOXML trust boundary: duplicate/encrypted parts, entry counts, compressed/uncompressed limits, and required parts are validated before XML is trusted. DOCX-specific checks cover invalid table widths/shading, literal bullets, missing grids, and TOC/outline inconsistencies.
 
-The skill authors with the preinstalled Node `docx` package, uses a deliverable-derived filename, generates the whole reflowing document, then calls the generic verify/save tools. It does not implement conversion, rasterization, receipts, or source loading.
+The skill authors with the preinstalled Node `docx` package, uses a deliverable-derived filename, generates the whole reflowing document, then calls the generic verify/save tools. It does not implement conversion, rasterization, receipts, or revision loading.
 
 The adapter owns the canonical WordprocessingML MIME. The saved artifact has:
 
 - primary `.docx`;
-- receipt-bound preview `.pdf`;
-- private generation source.
+- receipt-bound preview `.pdf`.
 
-The manifest omits source. The viewer renders preview and the stable download serves current primary.
+The viewer renders the preview and the stable download serves the current primary. Generation source remains a transient sandbox input.
 
 ## 4. Persistence assumptions
 
 - A DOCX save is one artifact `Document` plus `Artifact`/`ArtifactFile` rows; the bytes never become `DocumentFile` rows.
-- Revision starts with `load_artifact_source(artifact_id)` and saves with `artifact_id + expected_generation`.
-- Retitle leaves the authored `/documents/Artifacts/<title>.md` path unchanged.
+- Revision starts with `load_artifact_for_revision(artifact_id)`, which restores the current primary plus Markdown context, and saves with `artifact_id + expected_generation`.
+- Retitle leaves the authored `/documents/<title>.md` path unchanged.
 - Git-backed Markdown converges through document convergence; non-git Markdown indexes through the document pipeline inside the save.
 - Deletion runs through document deletion, which purges all artifact blob roles through artifact storage.
 - Search citations are knowledge-base chunk citations.
@@ -56,16 +55,16 @@ The manifest omits source. The viewer renders preview and the stable download se
 
 - Pure adapter fixtures for valid and malformed OOXML.
 - Receipt round-trip, tampering, expiry, audience, and hash mismatch tests.
-- Mocked-sandbox DOCX save with primary/preview/source, source omitted from result/manifest, and stale receipt refusal.
+- Mocked-sandbox DOCX save with primary/preview and stale receipt refusal.
 - One artifact document per save, with type preserved across projection.
-- Later-turn optimistic revision keeps the same artifact ID, increments generation, and uses stored source.
+- Later-turn optimistic revision keeps the same artifact ID, increments generation, and uses the restored current primary plus Markdown context.
 - Live OpenSandbox conversion/rasterization and canonical MIME check.
-- Delete removes all reachable primary/preview/source blobs.
+- Delete removes all reachable primary/preview blobs.
 
 ## 6. Exit criteria
 
 1. PDF and DOCX verify through one backend service with no skill scripts.
 2. DOCX renders through its PDF preview and downloads the real DOCX.
-3. Source remains private but loadable by the revision tool.
+3. Revision restores the current primary and Markdown context without persisting generation source.
 4. Failed/stale revisions preserve the previous generation.
 5. Phase 4 can add PPTX as an adapter, skill, registry entry, and tests without changing persistence or API contracts.

--- a/plans/artifacts/phase-4-pptx.md
+++ b/plans/artifacts/phase-4-pptx.md
@@ -28,9 +28,9 @@ The adapter owns the presentation MIME and PDF rendered policy. The generic rece
 
 ## 3. Artifact flow
 
-PPTX persists as one `Artifact` with primary, preview, and private source `ArtifactFile` rows over one artifact `Document`. Its searchable Markdown is that document, under `/documents/**` and in `Chunk`; the deck bytes never enter document file persistence.
+PPTX persists as one `Artifact` with primary and preview `ArtifactFile` rows over one artifact `Document`. Its searchable Markdown is that document, under `/documents/**` and in `Chunk`; the deck bytes never enter document file persistence. Generation source remains a transient sandbox input.
 
-Create returns `artifact_id` and generation. Revision loads source by artifact ID and requires the expected generation. The manifest and immutable file URLs are artifact routes. Search results and citations are the document ones, with type routing the citation to the artifact panel.
+Create returns `artifact_id` and generation. Revision uses `load_artifact_for_revision` to restore the current primary plus Markdown context and requires the expected generation. The manifest and immutable file URLs are artifact routes. Search results and citations are the document ones, with type routing the citation to the artifact panel.
 
 ## 4. Rendering
 
@@ -43,7 +43,7 @@ PPTX generation is independent of the video-media pipeline; no PPTX exporter rem
 - Adapter fixtures for package/count/relationship/hidden-slide/geometry/crop defects.
 - Service checks for pre-conversion ceiling and dropped converted pages.
 - Slide/document review framing under one verdict contract.
-- Artifact create, stale-receipt refusal, private source, optimistic revision, stable path, and blob purge.
+- Artifact create, stale-receipt refusal, optimistic revision, stable path, and blob purge.
 - Live OpenSandbox generation, LibreOffice conversion, Poppler rasterization, receipt, and canonical MIME.
 
 ## 6. Exit criteria

--- a/plans/artifacts/phase-5-xlsx.md
+++ b/plans/artifacts/phase-5-xlsx.md
@@ -11,7 +11,7 @@ Phase 5 added spreadsheet generation, structural verification, persistence, and 
 - The sandbox ships an XLSX skill backed by preinstalled XlsxWriter.
 - `.xlsx` has a structural `FormatAdapter` with the canonical spreadsheet MIME.
 - Verification is programmatic: no conversion, rasterization, vision review, or preview file.
-- Binary persistence uses the existing primary + private source artifact roles.
+- Binary persistence uses the existing primary artifact role.
 - The artifact panel lazy-loads a native spreadsheet viewer for XLSX manifests.
 
 Generic unknown formats, public artifact viewing, and cross-format hardening are phase 7. Legacy report and Typst removal is documented separately in phase 6.
@@ -21,10 +21,9 @@ Generic unknown formats, public artifact viewing, and cross-format hardening are
 An XLSX artifact is one `Document(document_type=ARTIFACT)` plus one `Artifact(format="xlsx")`. Its files are:
 
 - a primary `.xlsx` file;
-- a private `.py` generation source;
 - no preview.
 
-The document owns searchable Markdown under `/documents/Artifacts/` and follows ordinary chunking, indexing, search, move, rename, and deletion behavior. Artifact revisions load the private source and save with `artifact_id + expected_generation`.
+The document owns searchable Markdown under `/documents/` and follows ordinary chunking, indexing, search, move, rename, and deletion behavior. Artifact revisions restore the current workbook plus Markdown context and save with `artifact_id + expected_generation`.
 
 XLSX required no migration, document subtype, chunk table, search branch, or format-specific artifact route.
 
@@ -48,10 +47,10 @@ The generation flow is:
 
 1. create the workbook and complete Python source in the sandbox;
 2. call `verify_artifact` on the workbook;
-3. call `save_artifact` with primary and source paths and no preview;
-4. for revisions, load the source by artifact ID and save with the returned generation.
+3. call `save_artifact` with the primary path and no preview;
+4. for revisions, call `load_artifact_for_revision`, edit the restored workbook with a format-aware library, and save with the returned generation.
 
-The Markdown representation summarizes sheets, columns, and key figures for search and accessibility.
+The Python generation source remains transient in the sandbox. The Markdown representation summarizes sheets, columns, and key figures for search and accessibility.
 
 ## 5. Native viewer
 
@@ -71,7 +70,7 @@ Charts, pivot tables, macros, editing, and full Excel emulation are outside the 
 
 - Unit coverage exercises clean workbooks, formula caches, missing caches, Excel errors, empty content, the cell ceiling, and receipt behavior.
 - Receipt tests prove XLSX never enters conversion, rasterization, or vision.
-- Integration coverage proves primary + private source persistence, post-verification mutation rejection, source loading, optimistic revision, and blob purge.
+- Integration coverage proves primary-only persistence, post-verification mutation rejection, restoration of the current primary, optimistic revision, and blob purge.
 - Parser tests cover formatted values, formula results, row truncation, oversized payloads, and corrupt workbooks.
 
 ## 7. Exit criteria

--- a/plans/artifacts/phase-5-xlsx.md
+++ b/plans/artifacts/phase-5-xlsx.md
@@ -14,7 +14,7 @@ Phase 5 added spreadsheet generation, structural verification, persistence, and 
 - Binary persistence uses the existing primary artifact role.
 - The artifact panel lazy-loads a native spreadsheet viewer for XLSX manifests.
 
-Generic unknown formats, public artifact viewing, and cross-format hardening are phase 7. Legacy report and Typst removal is documented separately in phase 6.
+Generic unknown formats, public artifact viewing, and cross-format hardening are phase 8. Legacy report and Typst removal is documented separately in phase 7.
 
 ## 2. Persistence
 

--- a/plans/artifacts/phase-6-demolition.md
+++ b/plans/artifacts/phase-6-demolition.md
@@ -14,15 +14,17 @@ Land in this order, keeping each change green:
 3. Remove agent/frontend/backend legacy code, including clone-time report handling.
 4. Drop legacy data/model and dependencies.
 
-Shared-thread cloning is the last live `Report` writer: historical `generate_report` parts currently cause clone-time report inserts. Remove that behavior before dropping the table.
+Shared-thread cloning was the last live `Report` writer: historical `generate_report` parts caused clone-time report inserts. That behavior was removed before the table was dropped.
 
 ## 2. Legacy behavior
 
 Old `generate_report`/`generate_resume` parts render a static card:
 
-> Generated with the previous artifact system — no longer available. Ask me to regenerate it.
+> **Content unavailable**
+>
+> This content can’t be opened. Ask me to regenerate it.
 
-The card performs no fetch and opens no panel. Release notes warn users to export old deliverables before upgrading.
+The card performs no fetch and opens no panel. The changelog explains that deliverables from the previous tools are unavailable and should be regenerated through the artifact system.
 
 There is no backfill, `migrated_from_report_id`, lazy conversion, Typst compile, or mapping to the artifact schema.
 
@@ -32,7 +34,7 @@ There is no backfill, `migrated_from_report_id`, lazy conversion, Typst compile,
 
 - Delete `generate_report` and `generate_resume` implementations, registrations, catalogs, prune names, and streaming handlers.
 - Delete the legacy report-writing skill and resume-specific tests.
-- Keep `save_artifact`, `verify_artifact`, and `load_artifact_source` as the format-oriented system.
+- Keep `save_artifact`, `verify_artifact`, and `load_artifact_for_revision` as the format-oriented system.
 
 ### Frontend
 

--- a/plans/artifacts/phase-6-html.md
+++ b/plans/artifacts/phase-6-html.md
@@ -1,0 +1,237 @@
+# Phase 6 — Interactive HTML Artifacts
+
+**Status:** Planned.
+**Parent spec:** [`artifacts-overhaul.md`](./artifacts-overhaul.md).
+**Depends on:** phase 1 foundation (schema, storage, panel, manifest), phase 3 verification service, and the phase 5 programmatic-verification precedent.
+**Independent of:** phase 8. Authenticated HTML rendering needs nothing from the public path; public HTML sharing is gated on phase 8 route hardening (§9).
+
+## 1. Goal
+
+Add interactive, self-contained HTML as a first-class artifact format that renders in the existing right-hand artifact panel, without a schema, persistence, or API change. HTML is a new adapter plus a new viewer, exactly as invariant §12.12 requires. It is not a new artifact domain, panel, or route.
+
+The deliverable is a single self-contained page — inline CSS, inline JavaScript, browser-local state — of the kind an "interactive pricing calculator" or dashboard prompt produces. The reference output is [`html-artifacts.md`](../../html-artifacts.md).
+
+## 2. Scope
+
+In:
+
+- an `.html` structural `FormatAdapter` with MIME `text/html`;
+- a sandbox HTML authoring skill and deliverables-agent routing;
+- programmatic verification: no conversion, rasterization, vision review, or preview file;
+- primary-only persistence through the existing artifact service;
+- a sandboxed-iframe viewer in the artifact panel, keyed off `text/html`;
+- HTML revision instructions and format metadata;
+- backend and browser coverage.
+
+Out:
+
+- public artifact viewing of HTML (deferred to the phase 8 public path, see §9);
+- inline chat-card execution of HTML (panel-only; a card is a later option);
+- server-side HTML rendering, screenshotting, or PDF preview generation;
+- external application code, backends, or persisted state inside an artifact;
+- editing an HTML artifact in the document editor (artifacts stay read-only, invariant §12.10).
+
+## 3. Persistence
+
+An HTML artifact is one `Document(document_type=ARTIFACT)` plus one `Artifact(format="html")`. Its files are:
+
+- a primary `.html` file with MIME `text/html`;
+- no preview.
+
+`Artifact.format` remains an adapter-owned string (`enums.py` may add `HTML = "html"` for roster clarity only; it is not a database enum and nothing branches on it). The document owns searchable Markdown under `/documents/` and follows ordinary chunking, indexing, search, move, rename, and deletion. `save_artifact`, `service.py`, `storage.py`, and the artifact routes are already format-blind and require no change.
+
+HTML requires no migration, document subtype, chunk table, search branch, or format-specific route.
+
+## 4. Verification
+
+The `.html` adapter is registered in `verification/formats/registry.py::_ADAPTERS` as:
+
+```
+FormatAdapter(
+    name="html",
+    suffix=".html",
+    mime_type="text/html",
+    convert_to_pdf=False,
+    check=check_html,
+    requires_visual_review=False,
+)
+```
+
+`convert_to_pdf=False` and `requires_visual_review=False` keep HTML out of the conversion, rasterization, and vision paths, matching XLSX. A successful receipt records `visual="not_required"` and binds the primary hash; it has no page count, preview path, or preview hash.
+
+`check_html(data: bytes) -> StructuralCheckResult` in `verification/formats/html.py` is deliberately thin, because the render-time sandbox (§6) is the real trust boundary, not the verifier. It:
+
+- decodes the bytes as UTF-8 and rejects non-decodable input (blocking finding);
+- rejects empty or whitespace-only content (blocking finding);
+- confirms the payload parses as HTML markup (blocking finding on unparseable input);
+- enforces the **fragment contract** — the payload must not contain a `<!DOCTYPE>`, `<html>`, `<head>`, or `<body>` wrapper (blocking finding). A fragment guarantees the viewer's document shell, and therefore its Content-Security-Policy, is always authoritative (§6);
+- emits an **advisory** note (never a blocker) for any external resource reference (`<script src>`, `<link href>`, `@import`, `src=`/`href=` to an off-origin URL) outside the font allowlist, since the render-time CSP will silently drop those resources.
+
+Size stays bounded by the existing `ARTIFACT_MAX_FILE_BYTES` limit enforced in save, verify, sandbox read, and revision load. HTML introduces no second limit.
+
+Verification never rewrites or "sanitizes" the bytes. What the agent authored is what the viewer renders, under sandbox constraints.
+
+## 5. Generation skill
+
+`docker/sandbox/skills/html/SKILL.md` teaches the deliverables agent to author one self-contained interactive HTML **fragment** in `/workspace`, following the reference in `html-artifacts.md`:
+
+- emit a fragment only — no `<!DOCTYPE>`, `<html>`, `<head>`, or `<body>` wrapper; the panel wraps it in a shell (§6);
+- inline all CSS in a `<style>` block and all behavior in an inline `<script>`; do not fetch application code or link external stylesheets;
+- keep all state in the page (in-memory or the browser's own storage inside the sandbox); the page has no backend and must not call app APIs;
+- the only permitted external resources are Google Fonts (`fonts.googleapis.com`, `fonts.gstatic.com`); embed images as `data:` URIs; anything else will be dropped by the render-time CSP;
+- build for keyboard and screen-reader use (labels, roles, `:focus-visible`), matching the reference;
+- never install or download dependencies in the sandbox.
+
+The generation flow mirrors the other skills:
+
+1. author the fragment at an output path in the sandbox;
+2. call `verify_artifact(path=output_path)` — structural only, warnings advisory; fix all blockers together, regenerate once, reverify, and stop with an explanation rather than looping;
+3. call `save_artifact(path=output_path, title="...", markdown_representation="...")`.
+
+The Markdown representation summarizes the artifact's purpose, its interactive controls, and its key content for search and accessibility — not the raw HTML.
+
+Routing: the deliverables `system_prompt.md` and `description.md` gain an explicit rule that interactive requests (calculators, configurators, dashboards, interactive prototypes) route to the HTML skill, distinct from the PDF/DOCX/PPTX/XLSX/Markdown deliverable defaults. `load_artifact_instructions`' format `Literal` in `tools/sandbox.py` gains `"html"`, and the skill roster test (`tests/unit/sandbox/test_deliverables_skill_roster.py`) is updated so the installed skill appears in the prompt.
+
+## 6. Sandboxed viewer and security model
+
+HTML artifacts are untrusted, agent-authored code that executes in the viewer's browser. The entire security posture is: **never render artifact HTML on the SurfSense origin, and never grant the frame same-origin power.** Two rules, one boundary.
+
+### 6.1 Backend: attachment-only, always
+
+`text/html` must never be added to `_is_inline` in `document_files_routes.py` (or the artifact content route that reuses it). Stored HTML is served with `Content-Disposition: attachment` and `X-Content-Type-Options: nosniff`, so a direct hit on the content URL downloads a file and can never execute on our origin. A regression test asserts `text/html -> attachment`, alongside the existing PDF/MP4 inline cases.
+
+### 6.2 Frontend: fetch as bytes, render in a sandboxed frame
+
+The file-viewer registry (`features/file-viewers/viewer-registry.ts::FILE_VIEWERS`) maps `"text/html"` to a client-only `HtmlFileViewer`. Because `features/artifacts/viewer-registry.ts::VIEWERS` spreads `FILE_VIEWERS`, the artifact panel picks it up with no panel change. `HtmlFileViewer`:
+
+- rejects oversized files before fetch and again before render, mirroring `XlsxViewer`;
+- fetches the primary via the manifest `content_url` using the existing authenticated blob fetch (`download-file.ts`), so auth headers are sent and the frame never navigates the app to the content URL;
+- wraps the fetched fragment in a document shell it controls, then renders it through the frame's `srcdoc` — never by setting `iframe.src` to the content URL;
+- degrades a failed fetch, oversized payload, or decode error to the shared unviewable state while preserving the header download button.
+
+### 6.3 The frame contract
+
+The iframe is created with exactly:
+
+```
+sandbox="allow-scripts"
+```
+
+and nothing else. In particular it omits `allow-same-origin` (so the frame runs in an opaque origin with no access to parent DOM, cookies, `localStorage`, or the session), and omits `allow-forms`, `allow-popups`, `allow-popups-to-escape-sandbox`, `allow-modals`, `allow-downloads`, `allow-top-navigation`, and `allow-top-navigation-by-user-activation`. Scripts run; nothing escapes the frame.
+
+### 6.4 The document shell and CSP
+
+The viewer builds the shell so the fragment cannot supply its own `<head>`:
+
+```html
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta http-equiv="Content-Security-Policy" content="
+      default-src 'none';
+      script-src 'unsafe-inline';
+      style-src 'unsafe-inline' https://fonts.googleapis.com;
+      font-src https://fonts.gstatic.com;
+      img-src data:;
+      connect-src 'none';
+      form-action 'none';
+      base-uri 'none'">
+  </head>
+  <body><!-- agent fragment --></body>
+</html>
+```
+
+`script-src 'unsafe-inline'` is safe here because the frame is an opaque origin with no same-origin capability; `connect-src 'none'` blocks `fetch`/XHR/WebSocket exfiltration; `img-src data:` forces images inline; the font directives allow only the Google Fonts pair the reference uses. The CSP is defense in depth layered on the sandbox attribute; the sandbox attribute is the primary control. The fragment contract (§4) exists precisely so this shell is always the one that runs.
+
+All viewers remain read-only (overhaul §8). The frame is a preview surface, not an editor.
+
+## 7. Revision
+
+HTML uses the existing revision path with no contract change. `_REVISION_INSTRUCTIONS` in `tools/load_artifact_for_revision.py` gains an `"html"` entry:
+
+> Edit `primary_path` directly, or regenerate the fragment from `markdown_path` plus the user's new instruction, and write the result to `expected_output_path`. Keep it a self-contained fragment. Do not reconstruct the page with vision.
+
+`load_artifact_for_revision(artifact_id)` restores the current `.html` primary plus Markdown context and the current generation; the save passes `artifact_id + expected_generation`. A changed title, layout, or palette is still the same artifact unless the user asks for a separate copy.
+
+## 8. Format metadata and routing
+
+`features/artifacts/artifact-format-meta.ts` gains:
+
+```
+html: {
+  icon: FileCode,          // already imported
+  label: "Interactive",
+  detailLabel: "HTML",
+  groupKey: "files",
+  groupLabel: "Files",
+  viewingMode: "viewer",
+}
+```
+
+`viewingMode: "viewer"` sends HTML to the right panel through `ArtifactViewerContent`, the same path as PDF and XLSX; `open-chat-artifact.ts` and `artifact-format-icon.tsx`/`artifact-format-label.tsx` work off this meta with no further change.
+
+## 9. Public sharing boundary
+
+Public HTML is out of this phase. The current public content route (`public_chat_routes.py::stream_public_artifact_file`) streams the stored MIME with no `Content-Disposition` and no `nosniff`, which phase 8 §7.1 already commits to fixing for all formats. HTML must not be publicly served until that hardening lands, because a public content URL that omits attachment/`nosniff` is a route to executing agent HTML on a shared origin.
+
+When public HTML does ship, it reuses the same story: bytes fetched via the token-scoped content route (attachment + `nosniff`), rendered in the same sandboxed `srcdoc` frame. The phase 8 public viewer list gains an HTML entry at that point. No public artifact copy, no second render path.
+
+## 10. Security invariants
+
+1. `text/html` is never inline on any backend route; stored HTML is always an attachment with `X-Content-Type-Options: nosniff`.
+2. Artifact HTML renders only inside an iframe whose `sandbox` is `allow-scripts` and nothing else; `allow-same-origin` is never present.
+3. The frame is loaded from viewer-built `srcdoc`, never from `iframe.src` pointed at a content URL, and never through `dangerouslySetInnerHTML` in the React tree.
+4. The agent emits a fragment; the viewer owns the document shell and its Content-Security-Policy, so page-supplied `<head>` content can never displace the CSP.
+5. Verification neither rewrites nor sanitizes bytes; the sandbox and CSP are the trust boundary, and structural checks only fail closed on unusable input.
+6. External network access from a rendered artifact is limited to the Google Fonts pair by CSP; `connect-src 'none'` blocks data exfiltration.
+
+## 11. Required checks
+
+### 11.1 Verification
+
+- non-empty, UTF-8-decodable fragment verifies with `text/html` and `visual="not_required"`;
+- empty, non-UTF-8, unparseable, and full-document (`<html>`/`<head>`/`<body>`/`<!DOCTYPE>`) payloads fail before persistence;
+- off-allowlist external references produce advisory notes, not blockers;
+- the receipt binds the primary hash and carries no rendered fields;
+- oversized payloads fail on the existing size limit.
+
+### 11.2 Persistence and revision
+
+- save creates one document + one `Artifact(format="html")` + one primary file, no preview;
+- the manifest exposes the primary with MIME `text/html` and a `content_url`;
+- `load_artifact_for_revision` restores the current primary and Markdown; a stale `expected_generation` fails without touching files or generation;
+- one sandbox-to-save integration authors a real fragment, verifies it, persists it, revises it, and confirms blob purge of the superseded generation.
+
+### 11.3 Routing and serving
+
+- an interactive request routes to the HTML skill, and the skill appears in the deliverables prompt (roster test);
+- the authenticated content route serves `text/html` as `attachment` with `nosniff` (regression test beside the PDF/MP4 inline cases).
+
+### 11.4 Browser
+
+- the registry resolves `text/html` to `HtmlFileViewer`, and the meta reports `viewingMode: "viewer"`;
+- the rendered iframe carries `sandbox="allow-scripts"` with no `allow-same-origin`, and is fed by `srcdoc`, not `src`;
+- the reference calculator's controls (plan toggle, sliders, checkboxes, reset) operate inside the frame;
+- oversized and corrupt payloads fall back to the shared unviewable state with download preserved.
+
+## 12. Delivery order
+
+1. Add the `.html` adapter, `check_html`, and focused verification tests.
+2. Add the sandbox HTML skill, extend `load_artifact_instructions`, wire prompt routing, and update the roster test.
+3. Add `HtmlFileViewer`, register `text/html`, and add format metadata.
+4. Add the attachment/`nosniff` serving regression test and the sandbox-to-save integration test.
+5. Run cross-format regression and update `artifacts-overhaul.md` §7–§9.
+
+Each step leaves one format-neutral path. If any step needs a format-specific persistence or route branch, stop and repair the shared boundary instead.
+
+## 13. Exit criteria
+
+1. Interactive requests route to the HTML skill and produce a self-contained fragment.
+2. The fragment verifies programmatically with no preview or visual review.
+3. Save and revision use the same document-backed artifact model as PDF, DOCX, PPTX, and XLSX.
+4. The authenticated artifact panel renders the page in a sandboxed iframe with no same-origin power, and the header still downloads the original `.html`.
+5. `text/html` is attachment-only with `nosniff` on every backend route, and no artifact HTML executes on the SurfSense origin.
+6. No HTML-specific schema, persistence API, search path, or document-editor path exists.
+7. PDF, DOCX, PPTX, XLSX, Markdown, and unknown-format behavior remain green.

--- a/plans/artifacts/phase-6-html.md
+++ b/plans/artifacts/phase-6-html.md
@@ -16,7 +16,8 @@ The deliverable is a single self-contained page — inline CSS, inline JavaScrip
 In:
 
 - an `.html` structural `FormatAdapter` with MIME `text/html`;
-- a sandbox HTML authoring skill and deliverables-agent routing;
+- a sandbox HTML authoring skill (mechanics), and a shared design skill it defers to for aesthetics;
+- intent-based routing so interactive requests select HTML without the user naming a format;
 - programmatic verification: no conversion, rasterization, vision review, or preview file;
 - primary-only persistence through the existing artifact service;
 - a sandboxed-iframe viewer in the artifact panel, keyed off `text/html`;
@@ -73,6 +74,10 @@ Verification never rewrites or "sanitizes" the bytes. What the agent authored is
 
 ## 5. Generation skill
 
+Two layers author an HTML artifact, and they must stay separate: the **format skill** owns mechanics, and a **shared design skill** owns aesthetics. The HTML skill does not re-teach visual design; it defers to the design skill so PPTX, PDF, DOCX, and image generation can reuse the same design core rather than each carrying its own copy.
+
+### 5.1 HTML format skill (mechanics)
+
 `docker/sandbox/skills/html/SKILL.md` teaches the deliverables agent to author one self-contained interactive HTML **fragment** in `/workspace`, following the reference in `html-artifacts.md`:
 
 - emit a fragment only — no `<!DOCTYPE>`, `<html>`, `<head>`, or `<body>` wrapper; the panel wraps it in a shell (§6);
@@ -90,7 +95,30 @@ The generation flow mirrors the other skills:
 
 The Markdown representation summarizes the artifact's purpose, its interactive controls, and its key content for search and accessibility — not the raw HTML.
 
-Routing: the deliverables `system_prompt.md` and `description.md` gain an explicit rule that interactive requests (calculators, configurators, dashboards, interactive prototypes) route to the HTML skill, distinct from the PDF/DOCX/PPTX/XLSX/Markdown deliverable defaults. `load_artifact_instructions`' format `Literal` in `tools/sandbox.py` gains `"html"`, and the skill roster test (`tests/unit/sandbox/test_deliverables_skill_roster.py`) is updated so the installed skill appears in the prompt.
+### 5.2 Shared design skill (aesthetics)
+
+Visual quality is not duplicated across format skills.
+`docker/sandbox/skills/frontend-design/DESIGN.md` supplies general design
+guidance — subject grounding, a named palette, deliberate
+type pairing and scale, structural hierarchy, restraint, and copywriting.
+HTML keeps its web-only addendum (layout, motion, CSS specificity, responsive
+behavior, and reduced motion) in `html/SKILL.md`; other formats retain their
+own medium-specific rules.
+
+Because `load_artifact_instructions` simply `cat`s one
+`/opt/skills/<name>/SKILL.md`, the Docker skills-assembly step appends the
+shared guidance to every installed format `SKILL.md`. The `frontend-design` folder
+contains `DESIGN.md`, not `SKILL.md`, so it is neither advertised as an
+artifact format nor copied into `/opt/skills`. This also avoids replacing the
+base image's unrelated `frontend-design` skill.
+
+### 5.3 Intent routing — the user never has to say "HTML"
+
+Interactive intent, not the literal word "HTML", selects this format. `Create an interactive pricing calculator` produces an HTML artifact with no format hint from the user; this is the defining behavior of the format, matching the reference in `html-artifacts.md`.
+
+The deliverables `system_prompt.md` format policy currently ends with "otherwise, prefer PDF for a finished deliverable," which would swallow interactive requests into a static PDF. Phase 6 inserts an **interactive-intent branch ahead of that PDF default**: a request whose deliverable is something the user operates rather than reads — a calculator, configurator, estimator, simulator, interactive dashboard, live/interactive prototype, widget, or tool with controls — routes to HTML. The signal is interactivity (inputs, sliders, toggles, live-updating output), not the noun. A request for a static write-up, letter, report, deck, or sheet keeps its existing format; an explicit format request still overrides, as it does today.
+
+`description.md` advertises the interactive capability so the supervisor delegates these requests to the deliverables agent. `load_artifact_instructions`' format `Literal` in `tools/sandbox.py` gains `"html"`, and the roster test (`tests/unit/sandbox/test_deliverables_skill_roster.py`) is updated so the installed HTML skill is advertised. A routing test asserts that an interactive prompt with no format word selects HTML and does not fall through to PDF.
 
 ## 6. Sandboxed viewer and security model
 
@@ -206,7 +234,9 @@ When public HTML does ship, it reuses the same story: bytes fetched via the toke
 
 ### 11.3 Routing and serving
 
-- an interactive request routes to the HTML skill, and the skill appears in the deliverables prompt (roster test);
+- an interactive prompt with no format word (e.g. "create an interactive pricing calculator") selects HTML and does not fall through to the PDF default;
+- a static request (report, letter, deck, sheet) keeps its existing format, and an explicit format word still overrides;
+- the installed HTML skill appears in the deliverables prompt (roster test);
 - the authenticated content route serves `text/html` as `attachment` with `nosniff` (regression test beside the PDF/MP4 inline cases).
 
 ### 11.4 Browser
@@ -219,16 +249,17 @@ When public HTML does ship, it reuses the same story: bytes fetched via the toke
 ## 12. Delivery order
 
 1. Add the `.html` adapter, `check_html`, and focused verification tests.
-2. Add the sandbox HTML skill, extend `load_artifact_instructions`, wire prompt routing, and update the roster test.
-3. Add `HtmlFileViewer`, register `text/html`, and add format metadata.
-4. Add the attachment/`nosniff` serving regression test and the sandbox-to-save integration test.
-5. Run cross-format regression and update `artifacts-overhaul.md` §7–§9.
+2. Split `frontend-design/DESIGN.md` from HTML's web-runtime rules and compose the shared guidance into every installed format skill at image build.
+3. Add the sandbox HTML skill, extend `load_artifact_instructions`, insert the interactive-intent routing branch ahead of the PDF default, and update the roster and routing tests.
+4. Add `HtmlFileViewer`, register `text/html`, and add format metadata.
+5. Add the attachment/`nosniff` serving regression test and the sandbox-to-save integration test.
+6. Run cross-format regression and update `artifacts-overhaul.md` §7–§9.
 
 Each step leaves one format-neutral path. If any step needs a format-specific persistence or route branch, stop and repair the shared boundary instead.
 
 ## 13. Exit criteria
 
-1. Interactive requests route to the HTML skill and produce a self-contained fragment.
+1. Interactive requests route to HTML on intent alone — no format word required — ahead of the PDF default, and produce a self-contained fragment; static requests and explicit formats are unaffected.
 2. The fragment verifies programmatically with no preview or visual review.
 3. Save and revision use the same document-backed artifact model as PDF, DOCX, PPTX, and XLSX.
 4. The authenticated artifact panel renders the page in a sandboxed iframe with no same-origin power, and the header still downloads the original `.html`.

--- a/plans/artifacts/phase-7-demolition.md
+++ b/plans/artifacts/phase-7-demolition.md
@@ -1,4 +1,4 @@
-# Phase 6 — Legacy Deliverable Demolition
+# Phase 7 — Legacy Deliverable Demolition
 
 **Status:** Complete.
 **Parent spec:** [`artifacts-overhaul.md`](./artifacts-overhaul.md).
@@ -61,7 +61,7 @@ There is no backfill, `migrated_from_report_id`, lazy conversion, Typst compile,
 
 The artifacts library lists `GET /workspaces/{workspace_id}/artifacts`. Format, generation, and file roles come from the artifact rows; they are never inferred from document metadata or file kinds.
 
-Phase 6 must not:
+Phase 7 must not:
 
 - convert legacy reports to artifacts;
 - reintroduce a parallel artifact corpus, chunk table, or search leg;

--- a/plans/artifacts/phase-7-public-and-generic.md
+++ b/plans/artifacts/phase-7-public-and-generic.md
@@ -23,7 +23,7 @@ In:
 
 Out:
 
-- public access to generation source files;
+- persistence or public access for transient generation source files;
 - public artifact editing or revision;
 - retained historical artifact generations;
 - replacement of existing public image, podcast, or video-presentation delivery;
@@ -44,7 +44,7 @@ Unknown file suffixes resolve to one generic adapter instead of failing format l
 
 Unknown content is always served as an attachment. The backend must not infer an inline-safe MIME from untrusted bytes or add suffix checks to persistence. Existing size limits remain the trust boundary; the generic adapter does not introduce a second limit.
 
-Source requirements and privacy are unchanged. A generated binary still persists its complete generation source privately when the artifact contract requires one.
+Generation-source handling is unchanged: source files remain transient sandbox inputs and are not persisted as artifact roles.
 
 ## 4. Public artifact contract
 
@@ -56,7 +56,7 @@ A public share token grants access only when:
 2. the requested artifact ID is in that snapshot's artifact allowlist;
 3. the artifact belongs to the snapshot's workspace and originating thread.
 
-Every public manifest, file, and download route applies the same authorization helper. Invalid tokens, cross-thread IDs, cross-workspace IDs, source-file IDs, and deleted artifacts return `404` without disclosing which check failed.
+Every public manifest, file, and download route applies the same authorization helper. Invalid tokens, cross-thread IDs, cross-workspace IDs, file IDs outside the artifact's visible primary/preview roles, and deleted artifacts return `404` without disclosing which check failed.
 
 Chat messages remain immutable snapshot data. Artifact IDs are live references to the artifact's current generation; phase 7 does not retain or expose historical artifact generations.
 
@@ -68,7 +68,7 @@ Add token-scoped equivalents of the authenticated read surface:
 - `GET /public/{share_token}/artifacts/{artifact_id}/download`
 - `GET /public/{share_token}/artifacts/{artifact_id}/files/{file_id}/content`
 
-The public manifest uses the same artifact metadata and file-role shape as the authenticated manifest, but emits public URLs. It includes only `primary` and `preview` files. `source` is never serialized and cannot be fetched by guessing its ID.
+The public manifest uses the same artifact metadata and file-role shape as the authenticated manifest, but emits public URLs. It includes only `primary` and `preview` files; generation sources are not persisted.
 
 Download returns the real primary artifact with a safe filename and `Content-Disposition: attachment`. A Markdown-only artifact downloads the document's Markdown snapshot through the same route. File content supports only receipt-bound primary and preview files.
 
@@ -125,7 +125,7 @@ Add a live LibreOffice smoke check that opens/recalculates a generated workbook 
 
 - valid token can read only allowlisted artifact manifests and files;
 - another thread, workspace, token, or artifact ID receives `404`;
-- source file IDs are never listed and always receive `404`;
+- file IDs outside the artifact's visible primary/preview files are never listed and always receive `404`;
 - Markdown-only and binary primary downloads return correct bytes and filenames;
 - deleted artifacts and stale file IDs fail closed;
 - public DOCX/PPTX preview and XLSX primary routes use the shared viewer registry.
@@ -153,7 +153,7 @@ Each step leaves one format-neutral path. If public integration or XLSX hardenin
 
 1. Any bounded, non-empty unknown binary can verify, persist, and download safely without a format-specific code change.
 2. A public chat can view and download every allowlisted artifact format through token-scoped URLs.
-3. Public access cannot reveal source files or artifacts outside the shared thread and workspace.
+3. Public access cannot reveal files outside the visible primary/preview roles or artifacts outside the shared thread and workspace.
 4. Authenticated and public surfaces use the same manifest model, panel, and viewer registry.
 5. XLSX verification rejects hostile OOXML packages and the viewer preserves common formatting while remaining bounded.
 6. Real XlsxWriter output passes verification, persistence, LibreOffice smoke, and browser viewing.

--- a/plans/artifacts/phase-8-public-and-generic.md
+++ b/plans/artifacts/phase-8-public-and-generic.md
@@ -1,14 +1,14 @@
-# Phase 7 — Public, Generic, and Hardened Artifacts
+# Phase 8 — Public, Generic, and Hardened Artifacts
 
 **Status:** Planned.
 **Parent spec:** [`artifacts-overhaul.md`](./artifacts-overhaul.md).
-**Depends on:** phase 5 XLSX pipeline and phase 6 legacy demolition.
+**Depends on:** phase 5 XLSX pipeline and phase 7 legacy demolition.
 
 ## 1. Goal
 
 Complete the format-independent artifact contract by making artifacts available in public chat snapshots, accepting safe download-only formats through a generic adapter, and closing the remaining XLSX quality gaps.
 
-Phase 7 extends the existing artifact service and viewer registry. It does not introduce another persistence model, public artifact copy, panel, export system, or format-specific API.
+Phase 8 extends the existing artifact service and viewer registry. It does not introduce another persistence model, public artifact copy, panel, export system, or format-specific API.
 
 ## 2. Scope
 
@@ -58,7 +58,7 @@ A public share token grants access only when:
 
 Every public manifest, file, and download route applies the same authorization helper. Invalid tokens, cross-thread IDs, cross-workspace IDs, file IDs outside the artifact's visible primary/preview roles, and deleted artifacts return `404` without disclosing which check failed.
 
-Chat messages remain immutable snapshot data. Artifact IDs are live references to the artifact's current generation; phase 7 does not retain or expose historical artifact generations.
+Chat messages remain immutable snapshot data. Artifact IDs are live references to the artifact's current generation; phase 8 does not retain or expose historical artifact generations.
 
 ### 4.2 Routes
 
@@ -83,6 +83,7 @@ Public tool cards resolve artifact manifests with the share token and open the e
 - PDF uses the PDF viewer.
 - DOCX and PPTX use their receipt-bound PDF preview.
 - XLSX uses the native grid.
+- HTML uses the sandboxed iframe viewer (phase 6), served attachment-only with `nosniff` so it never executes on the app origin.
 - Markdown uses the Markdown viewer.
 - Unknown formats use the download fallback.
 

--- a/surfsense_backend/app/agents/chat/multi_agent_chat/subagents/builtins/deliverables/description.md
+++ b/surfsense_backend/app/agents/chat/multi_agent_chat/subagents/builtins/deliverables/description.md
@@ -1,3 +1,4 @@
 Specialist for producing and revising file deliverables: Markdown, polished PDF files, editable Word DOCX (`.docx`) files, editable PowerPoint PPTX (`.pptx`) slide decks, Excel XLSX (`.xlsx`) workbooks, reports, and resumes.
+Creates interactive calculators, configurators, dashboards, widgets, and prototypes as HTML artifacts, even when the user does not name HTML.
 Also produces media deliverables: podcasts, videos, and generated images.
 Use proactively whenever the user asks for one of these artifacts.

--- a/surfsense_backend/app/agents/chat/multi_agent_chat/subagents/builtins/deliverables/system_prompt.md
+++ b/surfsense_backend/app/agents/chat/multi_agent_chat/subagents/builtins/deliverables/system_prompt.md
@@ -9,7 +9,8 @@ what was generated.
 <tool_policy>
 - Use only the tools provided for this invocation.
 - Choose the output format from the user's intent without asking them to select
-  one. Reports, resumes/CVs, printable documents, letters, and one-pagers
+  one. Interactive calculators, configurators, simulators, and tools whose
+  controls update results → HTML. Reports, resumes/CVs, printable documents, letters, and one-pagers
   default to PDF. Editable Word documents → DOCX. PowerPoint, `.pptx`, slides,
   and slide decks → PPTX. Spreadsheets, budgets, trackers, tables, and `.xlsx`
   → XLSX. Plain notes, briefs, and content intended for continued editing →
@@ -25,6 +26,8 @@ what was generated.
   decks and `.pptx` presentations.
 - Available format skill: `xlsx` — creates polished Excel workbooks for
   budgets, trackers, tables, and explicit `.xlsx` requests.
+- Available format skill: `html` — creates interactive calculators,
+  configurators, dashboards, widgets, and prototypes.
 - Before creating a PDF, load its full instructions with
   `load_artifact_instructions(artifact_type="pdf")`, then follow the
   skill's generate → verify → bounded repair/reverify → save workflow.
@@ -39,6 +42,10 @@ what was generated.
 - Before creating an XLSX, load its full instructions with
   `load_artifact_instructions(artifact_type="xlsx")`, then follow the
   same bounded generate → verify → save workflow. XLSX verification is
+  structural only.
+- Before creating HTML, load its full instructions with
+  `load_artifact_instructions(artifact_type="html")`, then follow the
+  same bounded generate → verify → save workflow. HTML verification is
   structural only.
 - A `/documents/...` path is a knowledge-base handle, not a sandbox file. To
   convert, reformat, or extract from a file the user already has, call

--- a/surfsense_backend/app/agents/chat/multi_agent_chat/subagents/builtins/deliverables/tools/load_artifact_for_revision.py
+++ b/surfsense_backend/app/agents/chat/multi_agent_chat/subagents/builtins/deliverables/tools/load_artifact_for_revision.py
@@ -37,6 +37,11 @@ _REVISION_INSTRUCTIONS = {
         "Regenerate expected_output_path from markdown_path and current user "
         "context; do not reconstruct the PDF with vision."
     ),
+    "html": (
+        "Edit primary_path directly, or regenerate the fragment from markdown_path "
+        "and the user's instruction, then write it to expected_output_path. Keep it "
+        "a self-contained fragment and do not reconstruct it with vision."
+    ),
     "video": (
         "Regenerate the video by re-authoring the deck from markdown_path plus "
         "the user's new instruction, render to expected_output_path, then verify "

--- a/surfsense_backend/app/agents/chat/multi_agent_chat/subagents/builtins/deliverables/tools/sandbox.py
+++ b/surfsense_backend/app/agents/chat/multi_agent_chat/subagents/builtins/deliverables/tools/sandbox.py
@@ -177,7 +177,7 @@ def create_sandbox_tools(*, workspace_id: int) -> list[BaseTool]:
 
     @tool
     async def load_artifact_instructions(
-        artifact_type: Literal["pdf", "docx", "pptx", "xlsx", "video"],
+        artifact_type: Literal["pdf", "docx", "pptx", "xlsx", "html", "video"],
         runtime: ToolRuntime,
     ) -> str:
         """Load the trusted creation instructions for one artifact format."""

--- a/surfsense_backend/app/artifacts/persistence/enums.py
+++ b/surfsense_backend/app/artifacts/persistence/enums.py
@@ -15,6 +15,7 @@ class ArtifactFormat(StrEnum):
     DOCX = "docx"
     PPTX = "pptx"
     XLSX = "xlsx"
+    HTML = "html"
     PDF = "pdf"
     PODCAST = "podcast"
     VIDEO = "video"

--- a/surfsense_backend/app/artifacts/verification/formats/html.py
+++ b/surfsense_backend/app/artifacts/verification/formats/html.py
@@ -1,0 +1,106 @@
+"""Structural checks for interactive HTML artifact fragments."""
+
+from __future__ import annotations
+
+import re
+from html.parser import HTMLParser
+from urllib.parse import urlsplit
+
+from .base import StructuralCheckResult
+
+_ALLOWED_FONT_HOSTS = frozenset({"fonts.googleapis.com", "fonts.gstatic.com"})
+_CSS_REFERENCE_RE = re.compile(
+    r"""(?:@import\s+|url\(\s*)["']?([^"')\s;]+)""",
+    re.IGNORECASE,
+)
+
+
+def _is_allowed_reference(value: str) -> bool:
+    value = value.strip()
+    if not value or value.startswith(("#", "data:")):
+        return True
+    parsed = urlsplit(value)
+    return parsed.scheme == "https" and parsed.hostname in _ALLOWED_FONT_HOSTS
+
+
+class _FragmentInspector(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.has_markup = False
+        self.has_document_wrapper = False
+        self.external_references: list[str] = []
+        self._in_style = False
+
+    def handle_decl(self, decl: str) -> None:
+        self.has_markup = True
+        if decl.lstrip().lower().startswith("doctype"):
+            self.has_document_wrapper = True
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        self.has_markup = True
+        lowered_tag = tag.lower()
+        if lowered_tag in {"html", "head", "body"}:
+            self.has_document_wrapper = True
+        self._in_style = lowered_tag == "style"
+        for name, value in attrs:
+            if value is None:
+                continue
+            if name.lower() in {"src", "href"} and not _is_allowed_reference(value):
+                self.external_references.append(value.strip())
+            elif name.lower() == "style":
+                self._inspect_css(value)
+
+    def handle_startendtag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        self.handle_starttag(tag, attrs)
+        self._in_style = False
+
+    def handle_endtag(self, tag: str) -> None:
+        lowered_tag = tag.lower()
+        if lowered_tag in {"html", "head", "body"}:
+            self.has_document_wrapper = True
+        if lowered_tag == "style":
+            self._in_style = False
+
+    def handle_data(self, data: str) -> None:
+        if self._in_style:
+            self._inspect_css(data)
+
+    def _inspect_css(self, css: str) -> None:
+        for match in _CSS_REFERENCE_RE.finditer(css):
+            reference = match.group(1)
+            if not _is_allowed_reference(reference):
+                self.external_references.append(reference)
+
+
+def check_html(data: bytes) -> StructuralCheckResult:
+    if not data:
+        return StructuralCheckResult(("HTML artifact is empty",))
+
+    try:
+        text = data.decode("utf-8")
+    except UnicodeDecodeError:
+        return StructuralCheckResult(("HTML artifact must be UTF-8 encoded",))
+
+    if not text.strip():
+        return StructuralCheckResult(("HTML artifact is empty",))
+
+    inspector = _FragmentInspector()
+    try:
+        inspector.feed(text)
+        inspector.close()
+    except (AssertionError, ValueError) as exc:
+        return StructuralCheckResult((f"HTML artifact could not be parsed: {exc}",))
+
+    findings: list[str] = []
+    if not inspector.has_markup:
+        findings.append("HTML artifact contains no markup")
+    if inspector.has_document_wrapper:
+        findings.append(
+            "HTML artifact must be a fragment without doctype, html, head, or body tags"
+        )
+
+    notes = tuple(
+        f"External resource will be blocked by the artifact viewer: {reference}"
+        for reference in dict.fromkeys(inspector.external_references)
+    )
+    return StructuralCheckResult(tuple(findings), notes=notes)

--- a/surfsense_backend/app/artifacts/verification/formats/registry.py
+++ b/surfsense_backend/app/artifacts/verification/formats/registry.py
@@ -6,6 +6,7 @@ from pathlib import PurePosixPath
 
 from .base import FormatAdapter
 from .docx import check_docx
+from .html import check_html
 from .pdf import check_pdf
 from .pptx import check_pptx
 from .video import check_video, reject_buffered_video_check
@@ -15,6 +16,7 @@ PDF_MIME = "application/pdf"
 DOCX_MIME = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
 PPTX_MIME = "application/vnd.openxmlformats-officedocument.presentationml.presentation"
 XLSX_MIME = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+HTML_MIME = "text/html"
 MP4_MIME = "video/mp4"
 
 _ADAPTERS = {
@@ -48,6 +50,14 @@ _ADAPTERS = {
         mime_type=XLSX_MIME,
         convert_to_pdf=False,
         check=check_xlsx,
+        requires_visual_review=False,
+    ),
+    ".html": FormatAdapter(
+        name="html",
+        suffix=".html",
+        mime_type=HTML_MIME,
+        convert_to_pdf=False,
+        check=check_html,
         requires_visual_review=False,
     ),
     ".mp4": FormatAdapter(

--- a/surfsense_backend/tests/integration/artifacts/test_html_artifacts.py
+++ b/surfsense_backend/tests/integration/artifacts/test_html_artifacts.py
@@ -1,0 +1,209 @@
+"""Integration: HTML create/revise through the real receipt and persistence path."""
+
+from __future__ import annotations
+
+import json
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock
+
+import pytest
+from langchain.tools import ToolRuntime
+from sqlalchemy import func, select
+
+from app.agents.chat.multi_agent_chat.subagents.builtins.deliverables.tools import (
+    load_artifact_for_revision as load_revision_tool,
+    save_artifact as save_artifact_tool,
+)
+from app.artifacts import service
+from app.artifacts.persistence import Artifact, ArtifactFile, ArtifactFileRole
+from app.artifacts.verification import service as verify_service
+from app.artifacts.verification.formats.registry import HTML_MIME
+from app.db import ChatVisibility, Chunk, Document, NewChatThread
+from app.file_storage.service import purge_document_blobs
+from tests.utils.fake_sandbox import FakeSandboxSession
+
+from .test_service import MemoryBackend
+
+pytestmark = pytest.mark.integration
+SECRET = "test-secret"
+
+
+def _runtime(thread_id: int) -> ToolRuntime:
+    return ToolRuntime(
+        state={},
+        context=None,
+        config={"configurable": {"thread_id": f"{thread_id}::task:html"}},
+        stream_writer=None,
+        tool_call_id="html",
+        store=None,
+    )
+
+
+async def test_html_tool_create_and_revise_primary_only(
+    db_session,
+    db_workspace,
+    db_user,
+    monkeypatch,
+):
+    thread = NewChatThread(
+        title="HTML artifact chat",
+        workspace_id=db_workspace.id,
+        created_by_id=db_user.id,
+        visibility=ChatVisibility.PRIVATE,
+    )
+    db_session.add(thread)
+    await db_session.flush()
+
+    backend = MemoryBackend()
+    primary_path = "/workspace/calculator.html"
+    first_bytes = b"<button id='calculate'>Calculate</button>"
+    sandbox = FakeSandboxSession({primary_path: first_bytes})
+
+    class Registry:
+        async def get_session(self, _thread_id, _workspace_id):
+            return sandbox
+
+    async def get_registry():
+        return Registry()
+
+    @asynccontextmanager
+    async def session_context():
+        yield db_session
+
+    monkeypatch.setattr(service, "get_storage_backend", lambda *_: backend)
+    monkeypatch.setattr(
+        service, "knowledge_store_enabled_for", AsyncMock(return_value=False)
+    )
+    monkeypatch.setattr(save_artifact_tool, "get_registry", get_registry)
+    monkeypatch.setattr(save_artifact_tool, "shielded_async_session", session_context)
+    monkeypatch.setattr(save_artifact_tool.app_config, "SECRET_KEY", SECRET)
+    monkeypatch.setattr(load_revision_tool, "get_registry", get_registry)
+    monkeypatch.setattr(load_revision_tool, "shielded_async_session", session_context)
+    monkeypatch.setattr(load_revision_tool, "get_storage_backend", lambda *_: backend)
+    monkeypatch.setattr(
+        load_revision_tool,
+        "uuid4",
+        lambda: type("Uuid", (), {"hex": "html-revision"})(),
+    )
+
+    verified = await verify_service.verify_artifact(
+        sandbox,
+        primary_path,
+        workspace_id=db_workspace.id,
+        vision_llm=None,
+        secret_key=SECRET,
+    )
+    assert verified.verified
+    assert verified.preview_path is None
+
+    tool = save_artifact_tool.create_save_artifact_tool(db_workspace.id)
+    runtime = _runtime(thread.id)
+
+    sandbox.files[primary_path] = b"<button>Changed after verification</button>"
+    rejected = await tool.coroutine(
+        title="Pricing calculator",
+        markdown_representation="# Pricing calculator\n\nInteractive controls.",
+        path=primary_path,
+        runtime=runtime,
+    )
+    assert "changed after verification" in str(rejected)
+
+    sandbox.files[primary_path] = first_bytes
+    reverified = await verify_service.verify_artifact(
+        sandbox,
+        primary_path,
+        workspace_id=db_workspace.id,
+        vision_llm=None,
+        secret_key=SECRET,
+    )
+    assert reverified.verified
+
+    created_command = await tool.coroutine(
+        title="Pricing calculator",
+        markdown_representation="# Pricing calculator\n\nInteractive controls.",
+        path=primary_path,
+        runtime=runtime,
+    )
+    created = json.loads(created_command.update["messages"][0].content)
+    artifact_id = created["artifact_id"]
+
+    assert [(file["role"], file["mime_type"]) for file in created["files"]] == [
+        ("primary", HTML_MIME),
+    ]
+
+    load_tool = load_revision_tool.create_load_artifact_for_revision_tool(
+        workspace_id=db_workspace.id
+    )
+    loaded = await load_tool.coroutine(artifact_id=artifact_id, runtime=runtime)
+    revision_dir = f"/workspace/artifact-revisions/{artifact_id}/html-revision"
+    assert loaded["format"] == "html"
+    assert loaded["primary_path"] == f"{revision_dir}/current.html"
+    assert loaded["expected_output_path"] == f"{revision_dir}/revised.html"
+    assert loaded["expected_generation"] == 1
+    assert sandbox.files[loaded["primary_path"]] == first_bytes
+
+    revised_path = loaded["expected_output_path"]
+    sandbox.files[revised_path] = b"<button id='estimate'>Estimate</button>"
+    revised_ok = await verify_service.verify_artifact(
+        sandbox,
+        revised_path,
+        workspace_id=db_workspace.id,
+        vision_llm=None,
+        secret_key=SECRET,
+    )
+    assert revised_ok.verified
+
+    revised_command = await tool.coroutine(
+        title="Pricing calculator",
+        markdown_representation="# Pricing calculator\n\nRevised estimator.",
+        path=revised_path,
+        artifact_id=artifact_id,
+        expected_generation=loaded["expected_generation"],
+        runtime=runtime,
+    )
+    revised = json.loads(revised_command.update["messages"][0].content)
+
+    assert revised["artifact_id"] == artifact_id
+    assert revised["generation"] == 2
+    assert (
+        await db_session.scalar(
+            select(func.count(Artifact.id)).where(Artifact.id == artifact_id)
+        )
+        == 1
+    )
+    assert (
+        await db_session.scalar(
+            select(func.count(ArtifactFile.id)).where(
+                ArtifactFile.artifact_id == artifact_id
+            )
+        )
+        == 1
+    )
+    stored_files = (
+        await db_session.scalars(
+            select(ArtifactFile).where(ArtifactFile.artifact_id == artifact_id)
+        )
+    ).all()
+    assert [(file.role, file.original_filename) for file in stored_files] == [
+        (ArtifactFileRole.PRIMARY, "revised.html")
+    ]
+
+    artifact = await db_session.get(Artifact, artifact_id)
+    document = await db_session.get(Document, artifact.document_id)
+    assert document.source_markdown == "# Pricing calculator\n\nRevised estimator."
+    assert (
+        await db_session.scalar(
+            select(func.count(Chunk.id)).where(
+                Chunk.document_id == document.id,
+                Chunk.content.ilike("%Revised estimator%"),
+            )
+        )
+        > 0
+    )
+
+    await purge_document_blobs(
+        db_session,
+        document_ids=[artifact.document_id],
+        backend=backend,
+    )
+    assert backend.data == {}

--- a/surfsense_backend/tests/unit/artifacts/test_html_verification.py
+++ b/surfsense_backend/tests/unit/artifacts/test_html_verification.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import pytest
+
+from app.artifacts.verification import service
+from app.artifacts.verification.formats.html import check_html
+from app.artifacts.verification.formats.registry import HTML_MIME, get_format_adapter
+from app.artifacts.verification.receipt import read_receipt, receipt_path
+from tests.utils.fake_sandbox import FakeSandboxSession
+
+SECRET = "test-secret"
+WORKSPACE_ID = 7
+
+
+def test_clean_html_fragment_and_registry():
+    result = check_html(
+        b"<style>button{color:red}</style><button>Calculate</button>"
+        b"<script>document.querySelector('button').onclick=()=>{}</script>"
+    )
+    adapter = get_format_adapter("/workspace/calculator.html")
+
+    assert result.clean
+    assert result.notes == ()
+    assert adapter.name == "html"
+    assert adapter.mime_type == HTML_MIME
+    assert not adapter.requires_visual_review
+    assert not adapter.convert_to_pdf
+
+
+@pytest.mark.parametrize(
+    ("data", "message"),
+    [
+        (b"", "empty"),
+        (b" \n\t", "empty"),
+        (b"\xff", "UTF-8"),
+        (b"plain text", "no markup"),
+        (b"<!doctype html><div>content</div>", "fragment"),
+        (b"<html><div>content</div></html>", "fragment"),
+        (b"<div>content</div></body>", "fragment"),
+    ],
+)
+def test_html_structural_findings(data, message):
+    result = check_html(data)
+
+    assert not result.clean
+    assert any(message in finding for finding in result.findings)
+
+
+def test_external_resources_are_advisory_and_google_fonts_are_allowed():
+    result = check_html(
+        b'<link href="https://fonts.googleapis.com/css2?family=Inter" rel="stylesheet">'
+        b'<script src="https://example.com/app.js"></script>'
+        b'<div style="background:url(https://example.com/pixel.png)">Ready</div>'
+    )
+
+    assert result.clean
+    assert len(result.notes) == 2
+    assert all("will be blocked" in note for note in result.notes)
+    assert not any("fonts.googleapis.com" in note for note in result.notes)
+
+
+async def test_verify_html_skips_render_and_vision():
+    path = "/workspace/calculator.html"
+    session = FakeSandboxSession({path: b"<button>Calculate</button>"})
+
+    result = await service.verify_artifact(
+        session,
+        path,
+        workspace_id=WORKSPACE_ID,
+        vision_llm=object(),
+        secret_key=SECRET,
+    )
+    receipt = await read_receipt(
+        session,
+        SECRET,
+        workspace_id=WORKSPACE_ID,
+        primary_path=path,
+    )
+
+    assert result.verified
+    assert result.preview_path is None
+    assert receipt.format == "html"
+    assert receipt.visual == "not_required"
+    assert receipt.preview_path is None
+    assert receipt.preview_sha256 is None
+    assert not any(
+        "soffice" in command or "pdftoppm" in command for command in session.commands
+    )
+
+
+async def test_verify_invalid_html_issues_no_receipt():
+    path = "/workspace/calculator.html"
+    session = FakeSandboxSession({path: b"<html><button>Calculate</button></html>"})
+
+    result = await service.verify_artifact(
+        session,
+        path,
+        workspace_id=WORKSPACE_ID,
+        vision_llm=None,
+        secret_key=SECRET,
+    )
+
+    assert not result.verified
+    assert any("fragment" in finding for finding in result.findings)
+    assert session.files[receipt_path(path)] == b""

--- a/surfsense_backend/tests/unit/routes/test_artifacts_routes.py
+++ b/surfsense_backend/tests/unit/routes/test_artifacts_routes.py
@@ -300,6 +300,28 @@ async def test_file_uses_checksum_etag_and_pdf_inline_disposition(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_html_file_is_attachment_with_nosniff(monkeypatch):
+    monkeypatch.setattr(artifacts_routes, "check_permission", AsyncMock())
+    record = _file(8, ArtifactFileRole.PRIMARY)
+    record.original_filename = "calculator.html"
+    record.mime_type = "text/html"
+    session = AsyncMock()
+    session.scalar.return_value = record
+    monkeypatch.setattr(
+        artifacts_routes,
+        "open_artifact_file_stream",
+        lambda _record: iter(()),
+    )
+
+    response = await artifacts_routes.stream_artifact_file(
+        2, 7, 8, _request(), session, SimpleNamespace()
+    )
+
+    assert response.headers["content-disposition"].startswith("attachment;")
+    assert response.headers["x-content-type-options"] == "nosniff"
+
+
+@pytest.mark.asyncio
 async def test_file_honors_checksum_etag(monkeypatch):
     monkeypatch.setattr(artifacts_routes, "check_permission", AsyncMock())
     session = AsyncMock()

--- a/surfsense_backend/tests/unit/sandbox/test_deliverables_skill_roster.py
+++ b/surfsense_backend/tests/unit/sandbox/test_deliverables_skill_roster.py
@@ -8,6 +8,8 @@ PROMPT_PATH = (
     / "deliverables/system_prompt.md"
 )
 SKILLS_ROOT = REPO_ROOT / "docker/sandbox/skills"
+FRONTEND_DESIGN_PATH = SKILLS_ROOT / "frontend-design/DESIGN.md"
+SANDBOX_DOCKERFILE = REPO_ROOT / "docker/sandbox/Dockerfile"
 
 
 def _prompt() -> str:
@@ -71,7 +73,7 @@ def test_deliverables_prompt_carries_revision_handles_without_vision_rebuild():
 
 
 def test_format_skills_share_pathless_verify_and_save_contract():
-    for name in ("pdf", "docx", "pptx", "xlsx"):
+    for name in ("pdf", "docx", "pptx", "xlsx", "html"):
         skill = _skill(name)
         assert "`load_artifact_for_revision`" in skill
         assert "`expected_output_path`" in skill
@@ -105,3 +107,25 @@ def test_format_skills_define_safe_revision_strategy():
     assert "Do not\nsilently rebuild from `markdown_path`" in docx
     assert "explicitly requested or accepted" in docx
     assert "do not fall back to a Markdown-only" in docx
+
+
+def test_deliverables_prompt_routes_interactive_requests_to_html_before_pdf_fallback():
+    prompt = _prompt()
+    html_route = "controls update results → HTML"
+    pdf_fallback = "prefer PDF for a finished deliverable"
+
+    assert html_route in prompt
+    assert '`load_artifact_instructions(artifact_type="html")`' in prompt
+    assert prompt.index(html_route) < prompt.index(pdf_fallback)
+
+
+def test_shared_frontend_design_is_composed_without_becoming_a_format_skill():
+    dockerfile = SANDBOX_DOCKERFILE.read_text()
+
+    assert FRONTEND_DESIGN_PATH.is_file()
+    assert not FRONTEND_DESIGN_PATH.with_name("SKILL.md").exists()
+    assert 'test -f "${skill}/SKILL.md" || continue' in dockerfile
+    assert (
+        "cat /tmp/surfsense-skills/frontend-design/DESIGN.md >> "
+        '"/opt/skills/${name}/SKILL.md"'
+    ) in dockerfile

--- a/surfsense_web/features/artifacts/artifact-format-meta.ts
+++ b/surfsense_web/features/artifacts/artifact-format-meta.ts
@@ -62,6 +62,14 @@ const FORMAT_META: Record<string, ArtifactFormatMeta> = {
 		groupLabel: "Files",
 		viewingMode: "viewer",
 	},
+	html: {
+		icon: FileCode,
+		label: "Interactive",
+		detailLabel: "HTML",
+		groupKey: "files",
+		groupLabel: "Files",
+		viewingMode: "viewer",
+	},
 	csv: {
 		icon: FileSpreadsheet,
 		label: "Table",

--- a/surfsense_web/features/artifacts/artifact-format-meta.ts
+++ b/surfsense_web/features/artifacts/artifact-format-meta.ts
@@ -64,7 +64,7 @@ const FORMAT_META: Record<string, ArtifactFormatMeta> = {
 	},
 	html: {
 		icon: FileCode,
-		label: "Interactive",
+		label: "Code",
 		detailLabel: "HTML",
 		groupKey: "files",
 		groupLabel: "Files",

--- a/surfsense_web/features/chat-messages/timeline/grouping.ts
+++ b/surfsense_web/features/chat-messages/timeline/grouping.ts
@@ -1,4 +1,5 @@
 import {
+	type ActivityData,
 	type ActivityJournal,
 	type ActivityTimingData,
 	extractActivityJournal,
@@ -207,4 +208,55 @@ export function firstToolIndexByActivityId(
 		if (activityId && !result.has(activityId)) result.set(activityId, index);
 	}
 	return result;
+}
+
+export function getTraceLeafKind({
+	part,
+	index,
+	activities,
+	firstActivityIndices,
+	showReasoning,
+}: {
+	part: TracePartLike;
+	index: number;
+	activities: ReadonlyMap<string, ActivityData>;
+	firstActivityIndices: ReadonlyMap<string, number>;
+	showReasoning: boolean;
+}): "reasoning" | "activity" | null {
+	if (part.type === "reasoning") {
+		return showReasoning && typeof part.text === "string" && part.text.length > 0
+			? "reasoning"
+			: null;
+	}
+	if (part.type !== "tool-call") return null;
+	const activityId = getToolActivityId(part);
+	return activityId && activities.has(activityId) && firstActivityIndices.get(activityId) === index
+		? "activity"
+		: null;
+}
+
+export function hasExpandableTraceDetails({
+	parts,
+	indices,
+	activities,
+	firstActivityIndices,
+	showReasoning,
+}: {
+	parts: readonly TracePartLike[];
+	indices: readonly number[];
+	activities: ReadonlyMap<string, ActivityData>;
+	firstActivityIndices: ReadonlyMap<string, number>;
+	showReasoning: boolean;
+}): boolean {
+	for (const index of indices) {
+		const kind = getTraceLeafKind({
+			part: parts[index],
+			index,
+			activities,
+			firstActivityIndices,
+			showReasoning,
+		});
+		if (kind !== null) return true;
+	}
+	return false;
 }

--- a/surfsense_web/features/chat-messages/timeline/interleaved-trace.tsx
+++ b/surfsense_web/features/chat-messages/timeline/interleaved-trace.tsx
@@ -41,6 +41,8 @@ import {
 	buildTurnRenderItems,
 	firstToolIndexByActivityId,
 	getToolActivityId,
+	getTraceLeafKind,
+	hasExpandableTraceDetails,
 	type TracePartLike,
 	type TurnRenderItem,
 } from "./grouping";
@@ -241,15 +243,33 @@ const TraceLeaf: FC<{
 	threadRunning: boolean;
 }> = ({ part, index, activities, firstActivityIndices, showReasoning, threadRunning }) => {
 	if (part.type === "reasoning") {
-		if (!showReasoning || part.text.length === 0) return null;
+		if (
+			getTraceLeafKind({
+				part,
+				index,
+				activities,
+				firstActivityIndices,
+				showReasoning,
+			}) !== "reasoning"
+		) {
+			return null;
+		}
 		return <ReasoningEpisode text={part.text} running={partIsRunning(part)} />;
 	}
-	if (part.type !== "tool-call") return null;
+	if (
+		getTraceLeafKind({
+			part,
+			index,
+			activities,
+			firstActivityIndices,
+			showReasoning,
+		}) !== "activity"
+	) {
+		return null;
+	}
 	const activityId = getToolActivityId(part);
 	const activity = activityId ? activities.get(activityId) : undefined;
-	return activity && firstActivityIndices.get(activity.id) === index ? (
-		<ActivityRow activity={activity} threadRunning={threadRunning} />
-	) : null;
+	return activity ? <ActivityRow activity={activity} threadRunning={threadRunning} /> : null;
 };
 
 const TraceLeafByIndex: FC<{
@@ -405,6 +425,13 @@ const TurnSegment: FC<{
 	const reducedMotion = useReducedMotion();
 	const { indices, phase, segmentId } = item;
 	const hasTrace = segmentId !== null;
+	const hasExpandableDetails = hasExpandableTraceDetails({
+		parts,
+		indices,
+		activities,
+		firstActivityIndices,
+		showReasoning,
+	});
 	const segmentActivities = indices.flatMap((index) => {
 		const activityId = getToolActivityId(parts[index] as TracePartLike);
 		const activity = activityId ? activities.get(activityId) : undefined;
@@ -441,7 +468,7 @@ const TurnSegment: FC<{
 		/>
 	);
 	const toggle = () => {
-		if (!hasTrace) return;
+		if (!hasExpandableDetails) return;
 		if (isMobile) {
 			onDrawerOpenChange(true);
 			trackActivityTraceInteraction("segment_expanded", {
@@ -470,12 +497,11 @@ const TurnSegment: FC<{
 			<Button
 				variant="ghost"
 				type="button"
-				onClick={hasTrace ? toggle : undefined}
-				aria-disabled={hasTrace ? undefined : true}
-				aria-expanded={hasTrace ? (isMobile ? drawerOpen : open) : undefined}
-				aria-controls={hasTrace ? id : undefined}
-				tabIndex={hasTrace ? undefined : -1}
-				className={TURN_HEADER_ROW_CLASS}
+				onClick={hasExpandableDetails ? toggle : undefined}
+				disabled={!hasExpandableDetails}
+				aria-expanded={hasExpandableDetails ? (isMobile ? drawerOpen : open) : undefined}
+				aria-controls={hasExpandableDetails ? id : undefined}
+				className={cn(TURN_HEADER_ROW_CLASS, "disabled:opacity-100")}
 			>
 				<TurnHeaderContent
 					active={active}
@@ -485,37 +511,35 @@ const TurnSegment: FC<{
 					swapKey={`${active}:${label}`}
 					turnTimingDisplay={turnTimingDisplay}
 					trailing={
-						<motion.span
-							className={cn(
-								"size-4 shrink-0 opacity-0 transition-opacity",
-								hasTrace &&
-									"group-hover/trace:opacity-100 group-focus-visible/trace:opacity-100 max-md:opacity-100"
-							)}
-							animate={{ rotate: !isMobile && open ? 90 : 0 }}
-							transition={{
-								duration: reducedMotion ? 0 : 0.22,
-								ease: [0.22, 1, 0.36, 1],
-							}}
-							aria-hidden="true"
-						>
-							<ChevronRightIcon className="size-4" />
-						</motion.span>
+						hasExpandableDetails ? (
+							<motion.span
+								className="size-4 shrink-0 opacity-0 transition-opacity group-hover/trace:opacity-100 group-focus-visible/trace:opacity-100 max-md:opacity-100"
+								animate={{ rotate: !isMobile && open ? 90 : 0 }}
+								transition={{
+									duration: reducedMotion ? 0 : 0.22,
+									ease: [0.22, 1, 0.36, 1],
+								}}
+								aria-hidden="true"
+							>
+								<ChevronRightIcon className="size-4" />
+							</motion.span>
+						) : null
 					}
 				/>
 			</Button>
 			<div
 				id={id}
-				aria-hidden={!hasTrace}
+				aria-hidden={!hasExpandableDetails}
 				className={cn(
 					"hidden transition-[grid-template-rows] duration-300 ease-out motion-reduce:transition-none md:grid",
-					hasTrace && open ? "grid-rows-[1fr]" : "grid-rows-[0fr]"
+					hasExpandableDetails && open ? "grid-rows-[1fr]" : "grid-rows-[0fr]"
 				)}
 			>
 				<div className="overflow-hidden">
 					<div className="mt-3">{details}</div>
 				</div>
 			</div>
-			{isMobile && hasTrace ? (
+			{isMobile && hasExpandableDetails ? (
 				<Drawer
 					open={drawerOpen}
 					onOpenChange={(next) => {

--- a/surfsense_web/features/file-viewers/html-file-viewer.tsx
+++ b/surfsense_web/features/file-viewers/html-file-viewer.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Spinner } from "@/components/ui/spinner";
+import { authenticatedFetch } from "@/lib/auth-fetch";
+import { buildBackendUrl } from "@/lib/env-config";
+import { cannotPreviewMessage } from "./file-format";
+import type { FileViewerProps } from "./model";
+import { UnviewableFile } from "./unviewable-file";
+
+export const HTML_MAX_VIEWER_BYTES = 15 * 1024 * 1024;
+export const HTML_IFRAME_SANDBOX = "allow-scripts";
+
+const CONTENT_SECURITY_POLICY = [
+	"default-src 'none'",
+	"script-src 'unsafe-inline'",
+	"style-src 'unsafe-inline' https://fonts.googleapis.com",
+	"font-src https://fonts.gstatic.com",
+	"img-src data:",
+	"connect-src 'none'",
+	"form-action 'none'",
+	"base-uri 'none'",
+	"object-src 'none'",
+	"frame-src 'none'",
+	"navigate-to 'none'",
+].join("; ");
+
+export function buildHtmlArtifactDocument(fragment: string): string {
+	return `<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="referrer" content="no-referrer">
+<meta http-equiv="Content-Security-Policy" content="${CONTENT_SECURITY_POLICY}">
+</head>
+<body>
+${fragment}
+</body>
+</html>`;
+}
+
+type LoadState =
+	| { status: "loading" }
+	| { status: "ready"; source: string }
+	| { status: "error"; message: string };
+
+class InvalidHtmlEncodingError extends Error {}
+
+export default function HtmlFileViewer({ primary }: FileViewerProps) {
+	const [state, setState] = useState<LoadState>({ status: "loading" });
+
+	useEffect(() => {
+		const controller = new AbortController();
+		setState({ status: "loading" });
+
+		if (primary.size_bytes > HTML_MAX_VIEWER_BYTES) {
+			setState({
+				status: "error",
+				message: `${cannotPreviewMessage(primary.filename)} (file is too large to preview)`,
+			});
+			return () => controller.abort();
+		}
+
+		void (async () => {
+			try {
+				const response = await authenticatedFetch(buildBackendUrl(primary.content_url), {
+					cache: "no-store",
+					signal: controller.signal,
+					skipAuthRedirect: true,
+				});
+				if (!response.ok) {
+					throw new Error(`Could not load HTML artifact (${response.status})`);
+				}
+				const bytes = await response.arrayBuffer();
+				if (controller.signal.aborted) return;
+				if (bytes.byteLength > HTML_MAX_VIEWER_BYTES) {
+					setState({
+						status: "error",
+						message: `${cannotPreviewMessage(primary.filename)} (file is too large to preview)`,
+					});
+					return;
+				}
+				let fragment: string;
+				try {
+					fragment = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+				} catch {
+					throw new InvalidHtmlEncodingError();
+				}
+				setState({ status: "ready", source: buildHtmlArtifactDocument(fragment) });
+			} catch (error) {
+				if (controller.signal.aborted) return;
+				const detail =
+					error instanceof InvalidHtmlEncodingError
+						? "file is not valid UTF-8"
+						: "file could not be opened";
+				setState({
+					status: "error",
+					message: `${cannotPreviewMessage(primary.filename)} (${detail})`,
+				});
+			}
+		})();
+
+		return () => controller.abort();
+	}, [primary.content_url, primary.filename, primary.size_bytes]);
+
+	if (state.status === "loading") {
+		return (
+			<div aria-busy="true" className="flex h-full items-center justify-center">
+				<Spinner size="lg" />
+			</div>
+		);
+	}
+
+	if (state.status === "error") {
+		return <UnviewableFile message={state.message} />;
+	}
+
+	return (
+		<iframe
+			className="h-full w-full border-0 bg-white"
+			sandbox={HTML_IFRAME_SANDBOX}
+			srcDoc={state.source}
+			title={primary.filename}
+		/>
+	);
+}

--- a/surfsense_web/features/file-viewers/viewer-registry.ts
+++ b/surfsense_web/features/file-viewers/viewer-registry.ts
@@ -25,10 +25,15 @@ const Mp4FileViewer = dynamic<FileViewerProps>(() => import("./mp4-file-viewer")
 	ssr: false,
 	loading: FileViewerLoading,
 });
+const HtmlFileViewer = dynamic<FileViewerProps>(() => import("./html-file-viewer"), {
+	ssr: false,
+	loading: FileViewerLoading,
+});
 
 /** Direct viewers render the file itself; domain-specific preview adapters remain with their owner. */
 export const FILE_VIEWERS: Readonly<Partial<Record<string, ComponentType<FileViewerProps>>>> = {
 	"application/pdf": PdfFileViewer,
 	"video/mp4": Mp4FileViewer,
 	"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": XlsxViewer,
+	"text/html": HtmlFileViewer,
 };


### PR DESCRIPTION
<!--- Summarize your pull request in a few sentences -->

## Description
<!--- Clearly describe what has changed in this pull request -->
- Add first-class interactive HTML artifacts with intent-based generation, structural verification, shared design guidance, secure sandboxed right-panel rendering, revision support, and comprehensive tests.
- Disable timeline expansion on desktop and mobile only when no renderable child steps exist.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If this PR relates to an open issue, please link to the issue here: FIX #123 -->
FIX #


## Screenshots
<!-- If applicable, add screenshots or images to demonstrate the changes visually -->

## API Changes
<!-- Document any API changes if applicable -->
- [ ] This PR includes API changes

## Change Type
<!--- Indicate what kind(s) of changes this PR includes: -->
- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Dependency/Build system
- [ ] Breaking change
- [ ] Other (specify):

## Testing Performed
<!--- Briefly describe how you have tested these changes and what verification was performed -->
- [ ] Tested locally
- [ ] Manual/QA verification

## Checklist
<!--- Please confirm the following by marking with an 'x' as appropriate -->
- [ ] Follows project coding standards and conventions
- [ ] Documentation updated as needed
- [ ] Dependencies updated as needed
- [ ] No lint/build errors or new warnings
- [ ] All relevant tests are passing

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR implements interactive HTML artifacts as a new deliverable format within the existing artifact system. Users can now request interactive calculators, configurators, dashboards, and widgets which are generated as self-contained HTML fragments and rendered in a sandboxed iframe viewer. The implementation includes structural verification (fragment contract enforcement, external resource detection), intent-based routing (selecting HTML automatically for interactive requests), a shared design skill system (composing frontend-design guidance into format skills at Docker build time), and comprehensive security controls (attachment-only serving, sandboxed iframe with no same-origin capability, viewer-controlled CSP). The change follows the established format-agnostic artifact architecture with no schema, persistence, or API modifications required, and generation sources remain transient sandbox inputs rather than persisted artifact files.

⏱️ Estimated Review Time: 1-3 hours

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `plans/artifacts/phase-6-html.md` |
| 2 | `plans/artifacts/artifacts-overhaul.md` |
| 3 | `docker/sandbox/skills/html/SKILL.md` |
| 4 | `docker/sandbox/skills/frontend-design/DESIGN.md` |
| 5 | `docker/sandbox/Dockerfile` |
| 6 | `surfsense_backend/app/artifacts/verification/formats/html.py` |
| 7 | `surfsense_backend/app/artifacts/verification/formats/registry.py` |
| 8 | `surfsense_backend/app/artifacts/persistence/enums.py` |
| 9 | `surfsense_backend/app/agents/chat/multi_agent_chat/subagents/builtins/deliverables/description.md` |
| 10 | `surfsense_backend/app/agents/chat/multi_agent_chat/subagents/builtins/deliverables/system_prompt.md` |
| 11 | `surfsense_backend/app/agents/chat/multi_agent_chat/subagents/builtins/deliverables/tools/load_artifact_for_revision.py` |
| 12 | `surfsense_backend/app/agents/chat/multi_agent_chat/subagents/builtins/deliverables/tools/sandbox.py` |
| 13 | `surfsense_web/features/file-viewers/html-file-viewer.tsx` |
| 14 | `surfsense_web/features/file-viewers/viewer-registry.ts` |
| 15 | `surfsense_web/features/artifacts/artifact-format-meta.ts` |
| 16 | `surfsense_web/features/chat-messages/timeline/grouping.ts` |
| 17 | `surfsense_web/features/chat-messages/timeline/interleaved-trace.tsx` |
| 18 | `surfsense_backend/tests/unit/artifacts/test_html_verification.py` |
| 19 | `surfsense_backend/tests/integration/artifacts/test_html_artifacts.py` |
| 20 | `surfsense_backend/tests/unit/routes/test_artifacts_routes.py` |
| 21 | `surfsense_backend/tests/unit/sandbox/test_deliverables_skill_roster.py` |
| 22 | `docs/adr/0003-artifacts-as-documents.md` |
| 23 | `plans/artifacts/phase-1-foundation.md` |
| 24 | `plans/artifacts/phase-2-sandbox-pdf.md` |
| 25 | `plans/artifacts/phase-3-docx.md` |
| 26 | `plans/artifacts/phase-4-pptx.md` |
| 27 | `plans/artifacts/phase-5-xlsx.md` |
| 28 | `plans/artifacts/phase-7-demolition.md` |
| 29 | `plans/artifacts/phase-8-public-and-generic.md` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->