### PR TITLE
[Fix] A "." or ".." folder name aborts the workspace seed

### DIFF
--- a/surfsense_backend/app/knowledge_store/paths/naming.py
+++ b/surfsense_backend/app/knowledge_store/paths/naming.py
@@ -38,7 +38,7 @@ def safe_folder_segment(value: str, *, fallback: str = "folder") -> str:
     """Sanitize one folder name into a path-safe segment."""
     name = _INVALID_FILENAME_CHARS.sub("_", value).strip()
     name = _WHITESPACE_RUN.sub(" ", name)
-    if not name:
+    if not name or name in (".", ".."):
         return fallback
     if len(name) > _MAX_SEGMENT_LEN:
         name = name[:_MAX_SEGMENT_LEN].rstrip()

--- a/surfsense_backend/tests/unit/knowledge_store/test_naming_traversal.py
+++ b/surfsense_backend/tests/unit/knowledge_store/test_naming_traversal.py
@@ -1,0 +1,40 @@
+"""A sanitized segment must never be a name the store's namespace rejects.
+
+A folder literally named ``.`` (or ``..``) reached ``allocate_path`` during the
+fleet seed (ws 38003) and raised ``StorePathError: Illegal path segment: '.'``,
+which aborts the *whole* workspace. ``validate_segments`` is the assertion; the
+sanitizer is what must guarantee a legal segment, so the guard lives there once
+instead of at every caller.
+"""
+
+import pytest
+
+from app.knowledge_store.paths import (
+    allocate_path,
+    normalize_filename,
+    safe_folder_segment,
+)
+from app.knowledge_store.paths.store_path import validate_segments
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.parametrize("raw", [".", "..", " . ", "  ..  ", "\t.."])
+def test_safe_folder_segment_never_yields_a_traversal_segment(raw):
+    seg = safe_folder_segment(raw)
+    assert seg not in (".", "..")
+    validate_segments((seg,))  # the choke point must accept it
+
+
+@pytest.mark.parametrize("raw", [".", ".."])
+def test_normalize_filename_never_yields_a_traversal_segment(raw):
+    name = normalize_filename(raw)
+    assert name not in (".", "..")
+    validate_segments((name,))
+
+
+def test_allocate_path_survives_a_dot_folder():
+    # The exact ws 38003 shape: a body-bearing doc under a folder named ".".
+    path = allocate_path(name="Weekly notes", folder_parts=(".",), taken=set())
+    assert path.folder_parts[0] not in (".", "..")
+    assert path.name  # the filename is still there


### PR DESCRIPTION
`safe_folder_segment` only guarded the empty case and its invalid-char regex omits the dot, so a folder literally named `.` or `..` passed through unchanged; `allocate_path` then handed it to `validate_segments` (which rejects `.`/`..`) and raised `StorePathError: Illegal path segment: '.'`, aborting the *whole* workspace seed. Fall back to the default segment in the shared sanitizer, fixing every caller at once.

Found flipping the fleet to git-native (ws 38003); re-seeds cleanly after this.

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
Fixes a critical bug where folders named `"."` or `".."` would abort workspace seeding. The `safe_folder_segment` sanitizer now detects these reserved path traversal segments (including whitespace variants) and falls back to a default name, preventing `StorePathError` exceptions during workspace initialization. This issue was discovered during a fleet-wide migration to git-native storage.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_backend/app/knowledge_store/paths/naming.py` |
| 2 | `surfsense_backend/tests/unit/knowledge_store/test_naming_traversal.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->