### PR TITLE
feat(local): complete chat, citation, source, and Electron UX

### DIFF
--- a/surfsense_local/backend/alembic/versions/0002_add_chat_message_completed_at.py
+++ b/surfsense_local/backend/alembic/versions/0002_add_chat_message_completed_at.py
@@ -1,0 +1,29 @@
+"""add chat message completion timestamp
+
+Revision ID: 0002
+Revises: 0001
+Create Date: 2026-09-08
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "0002"
+down_revision: str | Sequence[str] | None = "0001"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "chat_messages",
+        sa.Column("completed_at", sa.DateTime(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("chat_messages", "completed_at")

--- a/surfsense_local/backend/modules/chat/models.py
+++ b/surfsense_local/backend/modules/chat/models.py
@@ -47,5 +47,6 @@ class ChatMessage(Base):
     # Parts and citations travel together; only the UI interprets the shape.
     content: Mapped[dict[str, Any]] = mapped_column(JSON)
     created_at: Mapped[datetime] = mapped_column(server_default=func.now())
+    completed_at: Mapped[datetime | None]
 
     thread: Mapped[ChatThread] = relationship(back_populates="messages")

--- a/surfsense_local/backend/modules/chat/prompt.py
+++ b/surfsense_local/backend/modules/chat/prompt.py
@@ -12,6 +12,8 @@ INSTRUCTION = (
     "- If the context does not hold the answer, say so, then answer from your own "
     "knowledge if you can.\n"
     "- Respond in the same language as the question.\n"
+    "- Label fenced code blocks with their language, such as python, typescript, "
+    "sql, or bash.\n"
     "- Do not repeat the source tags back in your answer.\n"
     'Example: "The method raised efficiency by 20% [1]."'
 )

--- a/surfsense_local/backend/modules/chat/prompt.py
+++ b/surfsense_local/backend/modules/chat/prompt.py
@@ -7,7 +7,7 @@ from shared.search import Hit
 # explicit rules and example matter most for the small local models this targets.
 INSTRUCTION = (
     "Answer the question using the sources in the context below.\n"
-    "- Cite each claim inline with the source's id in square brackets, like [1], "
+    "- Cite each claim inline with the source's id, exactly like [citation:1], "
     "and only cite a source that carries an id.\n"
     "- If the context does not hold the answer, say so, then answer from your own "
     "knowledge if you can.\n"
@@ -15,24 +15,24 @@ INSTRUCTION = (
     "- Label fenced code blocks with their language, such as python, typescript, "
     "sql, or bash.\n"
     "- Do not repeat the source tags back in your answer.\n"
-    'Example: "The method raised efficiency by 20% [1]."'
+    'Example: "The method raised efficiency by 20% [citation:1]."'
 )
 
 # A chunk that contains these could otherwise close a source early and forge its
 # own, so its angle brackets are defanged before it goes between the tags.
 _TAGS = re.compile(r"</?(?:source|context)\b[^>]*>", re.IGNORECASE)
 
-# Fenced (```...```) and inline (`...`) code, so an ordinal inside an example or
-# `arr[1]` is never mistaken for a citation. Mirrors the frontend markdown.
+# Fenced (```...```) and inline (`...`) code, so citation-shaped examples remain
+# literal. Mirrors the frontend Markdown renderer.
 _CODE = re.compile(r"```[\s\S]*?```|`[^`\n]+`")
-_ORDINAL = re.compile(r"\[\s*(\d+)\s*\]")
+_CITATION = re.compile(r"\[citation:\s*(\d+)\s*\]")
 
 
 @dataclass(frozen=True)
 class Citation:
     """A source id the model may cite, resolved back to where it came from."""
 
-    id: int
+    source_id: int
     chunk_id: int
     document_id: int
     start_line: int | None
@@ -54,57 +54,45 @@ def build_context(hits: list[Hit]) -> tuple[str, list[Citation]]:
         for i, hit in enumerate(hits, start=1)
     ]
     sources = "\n".join(
-        f'<source id="{citation.id}" document="{citation.document_id}"'
+        f'<source id="{citation.source_id}" document="{citation.document_id}"'
         f' lines="{_lines(citation)}">{_defang(hit.content)}</source>'
         for citation, hit in zip(citations, hits, strict=True)
     )
     return f"{INSTRUCTION}\n\n<context>\n{sources}\n</context>", citations
 
 
-def normalize_citations(
+def resolve_citations(
     answer: str, citations: list[Citation]
 ) -> tuple[str, list[Citation]]:
-    """Resolve the answer's inline `[n]` against the sources it was given.
+    """Resolve inline citation tokens against the sources the model received.
 
-    An `[n]` that names a real source survives; one the model invented is dropped
-    rather than left pointing nowhere. The survivors are renumbered densely in
-    order of first appearance, so `[1]`, `[2]`, ... match the citations the UI
-    lists positionally. Ordinals inside code spans are left untouched.
+    Valid source ids remain stable so streamed and stored citations use the same
+    identity. Invented tokens are dropped rather than linked to the wrong source.
+    Citation-shaped text inside code remains literal.
     """
     if not answer:
         return answer, []
 
-    by_id = {citation.id: citation for citation in citations}
+    by_id = {citation.source_id: citation for citation in citations}
 
     order: list[int] = []
 
     def collect(span: str) -> str:
-        for match in _ORDINAL.finditer(span):
+        for match in _CITATION.finditer(span):
             cited = int(match.group(1))
             if cited in by_id and cited not in order:
                 order.append(cited)
         return span
 
     _outside_code(answer, collect)
-    renumbered = {old: new for new, old in enumerate(order, start=1)}
 
     def rewrite(span: str) -> str:
         def one(match: re.Match[str]) -> str:
-            new = renumbered.get(int(match.group(1)))
-            return f"[{new}]" if new is not None else ""
+            return match.group(0) if int(match.group(1)) in by_id else ""
 
-        return _ORDINAL.sub(one, span)
+        return _CITATION.sub(one, span)
 
-    used = [
-        Citation(
-            renumbered[old],
-            by_id[old].chunk_id,
-            by_id[old].document_id,
-            by_id[old].start_line,
-            by_id[old].end_line,
-        )
-        for old in order
-    ]
+    used = [by_id[source_id] for source_id in order]
     return _outside_code(answer, rewrite), used
 
 

--- a/surfsense_local/backend/modules/chat/router.py
+++ b/surfsense_local/backend/modules/chat/router.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from collections.abc import AsyncIterator, Sequence
 from dataclasses import asdict
 
@@ -17,12 +18,14 @@ from modules.chat.schemas import (
     ThreadCreate,
     ThreadRead,
 )
+from modules.chat.title import generate_title
 from modules.llm.models import ModelRole, SelectedModel
 from modules.llm.providers import get_provider
 from modules.workspaces.dependencies import WorkspaceDep
 from shared.search import retrieve
 
 router = APIRouter(tags=["chat"])
+logger = logging.getLogger(__name__)
 
 
 @router.post(
@@ -107,6 +110,9 @@ async def send_message(
         .where(ChatMessage.chat_thread_id == thread.id)
         .order_by(ChatMessage.created_at)
     ).all()
+    should_generate_title = (
+        not history and (thread.title or "").casefold() == "new chat"
+    )
     hits = retrieve(
         session,
         thread.workspace_id,
@@ -141,6 +147,20 @@ async def send_message(
                 "assistant_message_id": assistant_message.id,
             }
         )
+        if should_generate_title:
+            try:
+                title = await generate_title(generator, selected.name, payload.text)
+                if title:
+                    thread.title = title
+                    session.commit()
+                    yield _frame({"type": "thread-title-update", "title": title})
+            except Exception:
+                session.rollback()
+                logger.warning(
+                    "Chat title generation failed for thread %s",
+                    thread.id,
+                    exc_info=True,
+                )
         try:
             try:
                 async for delta in generator.chat(selected.name, messages):

--- a/surfsense_local/backend/modules/chat/router.py
+++ b/surfsense_local/backend/modules/chat/router.py
@@ -11,7 +11,7 @@ from api.dependencies import SessionDep
 from modules.chat.dependencies import ThreadDep
 from modules.chat.history import build_messages
 from modules.chat.models import ChatMessage, ChatThread, MessageRole
-from modules.chat.prompt import build_context, normalize_citations
+from modules.chat.prompt import build_context, resolve_citations
 from modules.chat.schemas import (
     MessageCreate,
     MessageRead,
@@ -158,6 +158,12 @@ async def send_message(
                 "assistant_message_id": assistant_message.id,
             }
         )
+        yield _frame(
+            {
+                "type": "citation-catalog",
+                "items": [asdict(citation) for citation in citations],
+            }
+        )
         if should_generate_title:
             try:
                 title = await generate_title(generator, selected.name, payload.text)
@@ -181,12 +187,9 @@ async def send_message(
                 # Surfaced as an event; the partial turn is still stored below.
                 yield _frame({"type": "error", "message": str(exc)})
         finally:
-            # Resolve the model's inline [n] against the sources it was given:
-            # invented citations are dropped and the survivors renumbered densely,
-            # so the stored turn and its listed sources agree. A disconnect still
-            # preserves this partial answer, and [DONE] guarantees a later read
-            # sees it.
-            answer, used = normalize_citations("".join(parts), citations)
+            # Keep source ids stable across the stream and stored answer. Invented
+            # tokens are removed and never become clickable citations.
+            answer, used = resolve_citations("".join(parts), citations)
             cited = [asdict(citation) for citation in used]
             assistant_message.content = {"text": answer, "citations": cited}
             session.commit()

--- a/surfsense_local/backend/modules/chat/router.py
+++ b/surfsense_local/backend/modules/chat/router.py
@@ -17,6 +17,7 @@ from modules.chat.schemas import (
     MessageRead,
     ThreadCreate,
     ThreadRead,
+    ThreadUpdate,
 )
 from modules.chat.title import generate_title
 from modules.llm.models import ModelRole, SelectedModel
@@ -54,6 +55,16 @@ def list_threads(workspace: WorkspaceDep, session: SessionDep) -> Sequence[ChatT
         .where(ChatThread.workspace_id == workspace.id)
         .order_by(ChatThread.created_at.desc())
     ).all()
+
+
+@router.patch(
+    "/chat/threads/{thread_id}",
+    response_model=ThreadRead,
+    summary="Rename a chat thread",
+)
+def update_thread(thread: ThreadDep, payload: ThreadUpdate) -> ChatThread:
+    thread.title = payload.title
+    return thread
 
 
 @router.get(

--- a/surfsense_local/backend/modules/chat/router.py
+++ b/surfsense_local/backend/modules/chat/router.py
@@ -2,6 +2,7 @@ import json
 import logging
 from collections.abc import AsyncIterator, Sequence
 from dataclasses import asdict
+from datetime import UTC, datetime
 
 from fastapi import APIRouter, HTTPException, Response, status
 from fastapi.responses import StreamingResponse
@@ -147,15 +148,18 @@ async def send_message(
     # Do not hold a write transaction open while the model generates. The IDs
     # are also the stable identities the client uses throughout the stream.
     session.commit()
+    user_created_at = user_message.created_at.isoformat()
 
     async def stream() -> AsyncIterator[bytes]:
         parts: list[str] = []
         cited: list[dict] = []
+        assistant_completed_at: str | None = None
         yield _frame(
             {
                 "type": "accepted",
                 "user_message_id": user_message.id,
                 "assistant_message_id": assistant_message.id,
+                "user_created_at": user_created_at,
             }
         )
         yield _frame(
@@ -192,10 +196,19 @@ async def send_message(
             answer, used = resolve_citations("".join(parts), citations)
             cited = [asdict(citation) for citation in used]
             assistant_message.content = {"text": answer, "citations": cited}
+            assistant_message.completed_at = datetime.now(UTC)
             session.commit()
+            session.refresh(assistant_message, attribute_names=["completed_at"])
+            assistant_completed_at = assistant_message.completed_at.isoformat()
 
         if cited:
             yield _frame({"type": "citations", "items": cited})
+        yield _frame(
+            {
+                "type": "completed",
+                "assistant_completed_at": assistant_completed_at,
+            }
+        )
         yield _DONE
 
     return StreamingResponse(

--- a/surfsense_local/backend/modules/chat/schemas.py
+++ b/surfsense_local/backend/modules/chat/schemas.py
@@ -18,6 +18,12 @@ class ThreadCreate(BaseModel):
     title: ThreadTitle = "New chat"
 
 
+class ThreadUpdate(BaseModel):
+    """Fields a client may change on an existing thread."""
+
+    title: ThreadTitle
+
+
 class ThreadRead(BaseModel):
     """A thread as the API returns it."""
 

--- a/surfsense_local/backend/modules/chat/schemas.py
+++ b/surfsense_local/backend/modules/chat/schemas.py
@@ -52,3 +52,4 @@ class MessageRead(BaseModel):
     role: MessageRole
     content: dict[str, Any]
     created_at: datetime
+    completed_at: datetime | None

--- a/surfsense_local/backend/modules/chat/schemas.py
+++ b/surfsense_local/backend/modules/chat/schemas.py
@@ -15,7 +15,7 @@ DocumentId = Annotated[int, Field(gt=0)]
 class ThreadCreate(BaseModel):
     """Fields a client supplies when opening a thread."""
 
-    title: ThreadTitle | None = None
+    title: ThreadTitle = "New chat"
 
 
 class ThreadRead(BaseModel):

--- a/surfsense_local/backend/modules/chat/title.py
+++ b/surfsense_local/backend/modules/chat/title.py
@@ -6,10 +6,13 @@ from modules.llm.providers.types import Message
 TITLE_PROMPT = """Write a 2-5 word noun-phrase title.
 Rewrite the request; do not copy it.
 Remove filler such as "tell me", "what's", "please", and "can you".
+Return plain text only: no quotes, slashes, Markdown, or explanation.
+For greetings and small talk, name the intent instead of repeating the words.
 
 Examples:
 "what's there in this chat?" -> Chat Content Overview
 "explain the refund policy" -> Refund Policy
+"hi bro" -> Casual Greeting
 
 Query: {user_query}
 Title:"""

--- a/surfsense_local/backend/modules/chat/title.py
+++ b/surfsense_local/backend/modules/chat/title.py
@@ -1,0 +1,55 @@
+import asyncio
+
+from modules.llm.providers.protocols import Generator
+from modules.llm.providers.types import Message
+
+TITLE_PROMPT = """Write a 2-5 word noun-phrase title.
+Rewrite the request; do not copy it.
+Remove filler such as "tell me", "what's", "please", and "can you".
+
+Examples:
+"what's there in this chat?" -> Chat Content Overview
+"explain the refund policy" -> Refund Policy
+
+Query: {user_query}
+Title:"""
+
+TITLE_TIMEOUT_SECONDS = 30
+TITLE_MAX_TOKENS = 12
+TITLE_MAX_CHARACTERS = 100
+
+
+async def generate_title(
+    generator: Generator, model: str, user_query: str
+) -> str | None:
+    """Generate and validate a short title without exposing raw model output."""
+    prompt = TITLE_PROMPT.replace(
+        "{user_query}", user_query.strip()[:500] or "(message)"
+    )
+    parts: list[str] = []
+    async with asyncio.timeout(TITLE_TIMEOUT_SECONDS):
+        async for delta in generator.chat(
+            model,
+            [Message("user", prompt)],
+            max_tokens=TITLE_MAX_TOKENS,
+            temperature=0,
+            reasoning=False,
+        ):
+            parts.append(delta)
+            if sum(map(len, parts)) > TITLE_MAX_CHARACTERS + 2:
+                return None
+    return valid_title("".join(parts))
+
+
+def valid_title(raw: str) -> str | None:
+    """Accept a short single-line title; rendering escapes ordinary punctuation."""
+    title = raw.strip().strip("\"'").strip()
+    words = title.split()
+    if (
+        not title
+        or len(title) > TITLE_MAX_CHARACTERS
+        or "\n" in title
+        or not 1 <= len(words) <= 6
+    ):
+        return None
+    return " ".join(words)

--- a/surfsense_local/backend/modules/documents/router.py
+++ b/surfsense_local/backend/modules/documents/router.py
@@ -176,18 +176,9 @@ def upload_documents(
     return UploadOutcome(created=created, duplicates=duplicates, rejected=rejected)
 
 
-@router.get(
-    "/{document_id}",
-    response_model=DocumentDetail,
-    summary="Read a document",
-)
-def read_document(document: DocumentDep) -> Document:
-    return document
-
-
 @router.patch(
     "/{document_id}",
-    response_model=DocumentDetail,
+    response_model=DocumentRead,
     summary="Edit a document",
 )
 def update_document(
@@ -217,7 +208,7 @@ def update_document(
 
 @router.post(
     "/{document_id}/retry",
-    response_model=DocumentDetail,
+    response_model=DocumentRead,
     summary="Requeue a failed document",
 )
 def retry_document(document: DocumentDep, session: SessionDep) -> Document:

--- a/surfsense_local/backend/modules/documents/router.py
+++ b/surfsense_local/backend/modules/documents/router.py
@@ -15,14 +15,17 @@ from modules.documents.schemas import (
     DocumentUpdate,
     DuplicateRead,
     NoteCreate,
+    RejectedUploadRead,
     UploadOutcome,
 )
 from modules.documents.storage import (
+    SUPPORTED_UPLOAD_SUFFIXES,
     StreamedUpload,
     original_path,
     stream_upload,
     suffix_of,
     title_of,
+    validate_upload,
 )
 from modules.documents.tasks import ingest_document
 from modules.workspaces.dependencies import WorkspaceDep
@@ -92,11 +95,35 @@ def upload_documents(
     storage = get_storage_settings()
     created: list[Document] = []
     duplicates: list[DuplicateRead] = []
+    rejected: list[RejectedUploadRead] = []
     accepted: list[tuple[Document, StreamedUpload, str]] = []
+    staged: list[StreamedUpload] = []
 
     try:
         for upload in files:
+            suffix = suffix_of(upload)
+            if suffix not in SUPPORTED_UPLOAD_SUFFIXES:
+                rejected.append(
+                    RejectedUploadRead(
+                        filename=title_of(upload),
+                        reason=f"{suffix or 'extensionless files'} are not supported",
+                    )
+                )
+                continue
+
             streamed = stream_upload(upload, storage.workspace_dir(workspace.id))
+            staged.append(streamed)
+            try:
+                mime_type = validate_upload(streamed.path, suffix)
+            except ValueError as failure:
+                streamed.path.unlink(missing_ok=True)
+                rejected.append(
+                    RejectedUploadRead(
+                        filename=title_of(upload),
+                        reason=str(failure),
+                    )
+                )
+                continue
 
             # Keyed on the bytes: the same report under two names is one
             # document, and two unrelated files both called report.pdf are two.
@@ -119,18 +146,18 @@ def upload_documents(
                 document_type=DocumentType.FILE,
                 dedup_key=streamed.digest,
                 document_metadata={
-                    "mime_type": upload.content_type,
+                    "mime_type": mime_type,
                     "size_bytes": streamed.size,
-                    "suffix": suffix_of(upload),
+                    "suffix": suffix,
                 },
             )
             session.add(document)
             # The file is stored under the id the database is about to assign.
             session.flush()
             created.append(document)
-            accepted.append((document, streamed, suffix_of(upload)))
+            accepted.append((document, streamed, suffix))
     except BaseException:
-        for _, streamed, _ in accepted:
+        for streamed in staged:
             streamed.path.unlink(missing_ok=True)
         raise
 
@@ -146,7 +173,7 @@ def upload_documents(
     for document, _, _ in accepted:
         ingest_document(document.id)
 
-    return UploadOutcome(created=created, duplicates=duplicates)
+    return UploadOutcome(created=created, duplicates=duplicates, rejected=rejected)
 
 
 @router.get(

--- a/surfsense_local/backend/modules/documents/schemas.py
+++ b/surfsense_local/backend/modules/documents/schemas.py
@@ -51,6 +51,13 @@ class DuplicateRead(BaseModel):
     document_id: int
 
 
+class RejectedUploadRead(BaseModel):
+    """A file the ingestion pipeline cannot safely process."""
+
+    filename: str
+    reason: str
+
+
 class UploadOutcome(BaseModel):
     """One upload can be a dropped folder, so each file gets its own verdict.
 
@@ -60,3 +67,4 @@ class UploadOutcome(BaseModel):
 
     created: list[DocumentRead]
     duplicates: list[DuplicateRead]
+    rejected: list[RejectedUploadRead]

--- a/surfsense_local/backend/modules/documents/storage.py
+++ b/surfsense_local/backend/modules/documents/storage.py
@@ -19,6 +19,9 @@ READ_SIZE = 1024 * 1024
 # The only part of a client's filename allowed near a path.
 SAFE_SUFFIX = re.compile(r"\A\.[A-Za-z0-9]{1,16}\Z")
 
+# This is the upload authority. The frontend mirrors these suffixes only to
+# filter its native picker; update that mirror when this changes. If formats
+# become dynamic or change often, expose them through a capabilities endpoint.
 UPLOAD_MIME_BY_SUFFIX = {
     ".pdf": "application/pdf",
     ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",

--- a/surfsense_local/backend/modules/documents/storage.py
+++ b/surfsense_local/backend/modules/documents/storage.py
@@ -1,8 +1,10 @@
 import hashlib
 import re
+from codecs import getincrementaldecoder
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import NamedTuple
+from zipfile import BadZipFile, ZipFile
 
 from fastapi import HTTPException, UploadFile, status
 
@@ -10,10 +12,111 @@ from modules.documents.models import Document
 from shared.config import get_storage_settings
 
 MAX_UPLOAD_BYTES = 500 * 1024 * 1024
+MAX_ARCHIVE_ENTRIES = 10_000
+MAX_ARCHIVE_UNPACKED_BYTES = 2 * 1024 * 1024 * 1024
 READ_SIZE = 1024 * 1024
 
 # The only part of a client's filename allowed near a path.
 SAFE_SUFFIX = re.compile(r"\A\.[A-Za-z0-9]{1,16}\Z")
+
+UPLOAD_MIME_BY_SUFFIX = {
+    ".pdf": "application/pdf",
+    ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    ".pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    ".html": "text/html",
+    ".htm": "text/html",
+    ".csv": "text/csv",
+    ".md": "text/markdown",
+    ".markdown": "text/markdown",
+    ".txt": "text/plain",
+    ".text": "text/plain",
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".tif": "image/tiff",
+    ".tiff": "image/tiff",
+    ".bmp": "image/bmp",
+    ".webp": "image/webp",
+}
+SUPPORTED_UPLOAD_SUFFIXES = frozenset(UPLOAD_MIME_BY_SUFFIX)
+
+_OOXML_MEMBER_BY_SUFFIX = {
+    ".docx": "word/document.xml",
+    ".pptx": "ppt/presentation.xml",
+    ".xlsx": "xl/workbook.xml",
+}
+
+
+def validate_upload(path: Path, suffix: str) -> str:
+    """Validate the stored bytes and return the server-owned MIME type."""
+    if suffix == ".pdf":
+        valid = _starts_with(path, b"%PDF-")
+    elif suffix in _OOXML_MEMBER_BY_SUFFIX:
+        valid = _is_ooxml(path, suffix)
+    elif suffix in {".html", ".htm", ".csv", ".md", ".markdown", ".txt", ".text"}:
+        valid = _is_utf8_text(path)
+    elif suffix in {".png", ".jpg", ".jpeg", ".tif", ".tiff", ".bmp", ".webp"}:
+        valid = _is_image(path, suffix)
+    else:
+        raise ValueError(f"{suffix or 'extensionless files'} are not supported")
+
+    if not valid:
+        raise ValueError(f"file contents do not match {suffix}")
+    return UPLOAD_MIME_BY_SUFFIX[suffix]
+
+
+def _starts_with(path: Path, signature: bytes) -> bool:
+    with path.open("rb") as source:
+        return source.read(len(signature)) == signature
+
+
+def _is_ooxml(path: Path, suffix: str) -> bool:
+    try:
+        with ZipFile(path) as archive:
+            entries = archive.infolist()
+            names = {entry.filename for entry in entries}
+            return (
+                len(entries) <= MAX_ARCHIVE_ENTRIES
+                and sum(entry.file_size for entry in entries)
+                <= MAX_ARCHIVE_UNPACKED_BYTES
+                and "[Content_Types].xml" in names
+                and _OOXML_MEMBER_BY_SUFFIX[suffix] in names
+            )
+    except (BadZipFile, OSError):
+        return False
+
+
+def _is_utf8_text(path: Path) -> bool:
+    size = 0
+    controls = 0
+    decoder = getincrementaldecoder("utf-8")()
+    try:
+        with path.open("rb") as source:
+            while chunk := source.read(READ_SIZE):
+                decoder.decode(chunk)
+                if b"\0" in chunk:
+                    return False
+                size += len(chunk)
+                controls += sum(byte < 32 and byte not in b"\t\n\f\r" for byte in chunk)
+        decoder.decode(b"", final=True)
+    except (OSError, UnicodeDecodeError):
+        return False
+    return size > 0 and controls <= max(1, size // 100)
+
+
+def _is_image(path: Path, suffix: str) -> bool:
+    with path.open("rb") as source:
+        header = source.read(12)
+    if suffix == ".png":
+        return header.startswith(b"\x89PNG\r\n\x1a\n")
+    if suffix in {".jpg", ".jpeg"}:
+        return header.startswith(b"\xff\xd8\xff")
+    if suffix in {".tif", ".tiff"}:
+        return header.startswith((b"II*\x00", b"MM\x00*"))
+    if suffix == ".bmp":
+        return header.startswith(b"BM")
+    return header.startswith(b"RIFF") and header[8:12] == b"WEBP"
 
 
 def original_path(document: Document) -> Path:

--- a/surfsense_local/backend/modules/llm/providers/ollama/provider.py
+++ b/surfsense_local/backend/modules/llm/providers/ollama/provider.py
@@ -111,11 +111,7 @@ class OllamaProvider:
             referenced = None
 
         def cancelled_files():
-            files = {
-                path
-                for pattern in patterns
-                for path in blobs_dir.glob(pattern)
-            }
+            files = {path for pattern in patterns for path in blobs_dir.glob(pattern)}
             if referenced is not None:
                 files.update(
                     path
@@ -161,12 +157,32 @@ class OllamaProvider:
                 if line:
                     yield _progress(json.loads(line))
 
-    async def chat(self, model: str, messages: list[Message]) -> AsyncIterator[str]:
+    async def chat(
+        self,
+        model: str,
+        messages: list[Message],
+        *,
+        max_tokens: int | None = None,
+        temperature: float | None = None,
+        reasoning: bool | None = None,
+    ) -> AsyncIterator[str]:
         body = {
             "model": model,
             "messages": [{"role": m.role, "content": m.content} for m in messages],
             "stream": True,
         }
+        if reasoning is not None:
+            body["think"] = reasoning
+        options = {
+            key: value
+            for key, value in (
+                ("num_predict", max_tokens),
+                ("temperature", temperature),
+            )
+            if value is not None
+        }
+        if options:
+            body["options"] = options
         async with (
             self._client() as client,
             client.stream("POST", "/api/chat", json=body) as reply,

--- a/surfsense_local/backend/modules/llm/providers/openrouter/provider.py
+++ b/surfsense_local/backend/modules/llm/providers/openrouter/provider.py
@@ -55,12 +55,26 @@ class OpenRouterProvider:
             if _answers_text(entry)
         ]
 
-    async def chat(self, model: str, messages: list[Message]) -> AsyncIterator[str]:
+    async def chat(
+        self,
+        model: str,
+        messages: list[Message],
+        *,
+        max_tokens: int | None = None,
+        temperature: float | None = None,
+        reasoning: bool | None = None,
+    ) -> AsyncIterator[str]:
         body = {
             "model": model,
             "messages": [{"role": m.role, "content": m.content} for m in messages],
             "stream": True,
         }
+        if max_tokens is not None:
+            body["max_tokens"] = max_tokens
+        if temperature is not None:
+            body["temperature"] = temperature
+        if reasoning is not None:
+            body["reasoning"] = {"enabled": reasoning}
         async with (
             self._client() as client,
             client.stream("POST", "/chat/completions", json=body) as reply,

--- a/surfsense_local/backend/modules/llm/providers/protocols.py
+++ b/surfsense_local/backend/modules/llm/providers/protocols.py
@@ -13,7 +13,15 @@ class Generator(Protocol):
 
     async def models(self) -> list[Model]: ...
 
-    def chat(self, model: str, messages: list[Message]) -> AsyncIterator[str]: ...
+    def chat(
+        self,
+        model: str,
+        messages: list[Message],
+        *,
+        max_tokens: int | None = None,
+        temperature: float | None = None,
+        reasoning: bool | None = None,
+    ) -> AsyncIterator[str]: ...
 
 
 @runtime_checkable

--- a/surfsense_local/backend/tests/integration/chat/conftest.py
+++ b/surfsense_local/backend/tests/integration/chat/conftest.py
@@ -8,7 +8,7 @@ import pytest
 from shared.config import get_llm_settings
 
 # The reply the stub streams back, split so the route emits more than one delta.
-REPLY_DELTAS = ["Revenue ", "climbed after the launch [1]."]
+REPLY_DELTAS = ["Revenue ", "climbed after the launch [citation:1]."]
 
 # Each chat request the stub received, so a test can assert what the route sent.
 _REQUESTS: list[dict] = []

--- a/surfsense_local/backend/tests/integration/chat/conftest.py
+++ b/surfsense_local/backend/tests/integration/chat/conftest.py
@@ -23,10 +23,15 @@ class StubOllamaChat(BaseHTTPRequestHandler):
             self.send_error(404)
             return
 
-        _REQUESTS.append(json.loads(raw))
+        request = json.loads(raw)
+        _REQUESTS.append(request)
+        deltas = (
+            ["Revenue ", "Growth"]
+            if request.get("options", {}).get("num_predict") == 12
+            else REPLY_DELTAS
+        )
         body = "".join(
-            json.dumps({"message": {"content": delta}}) + "\n"
-            for delta in REPLY_DELTAS
+            json.dumps({"message": {"content": delta}}) + "\n" for delta in deltas
         ).encode()
         self.send_response(200)
         self.send_header("Content-Length", str(len(body)))

--- a/surfsense_local/backend/tests/integration/chat/test_chat.py
+++ b/surfsense_local/backend/tests/integration/chat/test_chat.py
@@ -99,17 +99,24 @@ async def test_a_message_streams_a_grounded_reply(
     assert accepted["user_message_id"] > 0
     assert accepted["assistant_message_id"] > 0
 
-    title = events[1]
+    catalog = events[1]
+    assert catalog["type"] == "citation-catalog"
+    assert len(catalog["items"]) == 1
+    assert catalog["items"][0]["source_id"] == 1
+    assert catalog["items"][0]["document_id"] == doc_id
+
+    title = events[2]
     assert title == {"type": "thread-title-update", "title": "Revenue Growth"}
     assert (
         next(event["type"] for event in events if event["type"] == "delta") == "delta"
     )
 
     deltas = [event["text"] for event in events if event["type"] == "delta"]
-    assert "".join(deltas) == "Revenue climbed after the launch [1]."
+    assert "".join(deltas) == "Revenue climbed after the launch [citation:1]."
 
     citations = next(event for event in events if event["type"] == "citations")
     assert any(cite["document_id"] == doc_id for cite in citations["items"])
+    assert citations["items"][0]["source_id"] == 1
 
     stored = (await client.get(f"/chat/threads/{thread_id}/messages")).json()
     assert [message["role"] for message in stored] == ["user", "assistant"]
@@ -117,7 +124,9 @@ async def test_a_message_streams_a_grounded_reply(
         accepted["user_message_id"],
         accepted["assistant_message_id"],
     ]
-    assert stored[1]["content"]["text"] == "Revenue climbed after the launch [1]."
+    assert (
+        stored[1]["content"]["text"] == "Revenue climbed after the launch [citation:1]."
+    )
     assert stored[1]["content"]["citations"]
     threads = (await client.get(f"/workspaces/{workspace_id}/chat/threads")).json()
     assert threads[0]["title"] == "Revenue Growth"
@@ -165,7 +174,7 @@ async def test_title_failure_does_not_block_the_answer(
     assert not any(event["type"] == "thread-title-update" for event in events)
     assert (
         "".join(event["text"] for event in events if event["type"] == "delta")
-        == "Revenue climbed after the launch [1]."
+        == "Revenue climbed after the launch [citation:1]."
     )
     threads = (await client.get(f"/workspaces/{workspace_id}/chat/threads")).json()
     assert threads[0]["title"] == "New chat"

--- a/surfsense_local/backend/tests/integration/chat/test_chat.py
+++ b/surfsense_local/backend/tests/integration/chat/test_chat.py
@@ -81,6 +81,12 @@ async def test_a_message_streams_a_grounded_reply(
     assert accepted["user_message_id"] > 0
     assert accepted["assistant_message_id"] > 0
 
+    title = events[1]
+    assert title == {"type": "thread-title-update", "title": "Revenue Growth"}
+    assert (
+        next(event["type"] for event in events if event["type"] == "delta") == "delta"
+    )
+
     deltas = [event["text"] for event in events if event["type"] == "delta"]
     assert "".join(deltas) == "Revenue climbed after the launch [1]."
 
@@ -95,6 +101,11 @@ async def test_a_message_streams_a_grounded_reply(
     ]
     assert stored[1]["content"]["text"] == "Revenue climbed after the launch [1]."
     assert stored[1]["content"]["citations"]
+    threads = (await client.get(f"/workspaces/{workspace_id}/chat/threads")).json()
+    assert threads[0]["title"] == "Revenue Growth"
+    assert ollama_server[0]["think"] is False
+    assert ollama_server[0]["options"] == {"num_predict": 12, "temperature": 0}
+    assert "options" not in ollama_server[1]
 
 
 async def test_a_followup_carries_the_earlier_turn(
@@ -108,10 +119,38 @@ async def test_a_followup_carries_the_earlier_turn(
     ollama_server.clear()
     await _send(client, thread_id, "second question")
 
+    assert len(ollama_server) == 1
     sent = ollama_server[-1]["messages"]
     assert sent[0]["role"] == "system"
     assert sent[-1] == {"role": "user", "content": "second question"}
     assert "first question" in [message["content"] for message in sent]
+
+
+async def test_title_failure_does_not_block_the_answer(
+    client: AsyncClient,
+    engine: Engine,
+    real_model: object,
+    ollama_server: list[dict],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Naming is best effort; its failure must not consume or fail the chat turn."""
+
+    async def fail_title(*_args: object) -> None:
+        raise RuntimeError("title model failed")
+
+    monkeypatch.setattr("modules.chat.router.generate_title", fail_title)
+    workspace_id, _ = _seed(engine)
+    thread_id = await _open_thread(client, workspace_id)
+
+    events = await _send(client, thread_id, "what happened?")
+
+    assert not any(event["type"] == "thread-title-update" for event in events)
+    assert (
+        "".join(event["text"] for event in events if event["type"] == "delta")
+        == "Revenue climbed after the launch [1]."
+    )
+    threads = (await client.get(f"/workspaces/{workspace_id}/chat/threads")).json()
+    assert threads[0]["title"] == "New chat"
 
 
 async def test_a_thread_with_no_model_selected_is_a_409(client: AsyncClient) -> None:

--- a/surfsense_local/backend/tests/integration/chat/test_chat.py
+++ b/surfsense_local/backend/tests/integration/chat/test_chat.py
@@ -67,6 +67,24 @@ async def _send(client: AsyncClient, thread_id: int, text: str) -> list[dict]:
     return events
 
 
+async def test_a_thread_can_be_renamed(client: AsyncClient) -> None:
+    """A manual title is trimmed, persisted, and constrained at the API boundary."""
+    workspace = (await client.post("/workspaces", json={"name": "w"})).json()
+    thread_id = await _open_thread(client, workspace["id"])
+
+    renamed = await client.patch(
+        f"/chat/threads/{thread_id}", json={"title": "  Banking fees  "}
+    )
+
+    assert renamed.status_code == 200
+    assert renamed.json()["title"] == "Banking fees"
+    listed = (await client.get(f"/workspaces/{workspace['id']}/chat/threads")).json()
+    assert listed[0]["title"] == "Banking fees"
+    assert (
+        await client.patch(f"/chat/threads/{thread_id}", json={"title": "   "})
+    ).status_code == 422
+
+
 async def test_a_message_streams_a_grounded_reply(
     client: AsyncClient, engine: Engine, real_model: object, ollama_server: list[dict]
 ) -> None:

--- a/surfsense_local/backend/tests/integration/chat/test_chat.py
+++ b/surfsense_local/backend/tests/integration/chat/test_chat.py
@@ -98,6 +98,7 @@ async def test_a_message_streams_a_grounded_reply(
     assert accepted["type"] == "accepted"
     assert accepted["user_message_id"] > 0
     assert accepted["assistant_message_id"] > 0
+    assert accepted["user_created_at"]
 
     catalog = events[1]
     assert catalog["type"] == "citation-catalog"
@@ -117,6 +118,8 @@ async def test_a_message_streams_a_grounded_reply(
     citations = next(event for event in events if event["type"] == "citations")
     assert any(cite["document_id"] == doc_id for cite in citations["items"])
     assert citations["items"][0]["source_id"] == 1
+    completed = next(event for event in events if event["type"] == "completed")
+    assert completed["assistant_completed_at"]
 
     stored = (await client.get(f"/chat/threads/{thread_id}/messages")).json()
     assert [message["role"] for message in stored] == ["user", "assistant"]
@@ -128,6 +131,8 @@ async def test_a_message_streams_a_grounded_reply(
         stored[1]["content"]["text"] == "Revenue climbed after the launch [citation:1]."
     )
     assert stored[1]["content"]["citations"]
+    assert stored[0]["completed_at"] is None
+    assert stored[1]["completed_at"] == completed["assistant_completed_at"]
     threads = (await client.get(f"/workspaces/{workspace_id}/chat/threads")).json()
     assert threads[0]["title"] == "Revenue Growth"
     assert ollama_server[0]["think"] is False

--- a/surfsense_local/backend/tests/integration/documents/test_routes.py
+++ b/surfsense_local/backend/tests/integration/documents/test_routes.py
@@ -60,40 +60,6 @@ async def test_the_list_omits_document_content(
     assert listed.json()[0]["title"] == "Kickoff"
 
 
-async def test_a_document_is_read_with_its_content(
-    client: AsyncClient, workspace_id: int
-) -> None:
-    """Opening a document is the one place the extracted text is wanted."""
-    created = await client.post(
-        f"/workspaces/{workspace_id}/documents",
-        json={"title": "Kickoff", "content": "agreed to ship"},
-    )
-
-    response = await client.get(
-        f"/workspaces/{workspace_id}/documents/{created.json()['id']}"
-    )
-
-    assert response.status_code == 200
-    assert response.json()["content"] == "agreed to ship"
-
-
-async def test_a_document_is_not_readable_through_another_workspace(
-    client: AsyncClient, workspace_id: int
-) -> None:
-    """The workspace in the path is the scope, not decoration on the url."""
-    created = await client.post(
-        f"/workspaces/{workspace_id}/documents",
-        json={"title": "Kickoff", "content": "secret"},
-    )
-    other = await client.post("/workspaces", json={"name": "Other"})
-
-    response = await client.get(
-        f"/workspaces/{other.json()['id']}/documents/{created.json()['id']}"
-    )
-
-    assert response.status_code == 404
-
-
 async def test_a_document_can_be_retitled(
     client: AsyncClient, workspace_id: int
 ) -> None:
@@ -110,7 +76,7 @@ async def test_a_document_can_be_retitled(
 
     assert response.status_code == 200
     assert response.json()["title"] == "Kickoff"
-    assert response.json()["content"] == "x"
+    assert "content" not in response.json()
 
 
 async def test_editing_a_note_sends_it_back_for_indexing(
@@ -129,7 +95,7 @@ async def test_editing_a_note_sends_it_back_for_indexing(
     )
 
     assert response.status_code == 200
-    assert response.json()["content"] == "second draft"
+    assert "content" not in response.json()
     assert response.json()["status"] == "pending"
 
 

--- a/surfsense_local/backend/tests/integration/documents/test_upload.py
+++ b/surfsense_local/backend/tests/integration/documents/test_upload.py
@@ -54,11 +54,11 @@ async def test_the_same_bytes_are_not_ingested_twice(
     """Embedding a document twice doubles the work and splits its citations."""
     first = await client.post(
         f"/workspaces/{workspace_id}/documents/upload",
-        files={"files": ("report.pdf", b"identical", "application/pdf")},
+        files={"files": ("report.pdf", b"%PDF-identical", "application/pdf")},
     )
     second = await client.post(
         f"/workspaces/{workspace_id}/documents/upload",
-        files={"files": ("renamed.pdf", b"identical", "application/pdf")},
+        files={"files": ("renamed.pdf", b"%PDF-identical", "application/pdf")},
     )
 
     assert second.status_code == 201
@@ -74,11 +74,11 @@ async def test_a_different_file_of_the_same_name_is_kept(
     """Cloud keys dedup on the filename, so report.pdf could be uploaded once, ever."""
     await client.post(
         f"/workspaces/{workspace_id}/documents/upload",
-        files={"files": ("report.pdf", b"january", "application/pdf")},
+        files={"files": ("report.pdf", b"%PDF-january", "application/pdf")},
     )
     second = await client.post(
         f"/workspaces/{workspace_id}/documents/upload",
-        files={"files": ("report.pdf", b"february", "application/pdf")},
+        files={"files": ("report.pdf", b"%PDF-february", "application/pdf")},
     )
 
     assert len(second.json()["created"]) == 1
@@ -93,7 +93,7 @@ async def test_the_same_file_is_kept_per_workspace(client: AsyncClient) -> None:
     for workspace in (first, second):
         response = await client.post(
             f"/workspaces/{workspace.json()['id']}/documents/upload",
-            files={"files": ("report.pdf", b"shared", "application/pdf")},
+            files={"files": ("report.pdf", b"%PDF-shared", "application/pdf")},
         )
 
         assert len(response.json()["created"]) == 1
@@ -105,19 +105,62 @@ async def test_a_batch_is_split_rather_than_rejected(
     """A dropped folder holding one known file must not lose the other three."""
     await client.post(
         f"/workspaces/{workspace_id}/documents/upload",
-        files={"files": ("old.pdf", b"seen before", "application/pdf")},
+        files={"files": ("old.pdf", b"%PDF-seen before", "application/pdf")},
     )
 
     response = await client.post(
         f"/workspaces/{workspace_id}/documents/upload",
         files=[
-            ("files", ("old.pdf", b"seen before", "application/pdf")),
-            ("files", ("new.pdf", b"never seen", "application/pdf")),
+            ("files", ("old.pdf", b"%PDF-seen before", "application/pdf")),
+            ("files", ("new.pdf", b"%PDF-never seen", "application/pdf")),
         ],
     )
 
     assert [document["title"] for document in response.json()["created"]] == ["new.pdf"]
     assert [entry["filename"] for entry in response.json()["duplicates"]] == ["old.pdf"]
+
+
+async def test_unsupported_and_mismatched_files_are_rejected_per_file(
+    client: AsyncClient, workspace_id: int, data_dir: Path
+) -> None:
+    """Only verified formats reach storage and the ingestion queue."""
+    response = await client.post(
+        f"/workspaces/{workspace_id}/documents/upload",
+        files=[
+            ("files", ("notes.txt", b"research notes", "application/octet-stream")),
+            ("files", ("malware.exe", b"MZ", "application/pdf")),
+            ("files", ("fake.pdf", b"MZ", "application/pdf")),
+        ],
+    )
+
+    assert response.status_code == 201
+    assert [entry["title"] for entry in response.json()["created"]] == ["notes.txt"]
+    assert response.json()["rejected"] == [
+        {"filename": "malware.exe", "reason": ".exe are not supported"},
+        {
+            "filename": "fake.pdf",
+            "reason": "file contents do not match .pdf",
+        },
+    ]
+    assert [path.name for path in stored_files(data_dir)] == ["original.txt"]
+    assert len(huey.pending()) == 1
+
+
+async def test_server_records_verified_mime_not_the_clients_claim(
+    client: AsyncClient, workspace_id: int
+) -> None:
+    """Multipart MIME is advisory; downloads use the server-owned type."""
+    created = await client.post(
+        f"/workspaces/{workspace_id}/documents/upload",
+        files={"files": ("notes.txt", b"research", "application/x-msdownload")},
+    )
+    document_id = created.json()["created"][0]["id"]
+
+    downloaded = await client.get(
+        f"/workspaces/{workspace_id}/documents/{document_id}/original"
+    )
+
+    assert downloaded.headers["content-type"].startswith("text/plain")
 
 
 async def test_one_batch_cannot_hold_the_same_file_twice(
@@ -127,8 +170,8 @@ async def test_one_batch_cannot_hold_the_same_file_twice(
     response = await client.post(
         f"/workspaces/{workspace_id}/documents/upload",
         files=[
-            ("files", ("report.pdf", b"identical", "application/pdf")),
-            ("files", ("copy.pdf", b"identical", "application/pdf")),
+            ("files", ("report.pdf", b"%PDF-identical", "application/pdf")),
+            ("files", ("copy.pdf", b"%PDF-identical", "application/pdf")),
         ],
     )
 
@@ -163,7 +206,7 @@ async def test_a_filename_cannot_escape_the_data_directory(
     """The client names the file; only its extension is allowed near a path."""
     response = await client.post(
         f"/workspaces/{workspace_id}/documents/upload",
-        files={"files": ("../../../../etc/passwd", b"root:x:0:0", "text/plain")},
+        files={"files": ("../../../../etc/report.txt", b"root:x:0:0", "text/plain")},
     )
 
     assert response.status_code == 201
@@ -174,7 +217,7 @@ async def test_a_filename_cannot_escape_the_data_directory(
         / str(workspace_id)
         / "documents"
         / str(response.json()["created"][0]["id"])
-        / "original"
+        / "original.txt"
     ]
 
 
@@ -249,7 +292,7 @@ async def test_a_deleted_workspace_takes_every_file(
     for name in ("a.pdf", "b.pdf"):
         await client.post(
             f"/workspaces/{workspace_id}/documents/upload",
-            files={"files": (name, name.encode(), "application/pdf")},
+            files={"files": (name, b"%PDF-" + name.encode(), "application/pdf")},
         )
 
     await client.delete(f"/workspaces/{workspace_id}")

--- a/surfsense_local/backend/tests/unit/chat/test_citations.py
+++ b/surfsense_local/backend/tests/unit/chat/test_citations.py
@@ -1,8 +1,8 @@
-"""normalize_citations resolves inline [n] against the sources the model was given."""
+"""Source citation tokens resolve against the catalog given to the model."""
 
 import pytest
 
-from modules.chat.prompt import Citation, normalize_citations
+from modules.chat.prompt import Citation, resolve_citations
 
 pytestmark = pytest.mark.unit
 
@@ -13,36 +13,39 @@ SOURCES = [
 ]
 
 
-def test_drops_invented_ordinals_and_renumbers_survivors() -> None:
-    """An [n] with no source is dropped; the rest renumber by first appearance."""
-    text, used = normalize_citations("First [3]. Second [1]. Bogus [9].", SOURCES)
+def test_drops_invented_tokens_and_preserves_source_ids() -> None:
+    """Unknown tokens are dropped while valid source identities remain stable."""
+    text, used = resolve_citations(
+        "First [citation:3]. Second [citation:1]. Bogus [citation:9].", SOURCES
+    )
 
-    assert text == "First [1]. Second [2]. Bogus ."
-    assert [(c.id, c.chunk_id) for c in used] == [(1, 103), (2, 101)]
+    assert text == "First [citation:3]. Second [citation:1]. Bogus ."
+    assert [(c.source_id, c.chunk_id) for c in used] == [(3, 103), (1, 101)]
 
 
 def test_a_repeated_source_maps_to_one_number() -> None:
-    """Citing the same source twice yields one entry, both markers the same number."""
-    text, used = normalize_citations("A [1] and again [1].", SOURCES)
+    """Citing the same source twice yields one catalog entry."""
+    text, used = resolve_citations("A [citation:1] and again [citation:1].", SOURCES)
 
-    assert text == "A [1] and again [1]."
-    assert [c.id for c in used] == [1]
+    assert text == "A [citation:1] and again [citation:1]."
+    assert [c.source_id for c in used] == [1]
 
 
-def test_ordinals_inside_code_are_left_alone() -> None:
-    """Inline and fenced code pass through, so `arr[1]` is never read as a citation."""
-    text, used = normalize_citations(
-        "Use `arr[1]` here [2].\n```\nx[1] = 3\n```\n", SOURCES
+def test_tokens_inside_code_are_left_alone() -> None:
+    """Inline and fenced code pass through without becoming citations."""
+    text, used = resolve_citations(
+        "Use `[citation:1]` here [citation:2].\n```\n[citation:3]\n```\n",
+        SOURCES,
     )
 
-    assert "`arr[1]`" in text
-    assert "x[1] = 3" in text
-    assert [c.id for c in used] == [1]  # only the [2] outside code, renumbered to [1]
+    assert "`[citation:1]`" in text
+    assert "[citation:3]" in text
+    assert [c.source_id for c in used] == [2]
 
 
 def test_no_valid_citation_leaves_no_sources() -> None:
     """When nothing resolves, the marker is dropped and the source list is empty."""
-    text, used = normalize_citations("Just text [9].", SOURCES)
+    text, used = resolve_citations("Just text [citation:9].", SOURCES)
 
     assert text == "Just text ."
     assert used == []
@@ -50,4 +53,9 @@ def test_no_valid_citation_leaves_no_sources() -> None:
 
 def test_empty_answer() -> None:
     """An empty answer resolves to itself with no sources."""
-    assert normalize_citations("", SOURCES) == ("", [])
+    assert resolve_citations("", SOURCES) == ("", [])
+
+
+def test_legacy_ordinals_are_plain_text() -> None:
+    """The pre-release [n] syntax is not a compatibility citation format."""
+    assert resolve_citations("Legacy [1].", SOURCES) == ("Legacy [1].", [])

--- a/surfsense_local/backend/tests/unit/chat/test_prompt.py
+++ b/surfsense_local/backend/tests/unit/chat/test_prompt.py
@@ -25,7 +25,7 @@ def test_each_hit_becomes_a_numbered_source() -> None:
 
     assert '<source id="1" document="42" lines="1-4">body of 10</source>' in context
     assert '<source id="2" document="7" lines="9-20">body of 11</source>' in context
-    assert [(c.id, c.document_id, c.chunk_id) for c in citations] == [
+    assert [(c.source_id, c.document_id, c.chunk_id) for c in citations] == [
         (1, 42, 10),
         (2, 7, 11),
     ]

--- a/surfsense_local/backend/tests/unit/chat/test_title.py
+++ b/surfsense_local/backend/tests/unit/chat/test_title.py
@@ -1,0 +1,63 @@
+from collections.abc import AsyncIterator
+
+import pytest
+
+from modules.chat.title import generate_title, valid_title
+from modules.llm.providers.types import Message
+
+pytestmark = pytest.mark.unit
+
+
+class StubGenerator:
+    """Records the bounded title request and streams a fixed response."""
+
+    def __init__(self, deltas: list[str]) -> None:
+        self.deltas = deltas
+        self.request: (
+            tuple[str, list[Message], int | None, float | None, bool | None] | None
+        ) = None
+
+    async def chat(
+        self,
+        model: str,
+        messages: list[Message],
+        *,
+        max_tokens: int | None = None,
+        temperature: float | None = None,
+        reasoning: bool | None = None,
+    ) -> AsyncIterator[str]:
+        self.request = (model, messages, max_tokens, temperature, reasoning)
+        for delta in self.deltas:
+            yield delta
+
+
+async def test_title_generation_is_short_bounded_and_uses_the_selected_model() -> None:
+    """The hidden inference cannot silently switch models or generate a long reply."""
+    generator = StubGenerator(["Quarterly ", "Revenue"])
+
+    title = await generate_title(generator, "qwen3:1.7b", "Explain the quarter")
+
+    assert title == "Quarterly Revenue"
+    assert generator.request is not None
+    model, messages, max_tokens, temperature, reasoning = generator.request
+    assert model == "qwen3:1.7b"
+    assert "Explain the quarter" in messages[0].content
+    assert "Rewrite the request; do not copy it." in messages[0].content
+    assert "Chat Content Overview" in messages[0].content
+    assert max_tokens == 12
+    assert temperature == 0
+    assert reasoning is False
+
+
+@pytest.mark.parametrize(
+    "raw",
+    ["", "one two three four five six seven", "Internal:\nDetails"],
+)
+def test_invalid_model_output_is_never_exposed_as_a_title(raw: str) -> None:
+    """Malformed output is rejected instead of leaking model prose into the UI."""
+    assert valid_title(raw) is None
+
+
+def test_normal_title_punctuation_is_preserved() -> None:
+    """A contraction from a small model is still a valid human-readable title."""
+    assert valid_title("what's there in chat") == "what's there in chat"

--- a/surfsense_local/backend/tests/unit/documents/test_upload_validation.py
+++ b/surfsense_local/backend/tests/unit/documents/test_upload_validation.py
@@ -1,0 +1,94 @@
+"""Content checks for the formats exposed by the source picker."""
+
+from pathlib import Path
+from zipfile import ZipFile
+
+import pytest
+
+from modules.documents.storage import (
+    SUPPORTED_UPLOAD_SUFFIXES,
+    UPLOAD_MIME_BY_SUFFIX,
+    validate_upload,
+)
+
+
+def test_the_public_allowlist_is_deliberately_small() -> None:
+    """A dependency upgrade must not silently expose another Docling format."""
+    assert {
+        ".pdf",
+        ".docx",
+        ".pptx",
+        ".xlsx",
+        ".html",
+        ".htm",
+        ".csv",
+        ".md",
+        ".markdown",
+        ".txt",
+        ".text",
+        ".png",
+        ".jpg",
+        ".jpeg",
+        ".tif",
+        ".tiff",
+        ".bmp",
+        ".webp",
+    } == SUPPORTED_UPLOAD_SUFFIXES
+
+
+@pytest.mark.parametrize(
+    ("suffix", "header"),
+    [
+        (".png", b"\x89PNG\r\n\x1a\n"),
+        (".jpg", b"\xff\xd8\xff"),
+        (".jpeg", b"\xff\xd8\xff"),
+        (".tif", b"II*\x00"),
+        (".tiff", b"MM\x00*"),
+        (".bmp", b"BM"),
+        (".webp", b"RIFF\x04\x00\x00\x00WEBP"),
+    ],
+)
+def test_selected_image_signatures_are_accepted(
+    tmp_path: Path, suffix: str, header: bytes
+) -> None:
+    """Each image extension must agree with its bytes."""
+    upload = tmp_path / f"image{suffix}"
+    upload.write_bytes(header + b"content")
+
+    assert validate_upload(upload, suffix) == UPLOAD_MIME_BY_SUFFIX[suffix]
+
+
+@pytest.mark.parametrize("content", [b"text\0binary", b"\xff\xfe"])
+def test_binary_content_cannot_enter_through_a_text_extension(
+    tmp_path: Path, content: bytes
+) -> None:
+    """Text formats must be nonempty UTF-8 without binary NUL bytes."""
+    upload = tmp_path / "notes.txt"
+    upload.write_bytes(content)
+
+    with pytest.raises(ValueError, match="file contents do not match"):
+        validate_upload(upload, ".txt")
+
+
+@pytest.mark.parametrize(
+    ("suffix", "member"),
+    [
+        (".docx", "word/document.xml"),
+        (".pptx", "ppt/presentation.xml"),
+        (".xlsx", "xl/workbook.xml"),
+    ],
+)
+def test_ooxml_container_must_match_its_extension(
+    tmp_path: Path, suffix: str, member: str
+) -> None:
+    """A generic ZIP or renamed Office file is not enough."""
+    upload = tmp_path / f"office{suffix}"
+    with ZipFile(upload, "w") as archive:
+        archive.writestr("[Content_Types].xml", "<Types />")
+        archive.writestr(member, "<document />")
+
+    assert validate_upload(upload, suffix) == UPLOAD_MIME_BY_SUFFIX[suffix]
+
+    wrong_suffix = ".pptx" if suffix == ".docx" else ".docx"
+    with pytest.raises(ValueError, match="file contents do not match"):
+        validate_upload(upload, wrong_suffix)

--- a/surfsense_local/backend/worker/ingestion/parsing.py
+++ b/surfsense_local/backend/worker/ingestion/parsing.py
@@ -8,7 +8,7 @@ from modules.documents.storage import original_path
 from shared.config import get_storage_settings
 
 # Already text: read off disk rather than round-trip through Docling.
-TEXT_SUFFIXES = {".md", ".markdown", ".txt", ".text", ""}
+TEXT_SUFFIXES = {".md", ".markdown", ".txt", ".text"}
 
 
 def markdown_for(document: Document) -> str:
@@ -50,5 +50,15 @@ def _converter() -> Any:
     options.do_table_structure = True
 
     return DocumentConverter(
-        format_options={InputFormat.PDF: PdfFormatOption(pipeline_options=options)}
+        allowed_formats=[
+            InputFormat.PDF,
+            InputFormat.DOCX,
+            InputFormat.PPTX,
+            InputFormat.XLSX,
+            InputFormat.HTML,
+            InputFormat.CSV,
+            InputFormat.MD,
+            InputFormat.IMAGE,
+        ],
+        format_options={InputFormat.PDF: PdfFormatOption(pipeline_options=options)},
     )

--- a/surfsense_local/electron/package.json
+++ b/surfsense_local/electron/package.json
@@ -20,6 +20,7 @@
     "build:ollama": "node scripts/fetch-ollama.mjs",
     "build:llmfit": "node scripts/fetch-llmfit.mjs",
     "dist": "pnpm build:frontend && pnpm build:binaries && pnpm build:model && pnpm build:voice && pnpm build:ollama && pnpm build:llmfit && pnpm build && electron-builder",
+    "test": "node --test src/main/document-files.test.mts",
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "check:sidecars": "node scripts/check-sidecars.mjs",
     "check:llmfit": "node scripts/check-llmfit.mjs"

--- a/surfsense_local/electron/src/main/document-files.mts
+++ b/surfsense_local/electron/src/main/document-files.mts
@@ -1,0 +1,42 @@
+import { readdir } from "node:fs/promises"
+import { isAbsolute, join, relative, resolve } from "node:path"
+
+// The backend validates uploads before creating original.<suffix>. Do not copy
+// its format allowlist here: a newly supported upload should open immediately.
+const ORIGINAL_FILENAME = /^original\.[A-Za-z0-9]{1,16}$/
+
+function positiveInteger(value: unknown): value is number {
+  return Number.isInteger(value) && Number(value) > 0
+}
+
+export async function managedOriginalPath(
+  dataDir: string,
+  workspaceId: unknown,
+  documentId: unknown
+): Promise<string> {
+  if (!positiveInteger(workspaceId) || !positiveInteger(documentId)) {
+    throw new Error("Invalid source identifier.")
+  }
+
+  const documentsRoot = resolve(dataDir, "data", "workspaces")
+  const directory = resolve(
+    documentsRoot,
+    String(workspaceId),
+    "documents",
+    String(documentId)
+  )
+  const relativeDirectory = relative(documentsRoot, directory)
+  if (relativeDirectory.startsWith("..") || isAbsolute(relativeDirectory)) {
+    throw new Error("Invalid source location.")
+  }
+
+  const entries = await readdir(directory, { withFileTypes: true })
+  const originals = entries.filter(
+    (entry) => entry.isFile() && ORIGINAL_FILENAME.test(entry.name)
+  )
+  if (originals.length !== 1) {
+    throw new Error("The imported file is no longer available.")
+  }
+
+  return join(directory, originals[0].name)
+}

--- a/surfsense_local/electron/src/main/document-files.test.mts
+++ b/surfsense_local/electron/src/main/document-files.test.mts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict"
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import test from "node:test"
+
+import { managedOriginalPath } from "./document-files.mts"
+
+test("resolves a backend-managed original without duplicating its formats", async (t) => {
+  const dataDir = await mkdtemp(join(tmpdir(), "surfsense-document-"))
+  t.after(() => rm(dataDir, { force: true, recursive: true }))
+  const directory = join(dataDir, "data", "workspaces", "2", "documents", "7")
+  await mkdir(directory, { recursive: true })
+  const original = join(directory, "original.futureformat")
+  await writeFile(original, "validated by the backend")
+
+  assert.equal(await managedOriginalPath(dataDir, 2, 7), original)
+})
+
+test("rejects invalid identifiers and malformed original names", async (t) => {
+  const dataDir = await mkdtemp(join(tmpdir(), "surfsense-document-"))
+  t.after(() => rm(dataDir, { force: true, recursive: true }))
+  const directory = join(dataDir, "data", "workspaces", "2", "documents", "7")
+  await mkdir(directory, { recursive: true })
+  await writeFile(join(directory, "original.pdf.exe"), "not a managed original")
+
+  await assert.rejects(() => managedOriginalPath(dataDir, "../2", 7))
+  await assert.rejects(
+    () => managedOriginalPath(dataDir, 2, 7),
+    /no longer available/
+  )
+})
+
+test("requires exactly one regular original", async (t) => {
+  const dataDir = await mkdtemp(join(tmpdir(), "surfsense-document-"))
+  t.after(() => rm(dataDir, { force: true, recursive: true }))
+  const directory = join(dataDir, "data", "workspaces", "2", "documents", "7")
+  await mkdir(directory, { recursive: true })
+  await writeFile(join(directory, "original.pdf"), "%PDF-test")
+  await writeFile(join(directory, "original.txt"), "unexpected second original")
+
+  await assert.rejects(
+    () => managedOriginalPath(dataDir, 2, 7),
+    /no longer available/
+  )
+})

--- a/surfsense_local/electron/src/main/index.ts
+++ b/surfsense_local/electron/src/main/index.ts
@@ -9,7 +9,6 @@ import { apiSpec, workerSpec } from "./sidecars/python.ts"
 import { startAll, stopAll, type Sidecars } from "./sidecars/supervisor.ts"
 import type { SidecarContext, SidecarSpec } from "./sidecars/types.ts"
 
-const DEV_API_PORT = 8000
 const DEV_RENDERER_URL = "http://localhost:5173"
 
 let sidecars: Sidecars | null = null
@@ -24,7 +23,7 @@ function onSidecarCrash(name: string, code: number | null): void {
 async function bootSidecars(): Promise<string> {
   const host = "127.0.0.1"
   const packaged = app.isPackaged
-  const apiPort = packaged ? await getFreePort(host) : DEV_API_PORT
+  const apiPort = await getFreePort(host)
   // Dev keeps its own dir so testing never leaks into the real install's ~/.surfsense.
   const dataDir = join(app.getPath("home"), packaged ? ".surfsense" : ".surfsense-dev")
 

--- a/surfsense_local/electron/src/main/index.ts
+++ b/surfsense_local/electron/src/main/index.ts
@@ -1,7 +1,8 @@
 import { join } from "node:path"
 
-import { app, BrowserWindow } from "electron"
+import { app, BrowserWindow, ipcMain, shell } from "electron"
 
+import { managedOriginalPath } from "./document-files.mts"
 import { getFreePort, waitForHealth } from "./net.ts"
 import { ollamaSpec } from "./sidecars/ollama.ts"
 import { exe } from "./sidecars/platform.ts"
@@ -13,20 +14,27 @@ import { loadWindowState, saveWindowState } from "./window-state.ts"
 const DEV_RENDERER_URL = "http://localhost:5173"
 
 let sidecars: Sidecars | null = null
+let mainWindow: BrowserWindow | null = null
 let shuttingDown = false
 
 function onSidecarCrash(name: string, code: number | null): void {
   process.stderr.write(`[main] sidecar ${name} crashed (code=${code})\n`)
   // best-effort: let the renderer show an error instead of hanging
-  BrowserWindow.getAllWindows()[0]?.webContents.send("sidecar:crashed", { name, code })
+  BrowserWindow.getAllWindows()[0]?.webContents.send("sidecar:crashed", {
+    name,
+    code,
+  })
 }
 
-async function bootSidecars(): Promise<string> {
+async function bootSidecars(): Promise<{ apiUrl: string; dataDir: string }> {
   const host = "127.0.0.1"
   const packaged = app.isPackaged
   const apiPort = await getFreePort(host)
   // Dev keeps its own dir so testing never leaks into the real install's ~/.surfsense.
-  const dataDir = join(app.getPath("home"), packaged ? ".surfsense" : ".surfsense-dev")
+  const dataDir = join(
+    app.getPath("home"),
+    packaged ? ".surfsense" : ".surfsense-dev"
+  )
 
   const ctx: SidecarContext = {
     packaged,
@@ -53,14 +61,54 @@ async function bootSidecars(): Promise<string> {
 
   // ollamaSpec is null in dev (the developer runs their own `ollama serve`)
   const specs = [apiSpec(ctx), workerSpec(ctx), ollamaSpec(ctx)].filter(
-    (s): s is SidecarSpec => s !== null,
+    (s): s is SidecarSpec => s !== null
   )
   sidecars = startAll(specs, onSidecarCrash)
 
   // gate on the API only; fail fast if it dies during startup. Ollama is
   // best-effort (its state shows via /llm/providers; an early exit hits onSidecarCrash).
   await waitForHealth(host, apiPort, { child: sidecars.get("api") })
-  return `http://${host}:${apiPort}`
+  return { apiUrl: `http://${host}:${apiPort}`, dataDir }
+}
+
+function registerDocumentHandlers(dataDir: string): void {
+  const trusted = (sender: Electron.WebContents): boolean =>
+    mainWindow !== null && sender === mainWindow.webContents
+
+  ipcMain.handle("documents:open", async (event, workspaceId, documentId) => {
+    if (
+      !trusted(event.sender) ||
+      event.senderFrame !== event.sender.mainFrame
+    ) {
+      return "The source request did not come from the application."
+    }
+    try {
+      const path = await managedOriginalPath(dataDir, workspaceId, documentId)
+      return await shell.openPath(path)
+    } catch (error) {
+      return error instanceof Error
+        ? error.message
+        : "Couldn’t open the source."
+    }
+  })
+
+  ipcMain.handle("documents:reveal", async (event, workspaceId, documentId) => {
+    if (
+      !trusted(event.sender) ||
+      event.senderFrame !== event.sender.mainFrame
+    ) {
+      return "The source request did not come from the application."
+    }
+    try {
+      const path = await managedOriginalPath(dataDir, workspaceId, documentId)
+      shell.showItemInFolder(path)
+      return ""
+    } catch (error) {
+      return error instanceof Error
+        ? error.message
+        : "Couldn’t locate the source."
+    }
+  })
 }
 
 function createWindow(apiUrl: string): void {
@@ -73,6 +121,10 @@ function createWindow(apiUrl: string): void {
       preload: join(__dirname, "../preload/index.js"),
       additionalArguments: [`--surfsense-api-url=${apiUrl}`],
     },
+  })
+  mainWindow = win
+  win.on("closed", () => {
+    if (mainWindow === win) mainWindow = null
   })
 
   if (app.isPackaged) {
@@ -87,7 +139,9 @@ function createWindow(apiUrl: string): void {
   })
 
   if (app.isPackaged) {
-    void win.loadFile(join(app.getAppPath(), "..", "frontend", "dist", "index.html"))
+    void win.loadFile(
+      join(app.getAppPath(), "..", "frontend", "dist", "index.html")
+    )
   } else {
     void win.loadURL(DEV_RENDERER_URL)
   }
@@ -103,10 +157,12 @@ function main(): void {
   app
     .whenReady()
     .then(async () => {
-      const apiUrl = await bootSidecars()
-      createWindow(apiUrl)
+      const boot = await bootSidecars()
+      registerDocumentHandlers(boot.dataDir)
+      createWindow(boot.apiUrl)
       app.on("activate", () => {
-        if (BrowserWindow.getAllWindows().length === 0) createWindow(apiUrl)
+        if (BrowserWindow.getAllWindows().length === 0)
+          createWindow(boot.apiUrl)
       })
     })
     .catch((err: unknown) => {

--- a/surfsense_local/electron/src/main/index.ts
+++ b/surfsense_local/electron/src/main/index.ts
@@ -8,6 +8,7 @@ import { exe } from "./sidecars/platform.ts"
 import { apiSpec, workerSpec } from "./sidecars/python.ts"
 import { startAll, stopAll, type Sidecars } from "./sidecars/supervisor.ts"
 import type { SidecarContext, SidecarSpec } from "./sidecars/types.ts"
+import { loadWindowState, saveWindowState } from "./window-state.ts"
 
 const DEV_RENDERER_URL = "http://localhost:5173"
 
@@ -63,9 +64,9 @@ async function bootSidecars(): Promise<string> {
 }
 
 function createWindow(apiUrl: string): void {
+  const savedState = app.isPackaged ? loadWindowState() : null
   const win = new BrowserWindow({
-    width: 1280,
-    height: 800,
+    ...(savedState?.bounds ?? { width: 1280, height: 800 }),
     show: false,
     ...(process.platform === "darwin" && { titleBarStyle: "hiddenInset" }),
     webPreferences: {
@@ -74,7 +75,16 @@ function createWindow(apiUrl: string): void {
     },
   })
 
-  win.once("ready-to-show", () => win.show())
+  if (app.isPackaged) {
+    win.on("close", () => saveWindowState(win))
+  }
+
+  win.once("ready-to-show", () => {
+    if (app.isPackaged && (savedState?.maximized ?? true)) {
+      win.maximize()
+    }
+    win.show()
+  })
 
   if (app.isPackaged) {
     void win.loadFile(join(app.getAppPath(), "..", "frontend", "dist", "index.html"))

--- a/surfsense_local/electron/src/main/net.ts
+++ b/surfsense_local/electron/src/main/net.ts
@@ -1,6 +1,6 @@
 // Localhost networking helpers for bringing the API sidecar up: probe its
-// health, and (packaged only) pick a free port for it to bind.
-import { type ChildProcess } from "node:child_process"
+// health, and pick a free port for it to bind.
+import type { ChildProcess } from "node:child_process"
 import http from "node:http"
 import net from "node:net"
 
@@ -49,7 +49,7 @@ export async function waitForHealth(
   }
 }
 
-/** Ask the OS for an unused TCP port (packaged app; dev uses a fixed one). */
+/** Ask the OS for an unused TCP port. */
 export function getFreePort(host = "127.0.0.1"): Promise<number> {
   return new Promise((resolve, reject) => {
     const srv = net.createServer()

--- a/surfsense_local/electron/src/main/window-state.ts
+++ b/surfsense_local/electron/src/main/window-state.ts
@@ -1,0 +1,96 @@
+import { readFileSync, renameSync, writeFileSync } from "node:fs"
+import { join } from "node:path"
+
+import { app, type BrowserWindow, type Rectangle, screen } from "electron"
+
+export type WindowState = {
+  bounds: Rectangle
+  maximized: boolean
+}
+
+const MIN_WIDTH = 480
+const MIN_HEIGHT = 320
+
+function statePath(): string {
+  return join(app.getPath("userData"), "window-state.json")
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value)
+}
+
+function parseState(value: unknown): WindowState | null {
+  if (!value || typeof value !== "object") return null
+  const state = value as Partial<WindowState>
+  const bounds = state.bounds
+  if (
+    !bounds ||
+    !isFiniteNumber(bounds.x) ||
+    !isFiniteNumber(bounds.y) ||
+    !isFiniteNumber(bounds.width) ||
+    !isFiniteNumber(bounds.height) ||
+    bounds.width <= 0 ||
+    bounds.height <= 0 ||
+    typeof state.maximized !== "boolean"
+  ) {
+    return null
+  }
+  return { bounds, maximized: state.maximized }
+}
+
+function clamp(value: number, minimum: number, maximum: number): number {
+  return Math.min(Math.max(value, minimum), maximum)
+}
+
+function visibleBounds(bounds: Rectangle): Rectangle {
+  const workArea = screen.getDisplayMatching(bounds).workArea
+  const width = Math.min(
+    Math.max(Math.round(bounds.width), MIN_WIDTH),
+    workArea.width,
+  )
+  const height = Math.min(
+    Math.max(Math.round(bounds.height), MIN_HEIGHT),
+    workArea.height,
+  )
+  return {
+    x: clamp(
+      Math.round(bounds.x),
+      workArea.x,
+      workArea.x + workArea.width - width,
+    ),
+    y: clamp(
+      Math.round(bounds.y),
+      workArea.y,
+      workArea.y + workArea.height - height,
+    ),
+    width,
+    height,
+  }
+}
+
+export function loadWindowState(): WindowState | null {
+  try {
+    const state = parseState(JSON.parse(readFileSync(statePath(), "utf8")))
+    return state ? { ...state, bounds: visibleBounds(state.bounds) } : null
+  } catch {
+    return null
+  }
+}
+
+export function saveWindowState(win: BrowserWindow): void {
+  try {
+    const path = statePath()
+    const temporary = `${path}.tmp`
+    const state: WindowState = {
+      bounds: win.getNormalBounds(),
+      maximized: win.isMaximized(),
+    }
+    writeFileSync(temporary, JSON.stringify(state))
+    renameSync(temporary, path)
+  } catch (error) {
+    // ponytail: window state is best-effort; failing to save must never block exit.
+    process.stderr.write(
+      `[main] failed to save window state: ${String(error)}\n`,
+    )
+  }
+}

--- a/surfsense_local/electron/src/preload/index.ts
+++ b/surfsense_local/electron/src/preload/index.ts
@@ -1,4 +1,4 @@
-import { contextBridge } from "electron"
+import { contextBridge, ipcRenderer } from "electron"
 
 // main passes the API base URL via additionalArguments; read it back off argv
 const FLAG = "--surfsense-api-url="
@@ -8,4 +8,8 @@ const arg = process.argv.find((a) => a.startsWith(FLAG))
 contextBridge.exposeInMainWorld("surfsense", {
   apiUrl: arg ? arg.slice(FLAG.length) : "http://127.0.0.1:8000",
   platform: process.platform,
+  openDocument: (workspaceId: number, documentId: number): Promise<string> =>
+    ipcRenderer.invoke("documents:open", workspaceId, documentId),
+  revealDocument: (workspaceId: number, documentId: number): Promise<string> =>
+    ipcRenderer.invoke("documents:reveal", workspaceId, documentId),
 })

--- a/surfsense_local/frontend/package.json
+++ b/surfsense_local/frontend/package.json
@@ -32,6 +32,7 @@
     "react-dom": "^19.2.6",
     "shadcn": "^4.20.1",
     "sonner": "^2.0.8",
+    "streamdown": "^2.6.0",
     "tailwind-merge": "^3.6.0",
     "tailwindcss": "^4",
     "tw-animate-css": "^1.4.0"

--- a/surfsense_local/frontend/pnpm-lock.yaml
+++ b/surfsense_local/frontend/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       sonner:
         specifier: ^2.0.8
         version: 2.0.8(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      streamdown:
+        specifier: ^2.6.0
+        version: 2.6.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0

--- a/surfsense_local/frontend/src/app/app-bootstrap.tsx
+++ b/surfsense_local/frontend/src/app/app-bootstrap.tsx
@@ -1,8 +1,8 @@
 import { lazy, Suspense, useEffect, useState } from "react"
-import { ServerOffIcon } from "@/components/ui/icons"
 
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { Button } from "@/components/ui/button"
+import { ServerOffIcon } from "@/components/ui/icons"
 import { Skeleton } from "@/components/ui/skeleton"
 import {
   getGenerationSelection,
@@ -46,7 +46,7 @@ async function fetchBootstrapState(): Promise<BootstrapState> {
 
 function ShellSkeleton() {
   return (
-    <main className="grid h-svh min-w-[1120px] grid-cols-[56px_272px_minmax(520px,1fr)_320px] overflow-hidden">
+    <main className="grid h-full min-w-[1120px] grid-cols-[56px_272px_minmax(520px,1fr)_320px] overflow-hidden">
       <Skeleton className="h-full rounded-none" />
       <div className="space-y-4 border-r p-4">
         <Skeleton className="h-8 w-full" />
@@ -103,7 +103,7 @@ export function AppBootstrap() {
 
   if (state.status === "error") {
     return (
-      <main className="flex min-h-svh items-center justify-center bg-muted/30 p-8">
+      <main className="flex min-h-full items-center justify-center bg-muted/30 p-8">
         <Alert variant="destructive" className="max-w-lg">
           <ServerOffIcon />
           <AlertTitle>SurfSense Local could not start</AlertTitle>

--- a/surfsense_local/frontend/src/components/relative-time.tsx
+++ b/surfsense_local/frontend/src/components/relative-time.tsx
@@ -1,0 +1,96 @@
+import { useSyncExternalStore } from "react"
+
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
+import { cn } from "@/lib/utils"
+
+const formatter = new Intl.RelativeTimeFormat(undefined, {
+  numeric: "auto",
+  style: "long",
+})
+const units: [number, Intl.RelativeTimeFormatUnit][] = [
+  [60, "minute"],
+  [24, "hour"],
+  [7, "day"],
+  [4.345, "week"],
+  [12, "month"],
+  [Number.POSITIVE_INFINITY, "year"],
+]
+
+let now = Date.now()
+let clock: number | undefined
+const listeners = new Set<() => void>()
+
+function subscribe(listener: () => void) {
+  listeners.add(listener)
+  if (listeners.size === 1) {
+    now = Date.now()
+    clock = window.setInterval(() => {
+      now = Date.now()
+      listeners.forEach((notify) => {
+        notify()
+      })
+    }, 60_000)
+  }
+  return () => {
+    listeners.delete(listener)
+    if (listeners.size === 0) {
+      window.clearInterval(clock)
+      clock = undefined
+    }
+  }
+}
+
+function formatRelativeTime(date: Date, currentTime: number) {
+  const seconds = (date.getTime() - currentTime) / 1000
+  if (Math.abs(seconds) < 60) {
+    return "just now"
+  }
+
+  let value = seconds / 60
+  for (const [limit, unit] of units) {
+    if (Math.abs(value) < limit) {
+      return formatter.format(Math.round(value), unit)
+    }
+    value /= limit
+  }
+}
+
+export function RelativeTime({
+  date,
+  className,
+}: {
+  date: Date
+  className?: string
+}) {
+  const currentTime = useSyncExternalStore(
+    subscribe,
+    () => now,
+    () => now
+  )
+  const exactTime = date.toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: true,
+  })
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <time
+          dateTime={date.toISOString()}
+          className={cn("cursor-default text-xs", className)}
+        >
+          {formatRelativeTime(date, currentTime)}
+        </time>
+      </TooltipTrigger>
+      <TooltipContent side="bottom">{exactTime}</TooltipContent>
+    </Tooltip>
+  )
+}

--- a/surfsense_local/frontend/src/components/relative-time.tsx
+++ b/surfsense_local/frontend/src/components/relative-time.tsx
@@ -85,12 +85,15 @@ export function RelativeTime({
       <TooltipTrigger asChild>
         <time
           dateTime={date.toISOString()}
-          className={cn("cursor-default text-xs", className)}
+          className={cn(
+            "inline-flex h-7 cursor-default items-center text-xs",
+            className
+          )}
         >
           {formatRelativeTime(date, currentTime)}
         </time>
       </TooltipTrigger>
-      <TooltipContent side="bottom">{exactTime}</TooltipContent>
+      <TooltipContent>{exactTime}</TooltipContent>
     </Tooltip>
   )
 }

--- a/surfsense_local/frontend/src/components/typewriter-text.test.tsx
+++ b/surfsense_local/frontend/src/components/typewriter-text.test.tsx
@@ -21,7 +21,7 @@ describe("TypewriterText", () => {
     reducedMotion(false)
     const view = render(<TypewriterText text="New chat" />)
 
-    view.rerender(<TypewriterText text="Revenue Growth" />)
+    view.rerender(<TypewriterText text="Revenue Growth" animate />)
 
     const visual = view.container.querySelector('[aria-hidden="true"]')
     expect(visual?.textContent).toBe("")
@@ -40,10 +40,21 @@ describe("TypewriterText", () => {
     reducedMotion(true)
     const view = render(<TypewriterText text="New chat" />)
 
-    view.rerender(<TypewriterText text="Revenue Growth" />)
+    view.rerender(<TypewriterText text="Revenue Growth" animate />)
 
     expect(
       view.container.querySelector('[aria-hidden="true"]')?.textContent
     ).toBe("Revenue Growth")
+  })
+
+  it("shows database and manual titles without animation", () => {
+    reducedMotion(false)
+    const view = render(<TypewriterText text="Saved title" />)
+
+    view.rerender(<TypewriterText text="Renamed title" />)
+
+    expect(
+      view.container.querySelector('[aria-hidden="true"]')?.textContent
+    ).toBe("Renamed title")
   })
 })

--- a/surfsense_local/frontend/src/components/typewriter-text.test.tsx
+++ b/surfsense_local/frontend/src/components/typewriter-text.test.tsx
@@ -1,0 +1,49 @@
+import { act, render } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { TypewriterText } from "./typewriter-text"
+
+function reducedMotion(matches: boolean) {
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    value: vi.fn().mockReturnValue({ matches }),
+  })
+}
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+})
+
+describe("TypewriterText", () => {
+  it("clears the placeholder before revealing the generated title", () => {
+    vi.useFakeTimers()
+    reducedMotion(false)
+    const view = render(<TypewriterText text="New chat" />)
+
+    view.rerender(<TypewriterText text="Revenue Growth" />)
+
+    const visual = view.container.querySelector('[aria-hidden="true"]')
+    expect(visual?.textContent).toBe("")
+    expect(view.container.querySelector(".sr-only")?.textContent).toBe(
+      "Revenue Growth"
+    )
+
+    act(() => vi.advanceTimersByTime(35))
+    expect(visual?.textContent).toBe("R")
+
+    act(() => vi.runAllTimers())
+    expect(visual?.textContent).toBe("Revenue Growth")
+  })
+
+  it("shows the final title immediately when reduced motion is requested", () => {
+    reducedMotion(true)
+    const view = render(<TypewriterText text="New chat" />)
+
+    view.rerender(<TypewriterText text="Revenue Growth" />)
+
+    expect(
+      view.container.querySelector('[aria-hidden="true"]')?.textContent
+    ).toBe("Revenue Growth")
+  })
+})

--- a/surfsense_local/frontend/src/components/typewriter-text.tsx
+++ b/surfsense_local/frontend/src/components/typewriter-text.tsx
@@ -1,0 +1,45 @@
+import { useEffect, useRef, useState } from "react"
+
+const REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)"
+
+function useTypewriter(text: string, placeholder = "New chat", speed = 35) {
+  const [displayed, setDisplayed] = useState(text)
+  const previous = useRef(text)
+
+  useEffect(() => {
+    const prior = previous.current
+    previous.current = text
+    if (
+      prior !== placeholder ||
+      text === placeholder ||
+      !text ||
+      window.matchMedia?.(REDUCED_MOTION_QUERY).matches
+    ) {
+      setDisplayed(text)
+      return
+    }
+
+    setDisplayed("")
+    let length = 0
+    const interval = window.setInterval(() => {
+      length += 1
+      setDisplayed(text.slice(0, length))
+      if (length >= text.length) {
+        window.clearInterval(interval)
+      }
+    }, speed)
+    return () => window.clearInterval(interval)
+  }, [placeholder, speed, text])
+
+  return displayed
+}
+
+export function TypewriterText({ text }: { text: string }) {
+  const displayed = useTypewriter(text)
+  return (
+    <>
+      <span className="sr-only">{text}</span>
+      <span aria-hidden="true">{displayed}</span>
+    </>
+  )
+}

--- a/surfsense_local/frontend/src/components/typewriter-text.tsx
+++ b/surfsense_local/frontend/src/components/typewriter-text.tsx
@@ -1,45 +1,62 @@
-import { useEffect, useRef, useState } from "react"
+import { useEffect, useState } from "react"
 
 const REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)"
 
-function useTypewriter(text: string, placeholder = "New chat", speed = 35) {
-  const [displayed, setDisplayed] = useState(text)
-  const previous = useRef(text)
-
+function AnimatedText({
+  text,
+  onComplete,
+  speed = 35,
+}: {
+  text: string
+  onComplete?: () => void
+  speed?: number
+}) {
+  const [length, setLength] = useState(0)
   useEffect(() => {
-    const prior = previous.current
-    previous.current = text
-    if (
-      prior !== placeholder ||
-      text === placeholder ||
-      !text ||
-      window.matchMedia?.(REDUCED_MOTION_QUERY).matches
-    ) {
-      setDisplayed(text)
-      return
-    }
-
-    setDisplayed("")
-    let length = 0
+    let next = 0
     const interval = window.setInterval(() => {
-      length += 1
-      setDisplayed(text.slice(0, length))
-      if (length >= text.length) {
+      next += 1
+      setLength(next)
+      if (next >= text.length) {
         window.clearInterval(interval)
+        onComplete?.()
       }
     }, speed)
     return () => window.clearInterval(interval)
-  }, [placeholder, speed, text])
+  }, [onComplete, speed, text])
 
-  return displayed
+  return <span aria-hidden="true">{text.slice(0, length)}</span>
 }
 
-export function TypewriterText({ text }: { text: string }) {
-  const displayed = useTypewriter(text)
+function CompleteAnimation({ onComplete }: { onComplete?: () => void }) {
+  useEffect(() => {
+    onComplete?.()
+  }, [onComplete])
+  return null
+}
+
+export function TypewriterText({
+  text,
+  animate = false,
+  onComplete,
+}: {
+  text: string
+  animate?: boolean
+  onComplete?: () => void
+}) {
+  const reducedMotion =
+    window.matchMedia?.(REDUCED_MOTION_QUERY).matches ?? false
   return (
     <>
       <span className="sr-only">{text}</span>
-      <span aria-hidden="true">{displayed}</span>
+      {animate && !reducedMotion ? (
+        <AnimatedText text={text} onComplete={onComplete} />
+      ) : (
+        <span aria-hidden="true">{text}</span>
+      )}
+      {animate && reducedMotion ? (
+        <CompleteAnimation onComplete={onComplete} />
+      ) : null}
     </>
   )
 }

--- a/surfsense_local/frontend/src/components/ui/dialog.tsx
+++ b/surfsense_local/frontend/src/components/ui/dialog.tsx
@@ -1,5 +1,5 @@
-import * as React from "react"
 import { Dialog as DialogPrimitive } from "radix-ui"
+import type * as React from "react"
 
 import { Button } from "@/components/ui/button"
 import { XIcon } from "@/components/ui/icons"

--- a/surfsense_local/frontend/src/components/ui/icons.tsx
+++ b/surfsense_local/frontend/src/components/ui/icons.tsx
@@ -22,6 +22,7 @@ import {
   Loading03Icon,
   MessageSquareIcon as MessageSquareIconData,
   NotebookTextIcon as NotebookTextIconData,
+  PencilEdit02Icon as PencilEdit02IconData,
   PencilIcon as PencilIconData,
   PlusIcon as PlusIconData,
   RefreshCwIcon as RefreshCwIconData,
@@ -78,6 +79,7 @@ export const LayoutGridIcon = createIcon(LayoutGridIconData)
 export const Loader2Icon = createIcon(Loading03Icon)
 export const MessageSquareIcon = createIcon(MessageSquareIconData)
 export const NotebookTextIcon = createIcon(NotebookTextIconData)
+export const PencilEdit02Icon = createIcon(PencilEdit02IconData)
 export const PencilIcon = createIcon(PencilIconData)
 export const PlusIcon = createIcon(PlusIconData)
 export const RefreshCwIcon = createIcon(RefreshCwIconData)

--- a/surfsense_local/frontend/src/components/ui/icons.tsx
+++ b/surfsense_local/frontend/src/components/ui/icons.tsx
@@ -10,6 +10,7 @@ import {
   CheckmarkCircle02Icon,
   ChevronDownIcon as ChevronDownIconData,
   ChevronRightIcon as ChevronRightIconData,
+  Copy01Icon,
   Delete02Icon,
   DownloadIcon as DownloadIconData,
   EllipsisIcon as EllipsisIconData,
@@ -52,6 +53,7 @@ export const ChevronDownIcon = createIcon(ChevronDownIconData)
 export const ChevronRightIcon = createIcon(ChevronRightIconData)
 export const CircleAlertIcon = createIcon(AlertCircleIcon)
 export const CircleStopIcon = createIcon(StopCircleIcon)
+export const CopyIcon = createIcon(Copy01Icon)
 export const DownloadIcon = createIcon(DownloadIconData)
 export const EllipsisIcon = createIcon(EllipsisIconData)
 export const FileIcon = createIcon(FileIconData)

--- a/surfsense_local/frontend/src/components/ui/icons.tsx
+++ b/surfsense_local/frontend/src/components/ui/icons.tsx
@@ -26,6 +26,7 @@ import {
   RefreshCwIcon as RefreshCwIconData,
   ServerOffIcon as ServerOffIconData,
   Settings02Icon,
+  SparklesIcon as SparklesIconData,
   StopCircleIcon,
   XIcon as XIconData,
 } from "@hugeicons/core-free-icons"
@@ -66,5 +67,6 @@ export const PlusIcon = createIcon(PlusIconData)
 export const RefreshCwIcon = createIcon(RefreshCwIconData)
 export const ServerOffIcon = createIcon(ServerOffIconData)
 export const Settings2Icon = createIcon(Settings02Icon)
+export const SparklesIcon = createIcon(SparklesIconData)
 export const Trash2Icon = createIcon(Delete02Icon)
 export const XIcon = createIcon(XIconData)

--- a/surfsense_local/frontend/src/components/ui/icons.tsx
+++ b/surfsense_local/frontend/src/components/ui/icons.tsx
@@ -34,11 +34,25 @@ import {
 import { HugeiconsIcon } from "@hugeicons/react"
 
 type IconData = React.ComponentProps<typeof HugeiconsIcon>["icon"]
-type IconProps = Omit<React.ComponentProps<typeof HugeiconsIcon>, "icon">
+type IconProps = Omit<
+  React.ComponentProps<typeof HugeiconsIcon>,
+  "icon" | "strokeWidth"
+> & {
+  strokeWidth?: React.SVGProps<SVGSVGElement>["strokeWidth"]
+}
 
 function createIcon(icon: IconData) {
-  return React.forwardRef<SVGSVGElement, IconProps>(function Icon(props, ref) {
-    return <HugeiconsIcon ref={ref} icon={icon} strokeWidth={2} {...props} />
+  return React.forwardRef<SVGSVGElement, IconProps>(function Icon(
+    { strokeWidth = 2, ...props },
+    ref
+  ) {
+    const width =
+      typeof strokeWidth === "number"
+        ? strokeWidth
+        : Number.parseFloat(strokeWidth) || 2
+    return (
+      <HugeiconsIcon ref={ref} icon={icon} strokeWidth={width} {...props} />
+    )
   })
 }
 

--- a/surfsense_local/frontend/src/components/ui/modal-layout.test.tsx
+++ b/surfsense_local/frontend/src/components/ui/modal-layout.test.tsx
@@ -1,0 +1,60 @@
+import type { ReactElement } from "react"
+import { afterEach, describe, expect, it } from "vitest"
+import { cleanup, render, waitFor } from "@testing-library/react"
+
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogTitle,
+} from "./alert-dialog"
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from "./dialog"
+
+const modals: [string, () => ReactElement][] = [
+  [
+    "dialog",
+    () => (
+      <Dialog defaultOpen>
+        <DialogContent>
+          <DialogTitle>Dialog</DialogTitle>
+          <DialogDescription>Dialog content</DialogDescription>
+        </DialogContent>
+      </Dialog>
+    ),
+  ],
+  [
+    "alert dialog",
+    () => (
+      <AlertDialog defaultOpen>
+        <AlertDialogContent>
+          <AlertDialogTitle>Alert dialog</AlertDialogTitle>
+          <AlertDialogDescription>Alert dialog content</AlertDialogDescription>
+        </AlertDialogContent>
+      </AlertDialog>
+    ),
+  ],
+]
+
+afterEach(() => {
+  cleanup()
+  document.documentElement.classList.remove("electron-macos")
+  document.body.replaceChildren()
+})
+
+describe.each(modals)("%s app-shell layout", (_name, renderModal) => {
+  it("keeps Electron title-bar spacing off the scroll-locked body", async () => {
+    document.documentElement.classList.add("electron-macos")
+    const root = document.createElement("div")
+    root.id = "root"
+    root.style.paddingTop = "28px"
+    document.body.append(root)
+
+    render(renderModal(), { container: root })
+
+    await waitFor(() =>
+      expect(document.body.hasAttribute("data-scroll-locked")).toBe(true)
+    )
+    expect(getComputedStyle(document.body).paddingTop).toBe("0px")
+    expect(getComputedStyle(root).paddingTop).toBe("28px")
+  })
+})

--- a/surfsense_local/frontend/src/components/ui/sonner.tsx
+++ b/surfsense_local/frontend/src/components/ui/sonner.tsx
@@ -1,7 +1,6 @@
 import { Toaster as Sonner, type ToasterProps } from "sonner"
-
-import { CheckCircle2Icon } from "@/components/ui/icons"
 import { useTheme } from "@/components/theme-provider"
+import { CheckCircle2Icon } from "@/components/ui/icons"
 
 function Toaster(props: ToasterProps) {
   const { theme } = useTheme()
@@ -10,7 +9,7 @@ function Toaster(props: ToasterProps) {
     <Sonner
       theme={theme}
       className="toaster group"
-      icons={{ success: <CheckCircle2Icon /> }}
+      icons={{ success: <CheckCircle2Icon className="size-4" /> }}
       style={
         {
           "--normal-bg": "var(--popover)",

--- a/surfsense_local/frontend/src/components/ui/sonner.tsx
+++ b/surfsense_local/frontend/src/components/ui/sonner.tsx
@@ -1,0 +1,27 @@
+import { Toaster as Sonner, type ToasterProps } from "sonner"
+
+import { CheckCircle2Icon } from "@/components/ui/icons"
+import { useTheme } from "@/components/theme-provider"
+
+function Toaster(props: ToasterProps) {
+  const { theme } = useTheme()
+
+  return (
+    <Sonner
+      theme={theme}
+      className="toaster group"
+      icons={{ success: <CheckCircle2Icon /> }}
+      style={
+        {
+          "--normal-bg": "var(--popover)",
+          "--normal-text": "var(--popover-foreground)",
+          "--normal-border": "var(--border)",
+          "--border-radius": "var(--radius)",
+        } as React.CSSProperties
+      }
+      {...props}
+    />
+  )
+}
+
+export { Toaster }

--- a/surfsense_local/frontend/src/components/ui/tooltip.tsx
+++ b/surfsense_local/frontend/src/components/ui/tooltip.tsx
@@ -1,18 +1,20 @@
 "use client"
 
-import * as React from "react"
+import type * as React from "react"
 import { Tooltip as TooltipPrimitive } from "radix-ui"
 
 import { cn } from "@/lib/utils"
 
 function TooltipProvider({
   delayDuration = 0,
+  disableHoverableContent = true,
   ...props
 }: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
   return (
     <TooltipPrimitive.Provider
       data-slot="tooltip-provider"
       delayDuration={delayDuration}
+      disableHoverableContent={disableHoverableContent}
       {...props}
     />
   )
@@ -32,7 +34,7 @@ function TooltipTrigger({
 
 function TooltipContent({
   className,
-  sideOffset = 0,
+  sideOffset = 4,
   children,
   ...props
 }: React.ComponentProps<typeof TooltipPrimitive.Content>) {
@@ -42,13 +44,12 @@ function TooltipContent({
         data-slot="tooltip-content"
         sideOffset={sideOffset}
         className={cn(
-          "z-50 inline-flex w-fit max-w-xs origin-(--radix-tooltip-content-transform-origin) items-center gap-1.5 rounded-md bg-foreground px-3 py-1.5 text-xs text-background has-data-[slot=kbd]:pr-1.5 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          "pointer-events-none z-50 w-fit rounded-md border border-border bg-popover px-3 py-1.5 text-xs font-medium text-pretty text-popover-foreground select-none data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95",
           className
         )}
         {...props}
       >
         {children}
-        <TooltipPrimitive.Arrow className="z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px] bg-foreground fill-foreground" />
       </TooltipPrimitive.Content>
     </TooltipPrimitive.Portal>
   )

--- a/surfsense_local/frontend/src/features/chat/api.ts
+++ b/surfsense_local/frontend/src/features/chat/api.ts
@@ -63,6 +63,19 @@ export function deleteThread(
   })
 }
 
+export function renameThread(
+  threadId: number,
+  title: string,
+  signal?: AbortSignal
+): Promise<ChatThread> {
+  return requestJson<ChatThread>(`/chat/threads/${threadId}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ title }),
+    signal,
+  })
+}
+
 export async function streamMessage(
   threadId: number,
   text: string,

--- a/surfsense_local/frontend/src/features/chat/api.ts
+++ b/surfsense_local/frontend/src/features/chat/api.ts
@@ -19,7 +19,8 @@ export type ChatMessage = {
   id: number | string
   role: "user" | "assistant" | "system"
   content: MessageContent
-  created_at: string
+  created_at: string | null
+  completed_at: string | null
 }
 
 export function listThreads(

--- a/surfsense_local/frontend/src/features/chat/chat-composer.tsx
+++ b/surfsense_local/frontend/src/features/chat/chat-composer.tsx
@@ -9,6 +9,70 @@ import {
 import type { ModelSelection } from "@/features/model-selection/api"
 import { cn } from "@/lib/utils"
 
+function ModelButton({
+  model,
+  providerAvailable,
+  onModelSetup,
+  className,
+}: {
+  model: ModelSelection
+  providerAvailable: boolean
+  onModelSetup: () => void
+  className?: string
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onModelSetup}
+      className={cn(
+        "flex shrink-0 cursor-pointer items-center gap-1.5 rounded-lg px-1.5 py-1 text-[11px] font-normal text-muted-foreground hover:bg-accent hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/20 focus-visible:outline-none",
+        className
+      )}
+      title="Change model"
+      aria-label={`Model ${model.name} on ${model.provider}. Change model.`}
+    >
+      <span>{model.name}</span>
+      <span>{providerAvailable ? model.provider : "Provider offline"}</span>
+      <ChevronDownIcon className="size-3" />
+    </button>
+  )
+}
+
+function ComposerAction({
+  isRunning,
+  className,
+}: {
+  isRunning: boolean
+  className?: string
+}) {
+  if (!isRunning) {
+    return (
+      <ComposerPrimitive.Send asChild>
+        <Button
+          size="icon-lg"
+          className={cn("rounded-xl", className)}
+          aria-label="Send message"
+        >
+          <ArrowUp02Icon />
+        </Button>
+      </ComposerPrimitive.Send>
+    )
+  }
+
+  return (
+    <ComposerPrimitive.Cancel asChild>
+      <Button
+        size="icon-lg"
+        variant="secondary"
+        className={cn("rounded-xl", className)}
+        aria-label="Stop generating"
+      >
+        <CircleStopIcon />
+      </Button>
+    </ComposerPrimitive.Cancel>
+  )
+}
+
 export function ChatComposer({
   placement,
   model,
@@ -23,12 +87,22 @@ export function ChatComposer({
   onModelSetup: () => void
 }) {
   return (
-    <div data-composer-placement={placement}>
-      <ComposerPrimitive.Root className="flex items-end gap-2 rounded-2xl border bg-card p-1.5 shadow-sm focus-within:ring-2 focus-within:ring-ring/20">
+    <div
+      className="mx-auto w-full max-w-xl"
+      data-composer-placement={placement}
+    >
+      <ComposerPrimitive.Root
+        className={cn(
+          "relative rounded-2xl border bg-card p-1.5 shadow-sm focus-within:ring-2 focus-within:ring-ring/20",
+          placement === "bottom" && "flex items-end gap-2"
+        )}
+      >
         <ComposerPrimitive.Input
           className={cn(
-            "max-h-44 flex-1 resize-none bg-transparent px-2 py-2.5 text-sm outline-none placeholder:text-muted-foreground",
-            placement === "center" ? "min-h-28" : "min-h-10"
+            "max-h-44 resize-none bg-transparent px-2 py-2.5 text-sm outline-none placeholder:text-muted-foreground",
+            placement === "center"
+              ? "block min-h-20 w-full pb-12"
+              : "min-h-10 flex-1"
           )}
           placeholder={
             providerAvailable
@@ -39,47 +113,34 @@ export function ChatComposer({
           rows={1}
           aria-label="Message"
         />
-        {!isRunning ? (
-          <ComposerPrimitive.Send asChild>
-            <Button
-              size="icon-lg"
-              className="mb-0.5 rounded-xl"
-              aria-label="Send message"
-            >
-              <ArrowUp02Icon />
-            </Button>
-          </ComposerPrimitive.Send>
+        {placement === "center" ? (
+          <div className="absolute right-1.5 bottom-2 flex items-center gap-2">
+            <ModelButton
+              model={model}
+              providerAvailable={providerAvailable}
+              onModelSetup={onModelSetup}
+              className="h-9 rounded-xl px-3 text-sm"
+            />
+            <ComposerAction isRunning={isRunning} />
+          </div>
         ) : (
-          <ComposerPrimitive.Cancel asChild>
-            <Button
-              size="icon-lg"
-              variant="secondary"
-              className="mb-0.5 rounded-xl"
-              aria-label="Stop generating"
-            >
-              <CircleStopIcon />
-            </Button>
-          </ComposerPrimitive.Cancel>
+          <ComposerAction isRunning={isRunning} className="mb-0.5" />
         )}
       </ComposerPrimitive.Root>
-      <div className="mt-1 flex min-h-7 items-center justify-between gap-3 px-2">
-        <p className="min-w-0 text-left text-[11px] text-muted-foreground">
-          {providerAvailable
-            ? `${model.name} runs locally. Check important answers.`
-            : "Historical chats remain available while the provider is offline."}
-        </p>
-        <button
-          type="button"
-          onClick={onModelSetup}
-          className="flex shrink-0 cursor-pointer items-center gap-1.5 rounded-lg px-1.5 py-1 text-[11px] font-normal text-muted-foreground hover:bg-accent hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/20 focus-visible:outline-none"
-          title="Change model"
-          aria-label={`Model ${model.name} on ${model.provider}. Change model.`}
-        >
-          <span>{model.name}</span>
-          <span>{providerAvailable ? model.provider : "Provider offline"}</span>
-          <ChevronDownIcon className="size-3" />
-        </button>
-      </div>
+      {placement === "bottom" ? (
+        <div className="mt-1 flex min-h-7 items-center justify-between gap-3 px-2">
+          <p className="min-w-0 text-left text-[11px] text-muted-foreground">
+            {providerAvailable
+              ? `${model.name} runs locally. Check important answers.`
+              : "Historical chats remain available while the provider is offline."}
+          </p>
+          <ModelButton
+            model={model}
+            providerAvailable={providerAvailable}
+            onModelSetup={onModelSetup}
+          />
+        </div>
+      ) : null}
     </div>
   )
 }

--- a/surfsense_local/frontend/src/features/chat/chat-composer.tsx
+++ b/surfsense_local/frontend/src/features/chat/chat-composer.tsx
@@ -1,0 +1,85 @@
+import { ComposerPrimitive } from "@assistant-ui/react"
+
+import { Button } from "@/components/ui/button"
+import {
+  ArrowUp02Icon,
+  ChevronDownIcon,
+  CircleStopIcon,
+} from "@/components/ui/icons"
+import type { ModelSelection } from "@/features/model-selection/api"
+import { cn } from "@/lib/utils"
+
+export function ChatComposer({
+  placement,
+  model,
+  isRunning,
+  providerAvailable,
+  onModelSetup,
+}: {
+  placement: "center" | "bottom"
+  model: ModelSelection
+  isRunning: boolean
+  providerAvailable: boolean
+  onModelSetup: () => void
+}) {
+  return (
+    <div data-composer-placement={placement}>
+      <ComposerPrimitive.Root className="flex items-end gap-2 rounded-2xl border bg-card p-1.5 shadow-sm focus-within:ring-2 focus-within:ring-ring/20">
+        <ComposerPrimitive.Input
+          className={cn(
+            "max-h-44 flex-1 resize-none bg-transparent px-2 py-2.5 text-sm outline-none placeholder:text-muted-foreground",
+            placement === "center" ? "min-h-28" : "min-h-10"
+          )}
+          placeholder={
+            providerAvailable
+              ? "Ask SurfSense about anything"
+              : "Reconnect your model provider to send"
+          }
+          submitMode="enter"
+          rows={1}
+          aria-label="Message"
+        />
+        {!isRunning ? (
+          <ComposerPrimitive.Send asChild>
+            <Button
+              size="icon-lg"
+              className="mb-0.5 rounded-xl"
+              aria-label="Send message"
+            >
+              <ArrowUp02Icon />
+            </Button>
+          </ComposerPrimitive.Send>
+        ) : (
+          <ComposerPrimitive.Cancel asChild>
+            <Button
+              size="icon-lg"
+              variant="secondary"
+              className="mb-0.5 rounded-xl"
+              aria-label="Stop generating"
+            >
+              <CircleStopIcon />
+            </Button>
+          </ComposerPrimitive.Cancel>
+        )}
+      </ComposerPrimitive.Root>
+      <div className="mt-1 flex min-h-7 items-center justify-between gap-3 px-2">
+        <p className="min-w-0 text-left text-[11px] text-muted-foreground">
+          {providerAvailable
+            ? `${model.name} runs locally. Check important answers.`
+            : "Historical chats remain available while the provider is offline."}
+        </p>
+        <button
+          type="button"
+          onClick={onModelSetup}
+          className="flex shrink-0 cursor-pointer items-center gap-1.5 rounded-lg px-1.5 py-1 text-[11px] font-normal text-muted-foreground hover:bg-accent hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/20 focus-visible:outline-none"
+          title="Change model"
+          aria-label={`Model ${model.name} on ${model.provider}. Change model.`}
+        >
+          <span>{model.name}</span>
+          <span>{providerAvailable ? model.provider : "Provider offline"}</span>
+          <ChevronDownIcon className="size-3" />
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/surfsense_local/frontend/src/features/chat/chat-viewport.tsx
+++ b/surfsense_local/frontend/src/features/chat/chat-viewport.tsx
@@ -28,6 +28,7 @@ export function ChatViewport({
 }) {
   return (
     <ThreadPrimitive.Viewport
+      turnAnchor="top"
       className="relative flex min-h-0 flex-1 flex-col overflow-y-auto px-4"
       style={{ scrollbarGutter: "stable" }}
       autoScroll

--- a/surfsense_local/frontend/src/features/chat/chat-viewport.tsx
+++ b/surfsense_local/frontend/src/features/chat/chat-viewport.tsx
@@ -2,11 +2,10 @@ import { ThreadPrimitive } from "@assistant-ui/react"
 import type { ReactNode } from "react"
 import { Button } from "@/components/ui/button"
 import { ArrowDownIcon } from "@/components/ui/icons"
-import { cn } from "@/lib/utils"
 
 function ScrollToBottom() {
   return (
-    <ThreadPrimitive.ScrollToBottom asChild>
+    <ThreadPrimitive.ScrollToBottom behavior="smooth" asChild>
       <Button
         type="button"
         variant="outline"
@@ -28,29 +27,24 @@ export function ChatViewport({
   footer?: ReactNode
 }) {
   return (
-    <>
-      <ThreadPrimitive.Viewport
-        className={cn(
-          "relative flex min-h-0 flex-1 flex-col overflow-y-auto px-4",
-          footer && "pb-8"
-        )}
-        style={{ scrollbarGutter: "stable" }}
-        autoScroll
-        scrollToBottomOnRunStart
-        scrollToBottomOnInitialize
-        scrollToBottomOnThreadSwitch
-        data-chat-viewport
-      >
-        {children}
-      </ThreadPrimitive.Viewport>
+    <ThreadPrimitive.Viewport
+      className="relative flex min-h-0 flex-1 flex-col overflow-y-auto px-4"
+      style={{ scrollbarGutter: "stable" }}
+      autoScroll
+      scrollToBottomOnRunStart
+      scrollToBottomOnInitialize
+      scrollToBottomOnThreadSwitch
+      data-chat-viewport
+    >
+      {children}
       {footer ? (
-        <div className="relative z-20 shrink-0 bg-gradient-to-t from-background via-background to-transparent px-4 pb-2">
+        <ThreadPrimitive.ViewportFooter className="sticky bottom-0 z-20 -mx-4 mt-auto shrink-0 bg-gradient-to-t from-background via-background to-transparent px-4 pb-1">
           <div className="relative mx-auto w-full max-w-2xl">
             <ScrollToBottom />
             {footer}
           </div>
-        </div>
+        </ThreadPrimitive.ViewportFooter>
       ) : null}
-    </>
+    </ThreadPrimitive.Viewport>
   )
 }

--- a/surfsense_local/frontend/src/features/chat/chat-viewport.tsx
+++ b/surfsense_local/frontend/src/features/chat/chat-viewport.tsx
@@ -2,6 +2,7 @@ import { ThreadPrimitive } from "@assistant-ui/react"
 import type { ReactNode } from "react"
 import { Button } from "@/components/ui/button"
 import { ArrowDownIcon } from "@/components/ui/icons"
+import { cn } from "@/lib/utils"
 
 function ScrollToBottom() {
   return (
@@ -10,7 +11,7 @@ function ScrollToBottom() {
         type="button"
         variant="outline"
         size="icon-sm"
-        className="absolute -top-10 left-1/2 -translate-x-1/2 rounded-full bg-background disabled:invisible"
+        className="absolute -top-10 left-1/2 -translate-x-1/2 rounded-full bg-card hover:bg-muted disabled:invisible dark:bg-card dark:hover:bg-muted"
         aria-label="Scroll to latest message"
       >
         <ArrowDownIcon />
@@ -29,7 +30,10 @@ export function ChatViewport({
   return (
     <>
       <ThreadPrimitive.Viewport
-        className="relative flex min-h-0 flex-1 flex-col overflow-y-auto"
+        className={cn(
+          "relative flex min-h-0 flex-1 flex-col overflow-y-auto px-4",
+          footer && "pb-8"
+        )}
         style={{ scrollbarGutter: "stable" }}
         autoScroll
         scrollToBottomOnRunStart
@@ -40,8 +44,8 @@ export function ChatViewport({
         {children}
       </ThreadPrimitive.Viewport>
       {footer ? (
-        <div className="relative z-20 shrink-0 bg-gradient-to-t from-background via-background to-transparent px-4 pt-7 pb-2">
-          <div className="relative mx-auto w-full max-w-3xl">
+        <div className="relative z-20 shrink-0 bg-gradient-to-t from-background via-background to-transparent px-4 pb-2">
+          <div className="relative mx-auto w-full max-w-2xl">
             <ScrollToBottom />
             {footer}
           </div>

--- a/surfsense_local/frontend/src/features/chat/chat-viewport.tsx
+++ b/surfsense_local/frontend/src/features/chat/chat-viewport.tsx
@@ -1,0 +1,52 @@
+import { ThreadPrimitive } from "@assistant-ui/react"
+import type { ReactNode } from "react"
+import { Button } from "@/components/ui/button"
+import { ArrowDownIcon } from "@/components/ui/icons"
+
+function ScrollToBottom() {
+  return (
+    <ThreadPrimitive.ScrollToBottom asChild>
+      <Button
+        type="button"
+        variant="outline"
+        size="icon-sm"
+        className="absolute -top-10 left-1/2 -translate-x-1/2 rounded-full bg-background disabled:invisible"
+        aria-label="Scroll to latest message"
+      >
+        <ArrowDownIcon />
+      </Button>
+    </ThreadPrimitive.ScrollToBottom>
+  )
+}
+
+export function ChatViewport({
+  children,
+  footer,
+}: {
+  children: ReactNode
+  footer?: ReactNode
+}) {
+  return (
+    <>
+      <ThreadPrimitive.Viewport
+        className="relative flex min-h-0 flex-1 flex-col overflow-y-auto"
+        style={{ scrollbarGutter: "stable" }}
+        autoScroll
+        scrollToBottomOnRunStart
+        scrollToBottomOnInitialize
+        scrollToBottomOnThreadSwitch
+        data-chat-viewport
+      >
+        {children}
+      </ThreadPrimitive.Viewport>
+      {footer ? (
+        <div className="relative z-20 shrink-0 bg-gradient-to-t from-background via-background to-transparent px-4 pt-7 pb-2">
+          <div className="relative mx-auto w-full max-w-3xl">
+            <ScrollToBottom />
+            {footer}
+          </div>
+        </div>
+      ) : null}
+    </>
+  )
+}

--- a/surfsense_local/frontend/src/features/chat/chat-viewport.tsx
+++ b/surfsense_local/frontend/src/features/chat/chat-viewport.tsx
@@ -29,7 +29,7 @@ export function ChatViewport({
   return (
     <ThreadPrimitive.Viewport
       turnAnchor="top"
-      className="relative flex min-h-0 flex-1 flex-col overflow-y-auto px-4"
+      className="relative flex min-h-0 w-full min-w-0 flex-1 flex-col overflow-y-auto px-4"
       style={{ scrollbarGutter: "stable" }}
       autoScroll
       scrollToBottomOnRunStart

--- a/surfsense_local/frontend/src/features/chat/citation-markdown.ts
+++ b/surfsense_local/frontend/src/features/chat/citation-markdown.ts
@@ -1,0 +1,16 @@
+const CODE_REGION = /(```[\s\S]*?```|`[^`\n]+`)/g
+const CITATION_TOKEN = /\[citation:\s*(\d+)\s*\]/g
+
+export function preprocessCitationMarkdown(content: string) {
+  return content
+    .split(CODE_REGION)
+    .map((part, index) =>
+      index % 2 === 1
+        ? part
+        : part.replace(
+            CITATION_TOKEN,
+            '<citation data-source-id="$1">$1</citation>'
+          )
+    )
+    .join("")
+}

--- a/surfsense_local/frontend/src/features/chat/inline-citation.test.ts
+++ b/surfsense_local/frontend/src/features/chat/inline-citation.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest"
+
+import { preprocessCitationMarkdown } from "./citation-markdown"
+
+describe("preprocessCitationMarkdown", () => {
+  it("turns explicit source citations into inline elements", () => {
+    expect(preprocessCitationMarkdown("Claim [citation:2].")).toBe(
+      'Claim <citation data-source-id="2">2</citation>.'
+    )
+  })
+
+  it("leaves citation-shaped code and legacy ordinals unchanged", () => {
+    const markdown = "Legacy [1]. Use `[citation:2]`.\n```\n[citation:3]\n```\n"
+
+    expect(preprocessCitationMarkdown(markdown)).toBe(markdown)
+  })
+})

--- a/surfsense_local/frontend/src/features/chat/inline-citation.tsx
+++ b/surfsense_local/frontend/src/features/chat/inline-citation.tsx
@@ -1,0 +1,82 @@
+import { createContext, useContext, useMemo, type ReactNode } from "react"
+
+import { Button } from "@/components/ui/button"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
+import type { WorkspaceDocument } from "@/features/sources/api"
+
+import type { Citation } from "./sse"
+
+type CitationContextValue = {
+  citationBySourceId: Map<number, Citation>
+  titleByDocumentId: Map<number, string>
+  onCitation: (citation: Citation) => void
+}
+
+const CitationContext = createContext<CitationContextValue | null>(null)
+
+export function CitationProvider({
+  citations,
+  documents,
+  onCitation,
+  children,
+}: {
+  citations: Citation[]
+  documents: WorkspaceDocument[]
+  onCitation: (citation: Citation) => void
+  children: ReactNode
+}) {
+  const value = useMemo(
+    () => ({
+      citationBySourceId: new Map(
+        citations.map((citation) => [citation.source_id, citation])
+      ),
+      titleByDocumentId: new Map(
+        documents.map((document) => [document.id, document.title])
+      ),
+      onCitation,
+    }),
+    [citations, documents, onCitation]
+  )
+
+  return (
+    <CitationContext.Provider value={value}>
+      {children}
+    </CitationContext.Provider>
+  )
+}
+
+export function InlineCitation(props: Record<string, unknown>) {
+  const context = useContext(CitationContext)
+  const sourceId = Number(props["data-source-id"] ?? props.children)
+  const citation = context?.citationBySourceId.get(sourceId)
+
+  if (!context || !citation) {
+    return null
+  }
+
+  const title =
+    context.titleByDocumentId.get(citation.document_id) ??
+    `Document ${citation.document_id}`
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="xs"
+          className="mx-0.5 inline-flex h-5 min-w-5 rounded-md bg-popover px-1.5 align-baseline text-[11px] text-popover-foreground hover:bg-popover hover:text-popover-foreground"
+          aria-label={`Open source ${sourceId}: ${title}`}
+          onClick={() => context.onCitation(citation)}
+        >
+          {sourceId}
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>{title}</TooltipContent>
+    </Tooltip>
+  )
+}

--- a/surfsense_local/frontend/src/features/chat/inline-citation.tsx
+++ b/surfsense_local/frontend/src/features/chat/inline-citation.tsx
@@ -70,7 +70,7 @@ export function InlineCitation(props: Record<string, unknown>) {
           variant="ghost"
           size="xs"
           className="mx-0.5 inline-flex h-5 min-w-5 rounded-md bg-popover px-1.5 align-baseline text-[11px] text-popover-foreground hover:bg-popover hover:text-popover-foreground"
-          aria-label={`Open source ${sourceId}: ${title}`}
+          aria-label={`Show source ${sourceId}: ${title}`}
           onClick={() => context.onCitation(citation)}
         >
           {sourceId}

--- a/surfsense_local/frontend/src/features/chat/message.tsx
+++ b/surfsense_local/frontend/src/features/chat/message.tsx
@@ -69,7 +69,7 @@ function CitationLinks({
 
 export function UserMessage() {
   return (
-    <MessagePrimitive.Root className="mx-auto flex w-full max-w-2xl justify-end px-6 py-3">
+    <MessagePrimitive.Root className="mx-auto flex w-full max-w-xl justify-end px-6 py-3">
       <div className="max-w-[78%] rounded-2xl rounded-br-md bg-primary px-4 py-2.5 text-sm leading-6 whitespace-pre-wrap text-primary-foreground">
         <MessagePrimitive.Parts />
       </div>
@@ -87,7 +87,7 @@ export function AssistantMessage({
   onCitation: (citation: Citation) => void
 }) {
   return (
-    <MessagePrimitive.Root className="mx-auto w-full max-w-2xl px-6 py-4">
+    <MessagePrimitive.Root className="mx-auto w-full max-w-xl px-6 py-4">
       <div className="min-w-0 text-sm leading-7">
         <MessagePrimitive.Parts components={assistantMessageParts} />
       </div>

--- a/surfsense_local/frontend/src/features/chat/message.tsx
+++ b/surfsense_local/frontend/src/features/chat/message.tsx
@@ -69,7 +69,7 @@ function CitationLinks({
 
 export function UserMessage() {
   return (
-    <MessagePrimitive.Root className="mx-auto flex w-full max-w-3xl justify-end px-6 py-3">
+    <MessagePrimitive.Root className="mx-auto flex w-full max-w-2xl justify-end px-6 py-3">
       <div className="max-w-[78%] rounded-2xl rounded-br-md bg-primary px-4 py-2.5 text-sm leading-6 whitespace-pre-wrap text-primary-foreground">
         <MessagePrimitive.Parts />
       </div>
@@ -87,7 +87,7 @@ export function AssistantMessage({
   onCitation: (citation: Citation) => void
 }) {
   return (
-    <MessagePrimitive.Root className="mx-auto w-full max-w-3xl px-6 py-4">
+    <MessagePrimitive.Root className="mx-auto w-full max-w-2xl px-6 py-4">
       <div className="min-w-0 text-sm leading-7">
         <MessagePrimitive.Parts components={assistantMessageParts} />
       </div>

--- a/surfsense_local/frontend/src/features/chat/message.tsx
+++ b/surfsense_local/frontend/src/features/chat/message.tsx
@@ -16,6 +16,11 @@ import { createMathPlugin } from "@streamdown/math"
 
 import { RelativeTime } from "@/components/relative-time"
 import { Button } from "@/components/ui/button"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
 import type { WorkspaceDocument } from "@/features/sources/api"
 import { cn } from "@/lib/utils"
 
@@ -65,6 +70,7 @@ function MessageActions({
   className?: string
 }) {
   const timestamp = <MessageTimestamp />
+  const isCopied = useAuiState(({ message }) => message.isCopied)
   return (
     <div
       className={cn(
@@ -74,22 +80,28 @@ function MessageActions({
     >
       {timestampRight ? null : timestamp}
       <ActionBarPrimitive.Root hideWhenRunning={hideWhenRunning}>
-        <ActionBarPrimitive.Copy copiedDuration={2_000} asChild>
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon-sm"
-            aria-label="Copy message"
-            title="Copy message"
-          >
-            <AuiIf condition={({ message }) => message.isCopied}>
-              <CheckIcon />
-            </AuiIf>
-            <AuiIf condition={({ message }) => !message.isCopied}>
-              <CopyIcon />
-            </AuiIf>
-          </Button>
-        </ActionBarPrimitive.Copy>
+        <Tooltip>
+          <ActionBarPrimitive.Copy copiedDuration={2_000} asChild>
+            <TooltipTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                aria-label={isCopied ? "Copied" : "Copy message"}
+              >
+                <AuiIf condition={({ message }) => message.isCopied}>
+                  <CheckIcon />
+                </AuiIf>
+                <AuiIf condition={({ message }) => !message.isCopied}>
+                  <CopyIcon />
+                </AuiIf>
+              </Button>
+            </TooltipTrigger>
+          </ActionBarPrimitive.Copy>
+          <TooltipContent>
+            {isCopied ? "Copied" : "Copy"}
+          </TooltipContent>
+        </Tooltip>
       </ActionBarPrimitive.Root>
       {timestampRight ? timestamp : null}
     </div>

--- a/surfsense_local/frontend/src/features/chat/message.tsx
+++ b/surfsense_local/frontend/src/features/chat/message.tsx
@@ -1,4 +1,9 @@
-import { CheckIcon, CopyIcon, FileTextIcon } from "@/components/ui/icons"
+import {
+  CheckIcon,
+  CopyIcon,
+  DownloadIcon,
+  FileTextIcon,
+} from "@/components/ui/icons"
 import {
   ActionBarPrimitive,
   AuiIf,
@@ -20,11 +25,13 @@ const streamdownPlugins = {
   code,
   math: createMathPlugin({ singleDollarTextMath: true }),
 }
+const streamdownIcons = { CheckIcon, CopyIcon, DownloadIcon }
 
 function MarkdownText() {
   return (
     <StreamdownTextPrimitive
       defer
+      icons={streamdownIcons}
       plugins={streamdownPlugins}
       linkSafety={{ enabled: true }}
       security={{
@@ -61,7 +68,7 @@ function MessageActions({
   return (
     <div
       className={cn(
-        "relative flex h-7 items-center gap-1 text-muted-foreground",
+        "relative flex h-7 items-center gap-2 text-muted-foreground",
         className
       )}
     >
@@ -149,8 +156,8 @@ export function AssistantMessage({
   onCitation: (citation: Citation) => void
 }) {
   return (
-    <MessagePrimitive.Root className="mx-auto flex w-full max-w-xl flex-col items-start px-6 py-4">
-      <div className="min-w-0 text-sm leading-7">
+    <MessagePrimitive.Root className="mx-auto flex w-full max-w-xl min-w-0 flex-col items-start px-6 py-4">
+      <div className="w-full max-w-full min-w-0 text-sm leading-7">
         <MessagePrimitive.Parts components={assistantMessageParts} />
       </div>
       <CitationLinks

--- a/surfsense_local/frontend/src/features/chat/message.tsx
+++ b/surfsense_local/frontend/src/features/chat/message.tsx
@@ -81,6 +81,19 @@ function MessageActions({
 }) {
   const timestamp = <MessageTimestamp />
   const isCopied = useAuiState(({ message }) => message.isCopied)
+  const isRunning = useAuiState(
+    ({ message }) => message.status?.type === "running"
+  )
+  const hasText = useAuiState(({ message }) =>
+    message.content.some(
+      (part) => part.type === "text" && part.text.trim().length > 0
+    )
+  )
+
+  if (hideWhenRunning && (isRunning || !hasText)) {
+    return null
+  }
+
   return (
     <div
       className={cn(

--- a/surfsense_local/frontend/src/features/chat/message.tsx
+++ b/surfsense_local/frontend/src/features/chat/message.tsx
@@ -1,11 +1,18 @@
-import { FileTextIcon } from "@/components/ui/icons"
-import { MessagePrimitive } from "@assistant-ui/react"
+import { CheckIcon, CopyIcon, FileTextIcon } from "@/components/ui/icons"
+import {
+  ActionBarPrimitive,
+  AuiIf,
+  MessagePrimitive,
+  useAuiState,
+} from "@assistant-ui/react"
 import { StreamdownTextPrimitive } from "@assistant-ui/react-streamdown"
 import { code } from "@streamdown/code"
 import { createMathPlugin } from "@streamdown/math"
 
+import { RelativeTime } from "@/components/relative-time"
 import { Button } from "@/components/ui/button"
 import type { WorkspaceDocument } from "@/features/sources/api"
+import { cn } from "@/lib/utils"
 
 import type { Citation } from "./sse"
 
@@ -30,6 +37,57 @@ function MarkdownText() {
 }
 
 const assistantMessageParts = { Text: MarkdownText }
+
+function MessageTimestamp() {
+  const createdAt = useAuiState(({ message }) => message.createdAt)
+
+  if (!createdAt) {
+    return null
+  }
+
+  return <RelativeTime date={createdAt} />
+}
+
+function MessageActions({
+  hideWhenRunning = false,
+  timestampRight = false,
+  className,
+}: {
+  hideWhenRunning?: boolean
+  timestampRight?: boolean
+  className?: string
+}) {
+  const timestamp = <MessageTimestamp />
+  return (
+    <div
+      className={cn(
+        "relative flex h-7 items-center gap-1 text-muted-foreground",
+        className
+      )}
+    >
+      {timestampRight ? null : timestamp}
+      <ActionBarPrimitive.Root hideWhenRunning={hideWhenRunning}>
+        <ActionBarPrimitive.Copy copiedDuration={2_000} asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            aria-label="Copy message"
+            title="Copy message"
+          >
+            <AuiIf condition={({ message }) => message.isCopied}>
+              <CheckIcon />
+            </AuiIf>
+            <AuiIf condition={({ message }) => !message.isCopied}>
+              <CopyIcon />
+            </AuiIf>
+          </Button>
+        </ActionBarPrimitive.Copy>
+      </ActionBarPrimitive.Root>
+      {timestampRight ? timestamp : null}
+    </div>
+  )
+}
 
 function CitationLinks({
   citations,
@@ -72,10 +130,11 @@ function CitationLinks({
 
 export function UserMessage() {
   return (
-    <MessagePrimitive.Root className="mx-auto flex w-full max-w-xl justify-end px-6 py-3">
+    <MessagePrimitive.Root className="mx-auto flex w-full max-w-xl flex-col items-end px-6 py-3">
       <div className="max-w-[78%] rounded-2xl rounded-br-md bg-primary px-4 py-2.5 text-sm leading-6 whitespace-pre-wrap text-primary-foreground">
         <MessagePrimitive.Parts />
       </div>
+      <MessageActions className="top-1" />
     </MessagePrimitive.Root>
   )
 }
@@ -90,7 +149,7 @@ export function AssistantMessage({
   onCitation: (citation: Citation) => void
 }) {
   return (
-    <MessagePrimitive.Root className="mx-auto w-full max-w-xl px-6 py-4">
+    <MessagePrimitive.Root className="mx-auto flex w-full max-w-xl flex-col items-start px-6 py-4">
       <div className="min-w-0 text-sm leading-7">
         <MessagePrimitive.Parts components={assistantMessageParts} />
       </div>
@@ -99,6 +158,7 @@ export function AssistantMessage({
         documents={documents}
         onCitation={onCitation}
       />
+      <MessageActions hideWhenRunning timestampRight className="top-0.5" />
     </MessagePrimitive.Root>
   )
 }

--- a/surfsense_local/frontend/src/features/chat/message.tsx
+++ b/surfsense_local/frontend/src/features/chat/message.tsx
@@ -2,14 +2,17 @@ import { FileTextIcon } from "@/components/ui/icons"
 import { MessagePrimitive } from "@assistant-ui/react"
 import { StreamdownTextPrimitive } from "@assistant-ui/react-streamdown"
 import { code } from "@streamdown/code"
-import { math } from "@streamdown/math"
+import { createMathPlugin } from "@streamdown/math"
 
 import { Button } from "@/components/ui/button"
 import type { WorkspaceDocument } from "@/features/sources/api"
 
 import type { Citation } from "./sse"
 
-const streamdownPlugins = { code, math }
+const streamdownPlugins = {
+  code,
+  math: createMathPlugin({ singleDollarTextMath: true }),
+}
 
 function MarkdownText() {
   return (

--- a/surfsense_local/frontend/src/features/chat/message.tsx
+++ b/surfsense_local/frontend/src/features/chat/message.tsx
@@ -1,9 +1,4 @@
-import {
-  CheckIcon,
-  CopyIcon,
-  DownloadIcon,
-  FileTextIcon,
-} from "@/components/ui/icons"
+import { CheckIcon, CopyIcon, DownloadIcon } from "@/components/ui/icons"
 import {
   ActionBarPrimitive,
   AuiIf,
@@ -13,6 +8,8 @@ import {
 import { StreamdownTextPrimitive } from "@assistant-ui/react-streamdown"
 import { code } from "@streamdown/code"
 import { createMathPlugin } from "@streamdown/math"
+import type { ComponentType } from "react"
+import type { Components, ExtraProps } from "streamdown"
 
 import { RelativeTime } from "@/components/relative-time"
 import { Button } from "@/components/ui/button"
@@ -24,6 +21,8 @@ import {
 import type { WorkspaceDocument } from "@/features/sources/api"
 import { cn } from "@/lib/utils"
 
+import { preprocessCitationMarkdown } from "./citation-markdown"
+import { CitationProvider, InlineCitation } from "./inline-citation"
 import type { Citation } from "./sse"
 
 const streamdownPlugins = {
@@ -31,13 +30,24 @@ const streamdownPlugins = {
   math: createMathPlugin({ singleDollarTextMath: true }),
 }
 const streamdownIcons = { CheckIcon, CopyIcon, DownloadIcon }
+const citationComponents: Components = {
+  citation: InlineCitation as ComponentType<
+    Record<string, unknown> & ExtraProps
+  >,
+}
+const citationAllowedTags = {
+  citation: ["data-source-id"],
+}
 
 function MarkdownText() {
   return (
     <StreamdownTextPrimitive
       defer
+      allowedTags={citationAllowedTags}
+      components={citationComponents}
       icons={streamdownIcons}
       plugins={streamdownPlugins}
+      preprocess={preprocessCitationMarkdown}
       linkSafety={{ enabled: true }}
       security={{
         allowedProtocols: ["http", "https", "mailto"],
@@ -98,52 +108,11 @@ function MessageActions({
               </Button>
             </TooltipTrigger>
           </ActionBarPrimitive.Copy>
-          <TooltipContent>
-            {isCopied ? "Copied" : "Copy"}
-          </TooltipContent>
+          <TooltipContent>{isCopied ? "Copied" : "Copy"}</TooltipContent>
         </Tooltip>
       </ActionBarPrimitive.Root>
       {timestampRight ? timestamp : null}
     </div>
-  )
-}
-
-function CitationLinks({
-  citations,
-  documents,
-  onCitation,
-}: {
-  citations: Citation[]
-  documents: WorkspaceDocument[]
-  onCitation: (citation: Citation) => void
-}) {
-  if (citations.length === 0) {
-    return null
-  }
-  const titleById = new Map(
-    documents.map((document) => [document.id, document.title])
-  )
-  return (
-    <ul className="mt-3 flex flex-wrap gap-1.5" aria-label="Citations">
-      {citations.map((citation, index) => {
-        const title =
-          titleById.get(citation.document_id) ??
-          `Document ${citation.document_id}`
-        return (
-          <li key={citation.chunk_id}>
-            <Button
-              variant="outline"
-              size="xs"
-              aria-label={`Source ${index + 1}: ${title}`}
-              onClick={() => onCitation(citation)}
-            >
-              <FileTextIcon />
-              {index + 1}
-            </Button>
-          </li>
-        )
-      })}
-    </ul>
   )
 }
 
@@ -169,14 +138,15 @@ export function AssistantMessage({
 }) {
   return (
     <MessagePrimitive.Root className="mx-auto flex w-full max-w-xl min-w-0 flex-col items-start px-6 py-4">
-      <div className="w-full max-w-full min-w-0 text-sm leading-7">
-        <MessagePrimitive.Parts components={assistantMessageParts} />
-      </div>
-      <CitationLinks
+      <CitationProvider
         citations={citations}
         documents={documents}
         onCitation={onCitation}
-      />
+      >
+        <div className="w-full max-w-full min-w-0 text-sm leading-7">
+          <MessagePrimitive.Parts components={assistantMessageParts} />
+        </div>
+      </CitationProvider>
       <MessageActions hideWhenRunning timestampRight className="top-0.5" />
     </MessagePrimitive.Root>
   )

--- a/surfsense_local/frontend/src/features/chat/sse.test.ts
+++ b/surfsense_local/frontend/src/features/chat/sse.test.ts
@@ -18,12 +18,12 @@ describe("parseSseStream", () => {
   it("buffers frames split across arbitrary network chunks", async () => {
     const events = []
     const stream = chunkedStream([
-      'data: {"type":"accepted","user_message_id":11,"assistant_message_id":12}\n\ndata: {"type":"del',
+      'data: {"type":"accepted","user_message_id":11,"assistant_message_id":12,"user_created_at":"2026-09-08T00:00:00"}\n\ndata: {"type":"del',
       'ta","text":"hel"}\n\ndata: {"type":"thread-title-update","title":"Revenue Growth"}',
       '\n\ndata: {"type":"delta","text":"lo"}',
       '\n\ndata: {"type":"citation-catalog","items":[{"source_id":1,"chunk_id":4,"document_id":2,',
       '"start_line":10,"end_line":12}]}\n\ndata: {"type":"citations","items":[{"source_id":1,"chunk_id":4,"document_id":2,',
-      '"start_line":10,"end_line":12}]}\n\ndata: [DONE]\n\n',
+      '"start_line":10,"end_line":12}]}\n\ndata: {"type":"completed","assistant_completed_at":"2026-09-08T00:00:05"}\n\ndata: [DONE]\n\n',
     ])
 
     for await (const event of parseSseStream(stream)) {
@@ -35,6 +35,7 @@ describe("parseSseStream", () => {
         type: "accepted",
         user_message_id: 11,
         assistant_message_id: 12,
+        user_created_at: "2026-09-08T00:00:00",
       },
       { type: "delta", text: "hel" },
       { type: "thread-title-update", title: "Revenue Growth" },
@@ -62,6 +63,10 @@ describe("parseSseStream", () => {
             end_line: 12,
           },
         ],
+      },
+      {
+        type: "completed",
+        assistant_completed_at: "2026-09-08T00:00:05",
       },
       { type: "done" },
     ])

--- a/surfsense_local/frontend/src/features/chat/sse.test.ts
+++ b/surfsense_local/frontend/src/features/chat/sse.test.ts
@@ -21,7 +21,8 @@ describe("parseSseStream", () => {
       'data: {"type":"accepted","user_message_id":11,"assistant_message_id":12}\n\ndata: {"type":"del',
       'ta","text":"hel"}\n\ndata: {"type":"thread-title-update","title":"Revenue Growth"}',
       '\n\ndata: {"type":"delta","text":"lo"}',
-      '\n\ndata: {"type":"citations","items":[{"chunk_id":4,"document_id":2,',
+      '\n\ndata: {"type":"citation-catalog","items":[{"source_id":1,"chunk_id":4,"document_id":2,',
+      '"start_line":10,"end_line":12}]}\n\ndata: {"type":"citations","items":[{"source_id":1,"chunk_id":4,"document_id":2,',
       '"start_line":10,"end_line":12}]}\n\ndata: [DONE]\n\n',
     ])
 
@@ -39,9 +40,22 @@ describe("parseSseStream", () => {
       { type: "thread-title-update", title: "Revenue Growth" },
       { type: "delta", text: "lo" },
       {
+        type: "citation-catalog",
+        items: [
+          {
+            source_id: 1,
+            chunk_id: 4,
+            document_id: 2,
+            start_line: 10,
+            end_line: 12,
+          },
+        ],
+      },
+      {
         type: "citations",
         items: [
           {
+            source_id: 1,
             chunk_id: 4,
             document_id: 2,
             start_line: 10,

--- a/surfsense_local/frontend/src/features/chat/sse.test.ts
+++ b/surfsense_local/frontend/src/features/chat/sse.test.ts
@@ -19,7 +19,8 @@ describe("parseSseStream", () => {
     const events = []
     const stream = chunkedStream([
       'data: {"type":"accepted","user_message_id":11,"assistant_message_id":12}\n\ndata: {"type":"del',
-      'ta","text":"hel"}\n\ndata: {"type":"delta","text":"lo"}',
+      'ta","text":"hel"}\n\ndata: {"type":"thread-title-update","title":"Revenue Growth"}',
+      '\n\ndata: {"type":"delta","text":"lo"}',
       '\n\ndata: {"type":"citations","items":[{"chunk_id":4,"document_id":2,',
       '"start_line":10,"end_line":12}]}\n\ndata: [DONE]\n\n',
     ])
@@ -35,6 +36,7 @@ describe("parseSseStream", () => {
         assistant_message_id: 12,
       },
       { type: "delta", text: "hel" },
+      { type: "thread-title-update", title: "Revenue Growth" },
       { type: "delta", text: "lo" },
       {
         type: "citations",

--- a/surfsense_local/frontend/src/features/chat/sse.ts
+++ b/surfsense_local/frontend/src/features/chat/sse.ts
@@ -11,6 +11,7 @@ export type ChatStreamEvent =
       user_message_id: number
       assistant_message_id: number
     }
+  | { type: "thread-title-update"; title: string }
   | { type: "delta"; text: string }
   | { type: "citations"; items: Citation[] }
   | { type: "error"; message: string }

--- a/surfsense_local/frontend/src/features/chat/sse.ts
+++ b/surfsense_local/frontend/src/features/chat/sse.ts
@@ -11,11 +11,13 @@ export type ChatStreamEvent =
       type: "accepted"
       user_message_id: number
       assistant_message_id: number
+      user_created_at: string
     }
   | { type: "thread-title-update"; title: string }
   | { type: "citation-catalog"; items: Citation[] }
   | { type: "delta"; text: string }
   | { type: "citations"; items: Citation[] }
+  | { type: "completed"; assistant_completed_at: string }
   | { type: "error"; message: string }
   | { type: "done" }
 

--- a/surfsense_local/frontend/src/features/chat/sse.ts
+++ b/surfsense_local/frontend/src/features/chat/sse.ts
@@ -1,4 +1,5 @@
 export type Citation = {
+  source_id: number
   chunk_id: number
   document_id: number
   start_line: number | null
@@ -12,6 +13,7 @@ export type ChatStreamEvent =
       assistant_message_id: number
     }
   | { type: "thread-title-update"; title: string }
+  | { type: "citation-catalog"; items: Citation[] }
   | { type: "delta"; text: string }
   | { type: "citations"; items: Citation[] }
   | { type: "error"; message: string }

--- a/surfsense_local/frontend/src/features/chat/thread-list.tsx
+++ b/surfsense_local/frontend/src/features/chat/thread-list.tsx
@@ -98,21 +98,25 @@ export function ThreadList({
   threads,
   activeThreadId,
   autoNamingThreadId,
+  animatingTitleThreadId,
   isLoading,
   onNewChat,
   onSelect,
   onRename,
   onDelete,
+  onTitleAnimationComplete,
 }: {
   workspaceName: string
   threads: ChatThread[]
   activeThreadId: number | null
   autoNamingThreadId: number | null
+  animatingTitleThreadId: number | null
   isLoading: boolean
   onNewChat: () => void
   onSelect: (id: number) => void
   onRename: (id: number, title: string) => Promise<boolean>
   onDelete: (id: number) => Promise<void>
+  onTitleAnimationComplete: () => void
 }) {
   const [openDropdownId, setOpenDropdownId] = useState<number | null>(null)
   const [renaming, setRenaming] = useState<ChatThread | null>(null)
@@ -161,7 +165,11 @@ export function ThreadList({
                   onClick={() => onSelect(thread.id)}
                 >
                   <span className="truncate">
-                    <TypewriterText text={title} />
+                    <TypewriterText
+                      text={title}
+                      animate={thread.id === animatingTitleThreadId}
+                      onComplete={onTitleAnimationComplete}
+                    />
                   </span>
                 </Button>
                 <div className="absolute inset-y-0 right-1 flex items-center">

--- a/surfsense_local/frontend/src/features/chat/thread-list.tsx
+++ b/surfsense_local/frontend/src/features/chat/thread-list.tsx
@@ -1,8 +1,9 @@
-import { useState } from "react"
+import { useState, type FormEvent } from "react"
 
 import {
   EllipsisIcon,
   MessageSquareIcon,
+  PencilIcon,
   PlusIcon,
   Trash2Icon,
 } from "@/components/ui/icons"
@@ -16,12 +17,21 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import {
   Empty,
   EmptyDescription,
   EmptyHeader,
   EmptyMedia,
   EmptyTitle,
 } from "@/components/ui/empty"
+import { Input } from "@/components/ui/input"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { Skeleton } from "@/components/ui/skeleton"
 import { TypewriterText } from "@/components/typewriter-text"
@@ -29,24 +39,83 @@ import { cn } from "@/lib/utils"
 
 import type { ChatThread } from "./api"
 
+function RenameChatDialog({
+  thread,
+  onClose,
+  onRename,
+}: {
+  thread: ChatThread
+  onClose: () => void
+  onRename: (id: number, title: string) => Promise<boolean>
+}) {
+  const [title, setTitle] = useState(thread.title || "New chat")
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  const submit = async (event: FormEvent) => {
+    event.preventDefault()
+    const normalized = title.trim()
+    if (!normalized) return
+
+    setIsSubmitting(true)
+    if (await onRename(thread.id, normalized)) onClose()
+    setIsSubmitting(false)
+  }
+
+  return (
+    <Dialog open onOpenChange={(open) => !open && onClose()}>
+      <DialogContent>
+        <form onSubmit={(event) => void submit(event)}>
+          <DialogHeader>
+            <DialogTitle>Rename chat</DialogTitle>
+            <DialogDescription>
+              Choose a short name that identifies this conversation.
+            </DialogDescription>
+          </DialogHeader>
+          <Input
+            className="my-4"
+            value={title}
+            onChange={(event) => setTitle(event.target.value)}
+            aria-label="Chat name"
+            maxLength={200}
+            autoFocus
+          />
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={!title.trim() || isSubmitting}>
+              {isSubmitting ? "Saving..." : "Rename"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
 export function ThreadList({
   workspaceName,
   threads,
   activeThreadId,
+  autoNamingThreadId,
   isLoading,
   onNewChat,
   onSelect,
+  onRename,
   onDelete,
 }: {
   workspaceName: string
   threads: ChatThread[]
   activeThreadId: number | null
+  autoNamingThreadId: number | null
   isLoading: boolean
   onNewChat: () => void
   onSelect: (id: number) => void
+  onRename: (id: number, title: string) => Promise<boolean>
   onDelete: (id: number) => Promise<void>
 }) {
   const [openDropdownId, setOpenDropdownId] = useState<number | null>(null)
+  const [renaming, setRenaming] = useState<ChatThread | null>(null)
 
   return (
     <aside className="flex h-full min-w-0 flex-col border-r bg-sidebar/60">
@@ -120,6 +189,16 @@ export function ThreadList({
                     >
                       <DropdownMenuGroup>
                         <DropdownMenuItem
+                          disabled={thread.id === autoNamingThreadId}
+                          onSelect={() => {
+                            setOpenDropdownId(null)
+                            setRenaming(thread)
+                          }}
+                        >
+                          <PencilIcon />
+                          Rename
+                        </DropdownMenuItem>
+                        <DropdownMenuItem
                           variant="destructive"
                           onSelect={() => {
                             setOpenDropdownId(null)
@@ -138,6 +217,14 @@ export function ThreadList({
           })}
         </div>
       </ScrollArea>
+      {renaming ? (
+        <RenameChatDialog
+          key={renaming.id}
+          thread={renaming}
+          onClose={() => setRenaming(null)}
+          onRename={onRename}
+        />
+      ) : null}
     </aside>
   )
 }

--- a/surfsense_local/frontend/src/features/chat/thread-list.tsx
+++ b/surfsense_local/frontend/src/features/chat/thread-list.tsx
@@ -3,8 +3,8 @@ import { useState, type FormEvent } from "react"
 import {
   EllipsisIcon,
   MessageSquareIcon,
+  PencilEdit02Icon,
   PencilIcon,
-  PlusIcon,
   Trash2Icon,
 } from "@/components/ui/icons"
 
@@ -126,7 +126,7 @@ export function ThreadList({
       <header className="space-y-3 border-b p-3">
         <h2 className="truncate px-1 text-sm font-semibold">{workspaceName}</h2>
         <Button className="w-full justify-start" onClick={onNewChat}>
-          <PlusIcon />
+          <PencilEdit02Icon />
           New chat
         </Button>
       </header>

--- a/surfsense_local/frontend/src/features/chat/thread-list.tsx
+++ b/surfsense_local/frontend/src/features/chat/thread-list.tsx
@@ -24,6 +24,7 @@ import {
 } from "@/components/ui/empty"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { Skeleton } from "@/components/ui/skeleton"
+import { TypewriterText } from "@/components/typewriter-text"
 import { cn } from "@/lib/utils"
 
 import type { ChatThread } from "./api"
@@ -90,7 +91,9 @@ export function ThreadList({
                   aria-current={selected ? "page" : undefined}
                   onClick={() => onSelect(thread.id)}
                 >
-                  <span className="truncate">{title}</span>
+                  <span className="truncate">
+                    <TypewriterText text={title} />
+                  </span>
                 </Button>
                 <div className="absolute inset-y-0 right-1 flex items-center">
                   <DropdownMenu

--- a/surfsense_local/frontend/src/features/chat/thread-panel.tsx
+++ b/surfsense_local/frontend/src/features/chat/thread-panel.tsx
@@ -53,11 +53,11 @@ function ComposerDraftLifecycle({ view }: { view: ConversationView }) {
     view.status === "active" ? `thread:${view.threadId}` : view.status
 
   useEffect(() => {
-    if (view.status === "initializing" || view.status === "creating") {
+    if (conversationId === "initializing" || conversationId === "creating") {
       return
     }
     void aui.thread.composer().reset()
-  }, [aui, conversationId, view.status])
+  }, [aui, conversationId])
 
   return null
 }

--- a/surfsense_local/frontend/src/features/chat/thread-panel.tsx
+++ b/surfsense_local/frontend/src/features/chat/thread-panel.tsx
@@ -72,9 +72,11 @@ export function ThreadPanel({
   error,
   isLoading,
   isRunning,
+  animateTitle,
   providerAvailable,
   onCitation,
   onModelSetup,
+  onTitleAnimationComplete,
 }: {
   runtime: AssistantRuntime
   thread: ChatThread | null
@@ -84,12 +86,16 @@ export function ThreadPanel({
   error: string | null
   isLoading: boolean
   isRunning: boolean
+  animateTitle: boolean
   providerAvailable: boolean
   onCitation: (citation: Citation) => void
   onModelSetup: () => void
+  onTitleAnimationComplete: () => void
 }) {
   const headingRef = useRef<HTMLHeadingElement>(null)
   const threadId = thread?.id
+  const title =
+    view.status === "initializing" ? null : thread?.title || "New chat"
   const bottomComposer = view.status === "creating" || view.status === "active"
   const composer = (placement: "center" | "bottom") => (
     <ChatComposer
@@ -120,7 +126,15 @@ export function ThreadPanel({
             tabIndex={-1}
             className="min-w-0 truncate font-heading text-lg font-medium outline-none"
           >
-            <TypewriterText text={thread?.title || "New chat"} />
+            {title === null ? (
+              <Skeleton className="h-5 w-32" />
+            ) : (
+              <TypewriterText
+                text={title}
+                animate={animateTitle}
+                onComplete={onTitleAnimationComplete}
+              />
+            )}
           </h1>
         </header>
 

--- a/surfsense_local/frontend/src/features/chat/thread-panel.tsx
+++ b/surfsense_local/frontend/src/features/chat/thread-panel.tsx
@@ -11,6 +11,7 @@ import {
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
+import { TypewriterText } from "@/components/typewriter-text"
 import type { ModelSelection } from "@/features/model-selection/api"
 import type { WorkspaceDocument } from "@/features/sources/api"
 
@@ -88,6 +89,7 @@ export function ThreadPanel({
   onModelSetup: () => void
 }) {
   const headingRef = useRef<HTMLHeadingElement>(null)
+  const threadId = thread?.id
   const bottomComposer = view.status === "creating" || view.status === "active"
   const composer = (placement: "center" | "bottom") => (
     <ChatComposer
@@ -100,10 +102,10 @@ export function ThreadPanel({
   )
 
   useEffect(() => {
-    if (thread) {
+    if (threadId !== undefined) {
       headingRef.current?.focus()
     }
-  }, [thread])
+  }, [threadId])
 
   return (
     <AssistantRuntimeProvider runtime={runtime}>
@@ -118,7 +120,7 @@ export function ThreadPanel({
             tabIndex={-1}
             className="min-w-0 truncate font-heading text-lg font-medium outline-none"
           >
-            {thread?.title || "New chat"}
+            <TypewriterText text={thread?.title || "New chat"} />
           </h1>
         </header>
 

--- a/surfsense_local/frontend/src/features/chat/thread-panel.tsx
+++ b/surfsense_local/frontend/src/features/chat/thread-panel.tsx
@@ -39,7 +39,7 @@ function citationsFrom(message: {
 function ThreadWelcome({ composer }: { composer: ReactNode }) {
   return (
     <div className="flex min-h-0 flex-1">
-      <div className="mx-auto grid h-full w-full max-w-3xl grid-rows-[minmax(0,1fr)_auto_minmax(0,1fr)] px-4">
+      <div className="mx-auto grid h-full w-full max-w-2xl grid-rows-[minmax(0,1fr)_auto_minmax(0,1fr)]">
         <div />
         {composer}
       </div>
@@ -141,7 +141,7 @@ export function ThreadPanel({
             footer={bottomComposer ? composer("bottom") : undefined}
           >
             {view.status === "initializing" || isLoading ? (
-              <div className="mx-auto w-full max-w-3xl space-y-4 p-6">
+              <div className="mx-auto w-full max-w-2xl space-y-4 p-6">
                 <Skeleton className="ml-auto h-16 w-2/3" />
                 <Skeleton className="h-24 w-4/5" />
               </div>

--- a/surfsense_local/frontend/src/features/chat/thread-panel.tsx
+++ b/surfsense_local/frontend/src/features/chat/thread-panel.tsx
@@ -1,18 +1,11 @@
-import { useEffect, useRef } from "react"
-import {
-  ArrowDownIcon,
-  ArrowUp02Icon,
-  BotIcon,
-  ChevronDownIcon,
-  CircleStopIcon,
-  Settings2Icon,
-} from "@/components/ui/icons"
+import { useEffect, useRef, type ReactNode } from "react"
+import { BotIcon, Settings2Icon } from "@/components/ui/icons"
 
 import {
   AssistantRuntimeProvider,
-  ComposerPrimitive,
   ThreadPrimitive,
   type AssistantRuntime,
+  useAui,
 } from "@assistant-ui/react"
 
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
@@ -20,11 +13,13 @@ import { Button } from "@/components/ui/button"
 import { Skeleton } from "@/components/ui/skeleton"
 import type { ModelSelection } from "@/features/model-selection/api"
 import type { WorkspaceDocument } from "@/features/sources/api"
-import { cn } from "@/lib/utils"
 
 import type { ChatThread } from "./api"
+import { ChatComposer } from "./chat-composer"
+import { ChatViewport } from "./chat-viewport"
 import { AssistantMessage, UserMessage } from "./message"
 import type { Citation } from "./sse"
+import type { ConversationView } from "./use-chat-runtime"
 
 function citationsFrom(message: {
   metadata?: { custom?: unknown }
@@ -41,9 +36,36 @@ function citationsFrom(message: {
   return []
 }
 
+function ThreadWelcome({ composer }: { composer: ReactNode }) {
+  return (
+    <div className="flex min-h-0 flex-1">
+      <div className="mx-auto grid h-full w-full max-w-3xl grid-rows-[minmax(0,1fr)_auto_minmax(0,1fr)] px-4">
+        <div />
+        {composer}
+      </div>
+    </div>
+  )
+}
+
+function ComposerDraftLifecycle({ view }: { view: ConversationView }) {
+  const aui = useAui()
+  const conversationId =
+    view.status === "active" ? `thread:${view.threadId}` : view.status
+
+  useEffect(() => {
+    if (view.status === "initializing" || view.status === "creating") {
+      return
+    }
+    void aui.thread.composer().reset()
+  }, [aui, conversationId, view.status])
+
+  return null
+}
+
 export function ThreadPanel({
   runtime,
   thread,
+  view,
   model,
   documents,
   error,
@@ -55,6 +77,7 @@ export function ThreadPanel({
 }: {
   runtime: AssistantRuntime
   thread: ChatThread | null
+  view: ConversationView
   model: ModelSelection
   documents: WorkspaceDocument[]
   error: string | null
@@ -65,6 +88,16 @@ export function ThreadPanel({
   onModelSetup: () => void
 }) {
   const headingRef = useRef<HTMLHeadingElement>(null)
+  const bottomComposer = view.status === "creating" || view.status === "active"
+  const composer = (placement: "center" | "bottom") => (
+    <ChatComposer
+      placement={placement}
+      model={model}
+      isRunning={isRunning}
+      providerAvailable={providerAvailable}
+      onModelSetup={onModelSetup}
+    />
+  )
 
   useEffect(() => {
     if (thread) {
@@ -74,6 +107,7 @@ export function ThreadPanel({
 
   return (
     <AssistantRuntimeProvider runtime={runtime}>
+      <ComposerDraftLifecycle view={view} />
       <section
         className="flex h-full min-w-0 flex-col bg-background"
         aria-label="Conversation"
@@ -103,18 +137,21 @@ export function ThreadPanel({
         ) : null}
 
         <ThreadPrimitive.Root className="relative flex min-h-0 flex-1 flex-col">
-          <ThreadPrimitive.Viewport
-            className="flex min-h-0 flex-1 flex-col overflow-y-auto"
-            autoScroll
+          <ChatViewport
+            footer={bottomComposer ? composer("bottom") : undefined}
           >
-            {isLoading ? (
+            {view.status === "initializing" || isLoading ? (
               <div className="mx-auto w-full max-w-3xl space-y-4 p-6">
                 <Skeleton className="ml-auto h-16 w-2/3" />
                 <Skeleton className="h-24 w-4/5" />
               </div>
             ) : null}
 
-            {!isLoading ? (
+            {view.status === "new" ? (
+              <ThreadWelcome composer={composer("center")} />
+            ) : null}
+
+            {view.status === "active" && !isLoading ? (
               <ThreadPrimitive.Messages>
                 {({ message }) =>
                   message.role === "user" ? (
@@ -129,89 +166,7 @@ export function ThreadPanel({
                 }
               </ThreadPrimitive.Messages>
             ) : null}
-
-            <ThreadPrimitive.ViewportFooter
-              className={cn(
-                "absolute inset-x-0 z-20 px-4",
-                thread
-                  ? "bottom-0 bg-gradient-to-t from-background via-background to-transparent pt-7 pb-2"
-                  : "top-1/2 -translate-y-1/2"
-              )}
-            >
-              <div className="relative mx-auto max-w-3xl">
-                {thread ? (
-                  <ThreadPrimitive.ScrollToBottom asChild>
-                    <Button
-                      variant="outline"
-                      size="icon-sm"
-                      className="absolute -top-8 left-1/2 -translate-x-1/2 rounded-full bg-background disabled:invisible"
-                      aria-label="Scroll to latest message"
-                    >
-                      <ArrowDownIcon />
-                    </Button>
-                  </ThreadPrimitive.ScrollToBottom>
-                ) : null}
-                <ComposerPrimitive.Root className="flex items-end gap-2 rounded-2xl border bg-card p-1.5 shadow-sm focus-within:ring-2 focus-within:ring-ring/20">
-                  <ComposerPrimitive.Input
-                    className={cn(
-                      "max-h-44 flex-1 resize-none bg-transparent px-2 py-2.5 text-sm outline-none placeholder:text-muted-foreground",
-                      thread ? "min-h-10" : "min-h-28"
-                    )}
-                    placeholder={
-                      providerAvailable
-                        ? "Ask SurfSense about anything"
-                        : "Reconnect your model provider to send"
-                    }
-                    submitMode="enter"
-                    rows={1}
-                    aria-label="Message"
-                  />
-                  {!isRunning ? (
-                    <ComposerPrimitive.Send asChild>
-                      <Button
-                        size="icon-lg"
-                        className="mb-0.5 rounded-xl"
-                        aria-label="Send message"
-                      >
-                        <ArrowUp02Icon />
-                      </Button>
-                    </ComposerPrimitive.Send>
-                  ) : (
-                    <ComposerPrimitive.Cancel asChild>
-                      <Button
-                        size="icon-lg"
-                        variant="secondary"
-                        className="mb-0.5 rounded-xl"
-                        aria-label="Stop generating"
-                      >
-                        <CircleStopIcon />
-                      </Button>
-                    </ComposerPrimitive.Cancel>
-                  )}
-                </ComposerPrimitive.Root>
-                <div className="mt-1 flex min-h-7 items-center justify-between gap-3 px-2">
-                  <p className="min-w-0 text-left text-[11px] text-muted-foreground">
-                    {providerAvailable
-                      ? `${model.name} runs locally. Check important answers.`
-                      : "Historical chats remain available while the provider is offline."}
-                  </p>
-                  <button
-                    type="button"
-                    onClick={onModelSetup}
-                    className="flex shrink-0 cursor-pointer items-center gap-1.5 rounded-lg px-1.5 py-1 text-[11px] font-normal text-muted-foreground hover:bg-accent hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/20 focus-visible:outline-none"
-                    title="Change model"
-                    aria-label={`Model ${model.name} on ${model.provider}. Change model.`}
-                  >
-                    <span>{model.name}</span>
-                    <span>
-                      {providerAvailable ? model.provider : "Provider offline"}
-                    </span>
-                    <ChevronDownIcon className="size-3" />
-                  </button>
-                </div>
-              </div>
-            </ThreadPrimitive.ViewportFooter>
-          </ThreadPrimitive.Viewport>
+          </ChatViewport>
         </ThreadPrimitive.Root>
       </section>
     </AssistantRuntimeProvider>

--- a/surfsense_local/frontend/src/features/chat/use-chat-runtime.ts
+++ b/surfsense_local/frontend/src/features/chat/use-chat-runtime.ts
@@ -369,6 +369,25 @@ export function useChatRuntime({
                       : thread
                   )
               )
+            } else if (
+              event.type === "citation-catalog" ||
+              event.type === "citations"
+            ) {
+              const targetId = assistantId
+              setLiveMessages(
+                (current) =>
+                  current?.map((message) =>
+                    message.id === targetId
+                      ? {
+                          ...message,
+                          content: {
+                            ...message.content,
+                            citations: event.items,
+                          },
+                        }
+                      : message
+                  ) ?? null
+              )
             } else if (event.type === "delta") {
               setAutoNamingThreadId(null)
               const targetId = assistantId
@@ -381,22 +400,6 @@ export function useChatRuntime({
                           content: {
                             ...message.content,
                             text: (message.content.text ?? "") + event.text,
-                          },
-                        }
-                      : message
-                  ) ?? null
-              )
-            } else if (event.type === "citations") {
-              const targetId = assistantId
-              setLiveMessages(
-                (current) =>
-                  current?.map((message) =>
-                    message.id === targetId
-                      ? {
-                          ...message,
-                          content: {
-                            ...message.content,
-                            citations: event.items,
                           },
                         }
                       : message

--- a/surfsense_local/frontend/src/features/chat/use-chat-runtime.ts
+++ b/surfsense_local/frontend/src/features/chat/use-chat-runtime.ts
@@ -19,7 +19,6 @@ import {
   type ChatThread,
 } from "./api"
 import { chatKeys } from "./query-keys"
-import type { Citation } from "./sse"
 
 function messageFrom(error: unknown) {
   return error instanceof Error ? error.message : "An unexpected error occurred"
@@ -66,13 +65,6 @@ function initialThreadId(workspaceId: number, threads: ChatThread[]) {
     // The newest thread below is a safe fallback.
   }
   return threads[0]?.id ?? null
-}
-
-function latestCitations(messages: ChatMessage[]) {
-  return (
-    [...messages].reverse().find((message) => message.role === "assistant")
-      ?.content.citations ?? []
-  )
 }
 
 function hasCanonicalTurn(
@@ -122,13 +114,11 @@ export function useChatRuntime({
   workspaceId,
   canSend,
   selectedDocumentIds,
-  onCitations,
   onModelRequired,
 }: {
   workspaceId: number
   canSend: boolean
   selectedDocumentIds: number[]
-  onCitations: (citations: Citation[]) => void
   onModelRequired: () => void
 }) {
   const queryClient = useQueryClient()
@@ -191,12 +181,6 @@ export function useChatRuntime({
       renameThread(threadId, title),
   })
 
-  useEffect(() => {
-    if (!usesLiveMessages) {
-      onCitations(latestCitations(persistedMessages))
-    }
-  }, [onCitations, persistedMessages, usesLiveMessages])
-
   const selectThread = useCallback(
     (threadId: number) => {
       if (threadId === activeThreadId) {
@@ -211,9 +195,8 @@ export function useChatRuntime({
       setIsRunning(false)
       setAutoNamingThreadId(null)
       setAnimatingTitleThreadId(null)
-      onCitations([])
     },
-    [activeThreadId, onCitations, workspaceId]
+    [activeThreadId, workspaceId]
   )
 
   useEffect(() => {
@@ -233,8 +216,7 @@ export function useChatRuntime({
     setIsRunning(false)
     setAutoNamingThreadId(null)
     setAnimatingTitleThreadId(null)
-    onCitations([])
-  }, [onCitations, workspaceId])
+  }, [workspaceId])
 
   const removeThread = async (threadId: number) => {
     try {
@@ -405,7 +387,6 @@ export function useChatRuntime({
                   ) ?? null
               )
             } else if (event.type === "citations") {
-              onCitations(event.items)
               const targetId = assistantId
               setLiveMessages(
                 (current) =>
@@ -478,7 +459,6 @@ export function useChatRuntime({
       conversationView,
       createThreadMutation,
       isRunning,
-      onCitations,
       onModelRequired,
       queryClient,
       selectedDocumentIds,

--- a/surfsense_local/frontend/src/features/chat/use-chat-runtime.ts
+++ b/surfsense_local/frontend/src/features/chat/use-chat-runtime.ts
@@ -95,11 +95,15 @@ function areLiveMessagesPersisted(
 }
 
 function toRuntimeMessage(message: ChatMessage): ThreadMessageLike {
+  // SQLite stores CURRENT_TIMESTAMP in UTC but returns it without an offset.
+  const timestamp = /(?:Z|[+-]\d{2}:\d{2})$/i.test(message.created_at)
+    ? message.created_at
+    : `${message.created_at}Z`
   return {
     id: String(message.id),
     role: message.role,
     content: [{ type: "text", text: message.content.text ?? "" }],
-    createdAt: new Date(message.created_at),
+    createdAt: new Date(timestamp),
     metadata: {
       custom: {
         citations: message.content.citations ?? [],

--- a/surfsense_local/frontend/src/features/chat/use-chat-runtime.ts
+++ b/surfsense_local/frontend/src/features/chat/use-chat-runtime.ts
@@ -87,15 +87,16 @@ function areLiveMessagesPersisted(
 }
 
 function toRuntimeMessage(message: ChatMessage): ThreadMessageLike {
+  const value =
+    message.role === "assistant" ? message.completed_at : message.created_at
   // SQLite stores CURRENT_TIMESTAMP in UTC but returns it without an offset.
-  const timestamp = /(?:Z|[+-]\d{2}:\d{2})$/i.test(message.created_at)
-    ? message.created_at
-    : `${message.created_at}Z`
+  const timestamp =
+    value && !/(?:Z|[+-]\d{2}:\d{2})$/i.test(value) ? `${value}Z` : value
   return {
     id: String(message.id),
     role: message.role,
     content: [{ type: "text", text: message.content.text ?? "" }],
-    createdAt: new Date(timestamp),
+    ...(timestamp ? { createdAt: new Date(timestamp) } : {}),
     metadata: {
       custom: {
         citations: message.content.citations ?? [],
@@ -304,7 +305,6 @@ export function useChatRuntime({
           rememberThread(workspaceId, thread.id)
         }
 
-        const timestamp = new Date().toISOString()
         let userId: number | string = `optimistic-user-${version}`
         let assistantId: number | string = `optimistic-assistant-${version}`
         const currentMessages =
@@ -317,13 +317,15 @@ export function useChatRuntime({
             id: userId,
             role: "user",
             content: { text },
-            created_at: timestamp,
+            created_at: null,
+            completed_at: null,
           },
           {
             id: assistantId,
             role: "assistant",
             content: { text: "", citations: [] },
-            created_at: timestamp,
+            created_at: null,
+            completed_at: null,
           },
         ])
 
@@ -349,13 +351,30 @@ export function useChatRuntime({
                 (current) =>
                   current?.map((message) => {
                     if (message.id === previousUserId) {
-                      return { ...message, id: nextUserId }
+                      return {
+                        ...message,
+                        id: nextUserId,
+                        created_at: event.user_created_at,
+                      }
                     }
                     if (message.id === previousAssistantId) {
                       return { ...message, id: nextAssistantId }
                     }
                     return message
                   }) ?? null
+              )
+            } else if (event.type === "completed") {
+              const targetId = assistantId
+              setLiveMessages(
+                (current) =>
+                  current?.map((message) =>
+                    message.id === targetId
+                      ? {
+                          ...message,
+                          completed_at: event.assistant_completed_at,
+                        }
+                      : message
+                  ) ?? null
               )
             } else if (event.type === "thread-title-update") {
               setAutoNamingThreadId(null)

--- a/surfsense_local/frontend/src/features/chat/use-chat-runtime.ts
+++ b/surfsense_local/frontend/src/features/chat/use-chat-runtime.ts
@@ -136,6 +136,9 @@ export function useChatRuntime({
   const [autoNamingThreadId, setAutoNamingThreadId] = useState<number | null>(
     null
   )
+  const [animatingTitleThreadId, setAnimatingTitleThreadId] = useState<
+    number | null
+  >(null)
   const [error, setError] = useState<string | null>(null)
   const streamController = useRef<AbortController | null>(null)
   const requestVersion = useRef(0)
@@ -203,6 +206,7 @@ export function useChatRuntime({
       setError(null)
       setIsRunning(false)
       setAutoNamingThreadId(null)
+      setAnimatingTitleThreadId(null)
       onCitations([])
     },
     [activeThreadId, onCitations, workspaceId]
@@ -224,6 +228,7 @@ export function useChatRuntime({
     setError(null)
     setIsRunning(false)
     setAutoNamingThreadId(null)
+    setAnimatingTitleThreadId(null)
     onCitations([])
   }, [onCitations, workspaceId])
 
@@ -252,6 +257,7 @@ export function useChatRuntime({
         threadId,
         title,
       })
+      setAnimatingTitleThreadId(null)
       queryClient.setQueryData<ChatThread[]>(
         chatKeys.threads(workspaceId),
         (current = []) =>
@@ -367,6 +373,7 @@ export function useChatRuntime({
               )
             } else if (event.type === "thread-title-update") {
               setAutoNamingThreadId(null)
+              setAnimatingTitleThreadId(threadId)
               queryClient.setQueryData<ChatThread[]>(
                 chatKeys.threads(workspaceId),
                 (current = []) =>
@@ -481,6 +488,10 @@ export function useChatRuntime({
     setAutoNamingThreadId(null)
   }, [])
 
+  const finishTitleAnimation = useCallback(() => {
+    setAnimatingTitleThreadId(null)
+  }, [])
+
   const isLoadingThreads = threadsQuery.isPending
   const isLoadingMessages =
     activeThreadId !== null && !usesLiveMessages && messagesQuery.isPending
@@ -511,6 +522,8 @@ export function useChatRuntime({
     isLoadingMessages,
     isRunning,
     autoNamingThreadId,
+    animatingTitleThreadId,
+    finishTitleAnimation,
     selectThread,
     startNewChat,
     rename,

--- a/surfsense_local/frontend/src/features/chat/use-chat-runtime.ts
+++ b/surfsense_local/frontend/src/features/chat/use-chat-runtime.ts
@@ -36,10 +36,6 @@ function submittedText(message: AppendMessage) {
     .trim()
 }
 
-function threadTitle(text: string) {
-  return (text.split(/\r?\n/, 1)[0].trim() || "New chat").slice(0, 80)
-}
-
 const EMPTY_THREADS: ChatThread[] = []
 const EMPTY_MESSAGES: ChatMessage[] = []
 
@@ -267,7 +263,7 @@ export function useChatRuntime({
         if (threadId === null) {
           setConversationView({ status: "creating" })
           const thread = await createThreadMutation.mutateAsync({
-            title: threadTitle(text),
+            title: "New chat",
             signal: controller.signal,
           })
           if (requestVersion.current !== version) {
@@ -338,6 +334,16 @@ export function useChatRuntime({
                     }
                     return message
                   }) ?? null
+              )
+            } else if (event.type === "thread-title-update") {
+              queryClient.setQueryData<ChatThread[]>(
+                chatKeys.threads(workspaceId),
+                (current = []) =>
+                  current.map((thread) =>
+                    thread.id === threadId
+                      ? { ...thread, title: event.title }
+                      : thread
+                  )
               )
             } else if (event.type === "delta") {
               const targetId = assistantId

--- a/surfsense_local/frontend/src/features/chat/use-chat-runtime.ts
+++ b/surfsense_local/frontend/src/features/chat/use-chat-runtime.ts
@@ -13,6 +13,7 @@ import {
   deleteThread,
   listMessages,
   listThreads,
+  renameThread,
   streamMessage,
   type ChatMessage,
   type ChatThread,
@@ -132,6 +133,9 @@ export function useChatRuntime({
   )
   const [liveMessages, setLiveMessages] = useState<ChatMessage[] | null>(null)
   const [isRunning, setIsRunning] = useState(false)
+  const [autoNamingThreadId, setAutoNamingThreadId] = useState<number | null>(
+    null
+  )
   const [error, setError] = useState<string | null>(null)
   const streamController = useRef<AbortController | null>(null)
   const requestVersion = useRef(0)
@@ -175,6 +179,10 @@ export function useChatRuntime({
   const deleteThreadMutation = useMutation({
     mutationFn: (threadId: number) => deleteThread(threadId),
   })
+  const renameThreadMutation = useMutation({
+    mutationFn: ({ threadId, title }: { threadId: number; title: string }) =>
+      renameThread(threadId, title),
+  })
 
   useEffect(() => {
     if (!usesLiveMessages) {
@@ -194,6 +202,7 @@ export function useChatRuntime({
       setLiveMessages(null)
       setError(null)
       setIsRunning(false)
+      setAutoNamingThreadId(null)
       onCitations([])
     },
     [activeThreadId, onCitations, workspaceId]
@@ -214,6 +223,7 @@ export function useChatRuntime({
     setLiveMessages(null)
     setError(null)
     setIsRunning(false)
+    setAutoNamingThreadId(null)
     onCitations([])
   }, [onCitations, workspaceId])
 
@@ -232,6 +242,25 @@ export function useChatRuntime({
       }
     } catch (cause) {
       setError(messageFrom(cause))
+    }
+  }
+
+  const rename = async (threadId: number, title: string) => {
+    setError(null)
+    try {
+      const renamed = await renameThreadMutation.mutateAsync({
+        threadId,
+        title,
+      })
+      queryClient.setQueryData<ChatThread[]>(
+        chatKeys.threads(workspaceId),
+        (current = []) =>
+          current.map((thread) => (thread.id === renamed.id ? renamed : thread))
+      )
+      return true
+    } catch (cause) {
+      setError(messageFrom(cause))
+      return false
     }
   }
 
@@ -279,6 +308,7 @@ export function useChatRuntime({
           )
           queryClient.setQueryData(chatKeys.messages(thread.id), EMPTY_MESSAGES)
           setConversationView({ status: "active", threadId: thread.id })
+          setAutoNamingThreadId(thread.id)
           rememberThread(workspaceId, thread.id)
         }
 
@@ -336,6 +366,7 @@ export function useChatRuntime({
                   }) ?? null
               )
             } else if (event.type === "thread-title-update") {
+              setAutoNamingThreadId(null)
               queryClient.setQueryData<ChatThread[]>(
                 chatKeys.threads(workspaceId),
                 (current = []) =>
@@ -346,6 +377,7 @@ export function useChatRuntime({
                   )
               )
             } else if (event.type === "delta") {
+              setAutoNamingThreadId(null)
               const targetId = assistantId
               setLiveMessages(
                 (current) =>
@@ -426,6 +458,7 @@ export function useChatRuntime({
       } finally {
         if (requestVersion.current === version) {
           setIsRunning(false)
+          setAutoNamingThreadId(null)
         }
       }
     },
@@ -445,6 +478,7 @@ export function useChatRuntime({
   const cancel = useCallback(async () => {
     streamController.current?.abort()
     setIsRunning(false)
+    setAutoNamingThreadId(null)
   }, [])
 
   const isLoadingThreads = threadsQuery.isPending
@@ -476,8 +510,10 @@ export function useChatRuntime({
     isLoadingThreads,
     isLoadingMessages,
     isRunning,
+    autoNamingThreadId,
     selectThread,
     startNewChat,
+    rename,
     removeThread,
     clearError: () => setError(null),
   }

--- a/surfsense_local/frontend/src/features/chat/use-chat-runtime.ts
+++ b/surfsense_local/frontend/src/features/chat/use-chat-runtime.ts
@@ -91,12 +91,9 @@ function areLiveMessagesPersisted(
   liveMessages: ChatMessage[],
   persistedMessages: ChatMessage[]
 ) {
-  const persistedIds = new Set(
-    persistedMessages.map((message) => message.id)
-  )
+  const persistedIds = new Set(persistedMessages.map((message) => message.id))
   return liveMessages.every(
-    (message) =>
-      typeof message.id === "number" && persistedIds.has(message.id)
+    (message) => typeof message.id === "number" && persistedIds.has(message.id)
   )
 }
 
@@ -114,6 +111,12 @@ function toRuntimeMessage(message: ChatMessage): ThreadMessageLike {
   }
 }
 
+export type ConversationView =
+  | { status: "initializing" }
+  | { status: "new" }
+  | { status: "creating" }
+  | { status: "active"; threadId: number }
+
 export function useChatRuntime({
   workspaceId,
   canSend,
@@ -128,19 +131,32 @@ export function useChatRuntime({
   onModelRequired: () => void
 }) {
   const queryClient = useQueryClient()
-  const [activeThreadId, setActiveThreadId] = useState<number | null>(null)
+  const [selectedView, setConversationView] = useState<ConversationView | null>(
+    null
+  )
   const [liveMessages, setLiveMessages] = useState<ChatMessage[] | null>(null)
   const [isRunning, setIsRunning] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const streamController = useRef<AbortController | null>(null)
   const requestVersion = useRef(0)
-  const initializedSelection = useRef(false)
 
   const threadsQuery = useQuery({
     queryKey: chatKeys.threads(workspaceId),
     queryFn: ({ signal }) => listThreads(workspaceId, signal),
   })
   const threads = threadsQuery.data ?? EMPTY_THREADS
+  const initialView = useMemo<ConversationView>(() => {
+    if (!threadsQuery.isSuccess) {
+      return { status: "initializing" }
+    }
+    const threadId = initialThreadId(workspaceId, threads)
+    return threadId === null
+      ? { status: "new" }
+      : { status: "active", threadId }
+  }, [threads, threadsQuery.isSuccess, workspaceId])
+  const conversationView = selectedView ?? initialView
+  const activeThreadId =
+    conversationView.status === "active" ? conversationView.threadId : null
 
   const messagesQuery = useQuery({
     queryKey: [...chatKeys.all, "messages", activeThreadId] as const,
@@ -157,29 +173,12 @@ export function useChatRuntime({
   const messages = usesLiveMessages ? liveMessages : persistedMessages
 
   const createThreadMutation = useMutation({
-    mutationFn: ({
-      title,
-      signal,
-    }: {
-      title: string
-      signal: AbortSignal
-    }) => createThread(workspaceId, title, signal),
+    mutationFn: ({ title, signal }: { title: string; signal: AbortSignal }) =>
+      createThread(workspaceId, title, signal),
   })
   const deleteThreadMutation = useMutation({
     mutationFn: (threadId: number) => deleteThread(threadId),
   })
-
-  useEffect(() => {
-    if (!threadsQuery.isSuccess || initializedSelection.current) {
-      return
-    }
-    initializedSelection.current = true
-    const threadId = initialThreadId(workspaceId, threads)
-    setActiveThreadId(threadId)
-    if (threadId !== null) {
-      rememberThread(workspaceId, threadId)
-    }
-  }, [threads, threadsQuery.isSuccess, workspaceId])
 
   useEffect(() => {
     if (!usesLiveMessages) {
@@ -194,7 +193,7 @@ export function useChatRuntime({
       }
       streamController.current?.abort()
       requestVersion.current += 1
-      setActiveThreadId(threadId)
+      setConversationView({ status: "active", threadId })
       rememberThread(workspaceId, threadId)
       setLiveMessages(null)
       setError(null)
@@ -214,8 +213,7 @@ export function useChatRuntime({
   const startNewChat = useCallback(() => {
     streamController.current?.abort()
     requestVersion.current += 1
-    initializedSelection.current = true
-    setActiveThreadId(null)
+    setConversationView({ status: "new" })
     rememberThread(workspaceId, null)
     setLiveMessages(null)
     setError(null)
@@ -244,7 +242,13 @@ export function useChatRuntime({
   const onNew = useCallback(
     async (appendMessage: AppendMessage) => {
       const text = submittedText(appendMessage)
-      if (!text || isRunning || !canSend) {
+      if (
+        !text ||
+        isRunning ||
+        !canSend ||
+        conversationView.status === "initializing" ||
+        conversationView.status === "creating"
+      ) {
         return
       }
 
@@ -255,11 +259,13 @@ export function useChatRuntime({
       setError(null)
       setIsRunning(true)
 
-      let threadId = activeThreadId
+      let threadId =
+        conversationView.status === "active" ? conversationView.threadId : null
       let userMessageId: number | null = null
       let assistantMessageId: number | null = null
       try {
         if (threadId === null) {
+          setConversationView({ status: "creating" })
           const thread = await createThreadMutation.mutateAsync({
             title: threadTitle(text),
             signal: controller.signal,
@@ -276,7 +282,7 @@ export function useChatRuntime({
             ]
           )
           queryClient.setQueryData(chatKeys.messages(thread.id), EMPTY_MESSAGES)
-          setActiveThreadId(thread.id)
+          setConversationView({ status: "active", threadId: thread.id })
           rememberThread(workspaceId, thread.id)
         }
 
@@ -284,8 +290,9 @@ export function useChatRuntime({
         let userId: number | string = `optimistic-user-${version}`
         let assistantId: number | string = `optimistic-assistant-${version}`
         const currentMessages =
-          queryClient.getQueryData<ChatMessage[]>(chatKeys.messages(threadId)) ??
-          EMPTY_MESSAGES
+          queryClient.getQueryData<ChatMessage[]>(
+            chatKeys.messages(threadId)
+          ) ?? EMPTY_MESSAGES
         setLiveMessages([
           ...currentMessages,
           {
@@ -320,47 +327,50 @@ export function useChatRuntime({
               assistantMessageId = nextAssistantId
               userId = nextUserId
               assistantId = nextAssistantId
-              setLiveMessages((current) =>
-                current?.map((message) => {
-                  if (message.id === previousUserId) {
-                    return { ...message, id: nextUserId }
-                  }
-                  if (message.id === previousAssistantId) {
-                    return { ...message, id: nextAssistantId }
-                  }
-                  return message
-                }) ?? null
+              setLiveMessages(
+                (current) =>
+                  current?.map((message) => {
+                    if (message.id === previousUserId) {
+                      return { ...message, id: nextUserId }
+                    }
+                    if (message.id === previousAssistantId) {
+                      return { ...message, id: nextAssistantId }
+                    }
+                    return message
+                  }) ?? null
               )
             } else if (event.type === "delta") {
               const targetId = assistantId
-              setLiveMessages((current) =>
-                current?.map((message) =>
-                  message.id === targetId
-                    ? {
-                        ...message,
-                        content: {
-                          ...message.content,
-                          text: (message.content.text ?? "") + event.text,
-                        },
-                      }
-                    : message
-                ) ?? null
+              setLiveMessages(
+                (current) =>
+                  current?.map((message) =>
+                    message.id === targetId
+                      ? {
+                          ...message,
+                          content: {
+                            ...message.content,
+                            text: (message.content.text ?? "") + event.text,
+                          },
+                        }
+                      : message
+                  ) ?? null
               )
             } else if (event.type === "citations") {
               onCitations(event.items)
               const targetId = assistantId
-              setLiveMessages((current) =>
-                current?.map((message) =>
-                  message.id === targetId
-                    ? {
-                        ...message,
-                        content: {
-                          ...message.content,
-                          citations: event.items,
-                        },
-                      }
-                    : message
-                ) ?? null
+              setLiveMessages(
+                (current) =>
+                  current?.map((message) =>
+                    message.id === targetId
+                      ? {
+                          ...message,
+                          content: {
+                            ...message.content,
+                            citations: event.items,
+                          },
+                        }
+                      : message
+                  ) ?? null
               )
             } else if (event.type === "error") {
               setError(event.message)
@@ -381,11 +391,7 @@ export function useChatRuntime({
           })
           if (
             requestVersion.current === version &&
-            hasCanonicalTurn(
-              canonical,
-              userMessageId,
-              assistantMessageId
-            )
+            hasCanonicalTurn(canonical, userMessageId, assistantMessageId)
           ) {
             setLiveMessages(null)
           } else {
@@ -395,6 +401,9 @@ export function useChatRuntime({
           }
         }
       } catch (cause) {
+        if (threadId === null && requestVersion.current === version) {
+          setConversationView({ status: "new" })
+        }
         if (
           cause instanceof ApiError &&
           cause.status === 409 &&
@@ -415,8 +424,8 @@ export function useChatRuntime({
       }
     },
     [
-      activeThreadId,
       canSend,
+      conversationView,
       createThreadMutation,
       isRunning,
       onCitations,
@@ -434,9 +443,7 @@ export function useChatRuntime({
 
   const isLoadingThreads = threadsQuery.isPending
   const isLoadingMessages =
-    activeThreadId !== null &&
-    !usesLiveMessages &&
-    messagesQuery.isPending
+    activeThreadId !== null && !usesLiveMessages && messagesQuery.isPending
   const queryError = threadsQuery.error ?? messagesQuery.error
   const runtime = useExternalStoreRuntime<ChatMessage>({
     messages,
@@ -455,6 +462,7 @@ export function useChatRuntime({
   return {
     runtime,
     threads,
+    conversationView,
     activeThread,
     activeThreadId,
     messages,

--- a/surfsense_local/frontend/src/features/dashboard/dashboard-page.test.tsx
+++ b/surfsense_local/frontend/src/features/dashboard/dashboard-page.test.tsx
@@ -125,7 +125,7 @@ describe("dashboard chat", () => {
         .getByRole("textbox", { name: "Message" })
         .closest('[data-composer-placement="bottom"]')
       expect(bottomComposer).toBeTruthy()
-      expect(bottomComposer?.closest("[data-chat-viewport]")).toBeNull()
+      expect(bottomComposer?.closest("[data-chat-viewport]")).toBeTruthy()
     })
 
     resolveCreate(

--- a/surfsense_local/frontend/src/features/dashboard/dashboard-page.test.tsx
+++ b/surfsense_local/frontend/src/features/dashboard/dashboard-page.test.tsx
@@ -278,6 +278,18 @@ describe("dashboard chat", () => {
             },
           ])
         }
+        if (path === "/workspaces/1/documents/20") {
+          return Response.json({
+            id: 20,
+            title: "Guide.txt",
+            document_type: "FILE",
+            status: "ready",
+            error_message: null,
+            content: "Grounded\nanswer",
+            created_at: "2026-09-05T00:00:00Z",
+            updated_at: "2026-09-05T00:00:00Z",
+          })
+        }
         if (path === "/workspaces/1/chat/threads" && init?.method === "POST") {
           return Response.json(
             {
@@ -293,7 +305,7 @@ describe("dashboard chat", () => {
         if (path === "/chat/threads/10/messages" && init?.method === "POST") {
           messageSent = true
           return new Response(
-            'data: {"type":"accepted","user_message_id":100,"assistant_message_id":101}\n\ndata: {"type":"delta","text":"Grounded "}\n\ndata: {"type":"delta","text":"answer"}\n\ndata: {"type":"citations","items":[{"chunk_id":30,"document_id":20,"start_line":1,"end_line":2}]}\n\ndata: [DONE]\n\n',
+            'data: {"type":"accepted","user_message_id":100,"assistant_message_id":101}\n\ndata: {"type":"citation-catalog","items":[{"source_id":1,"chunk_id":30,"document_id":20,"start_line":1,"end_line":2}]}\n\ndata: {"type":"delta","text":"Grounded answer [citation:1]"}\n\ndata: {"type":"citations","items":[{"source_id":1,"chunk_id":30,"document_id":20,"start_line":1,"end_line":2}]}\n\ndata: [DONE]\n\n',
             { headers: { "Content-Type": "text/event-stream" } }
           )
         }
@@ -316,9 +328,10 @@ describe("dashboard chat", () => {
               id: 101,
               role: "assistant",
               content: {
-                text: "Grounded answer",
+                text: "Grounded answer [citation:1]",
                 citations: [
                   {
+                    source_id: 1,
                     chunk_id: 30,
                     document_id: 20,
                     start_line: 1,
@@ -370,6 +383,12 @@ describe("dashboard chat", () => {
     await user.click(screen.getByRole("button", { name: "Send message" }))
 
     expect(await screen.findByText("Grounded answer")).toBeTruthy()
+    await user.click(
+      screen.getByRole("button", { name: "Open source 1: Guide.txt" })
+    )
+    expect(
+      await screen.findByRole("complementary", { name: "Source preview" })
+    ).toBeTruthy()
     expect(screen.queryByText("Used in answer")).toBeNull()
     resolveCanonical(Response.json([]))
     await screen.findByRole("button", { name: "Send message" })

--- a/surfsense_local/frontend/src/features/dashboard/dashboard-page.test.tsx
+++ b/surfsense_local/frontend/src/features/dashboard/dashboard-page.test.tsx
@@ -36,6 +36,87 @@ beforeEach(() => {
 })
 
 describe("dashboard chat", () => {
+  it("renames a saved chat from the sidebar", async () => {
+    const thread = {
+      id: 10,
+      workspace_id: 1,
+      title: "Original title",
+      created_at: "2026-09-05T00:00:00Z",
+      updated_at: "2026-09-05T00:00:00Z",
+    }
+    const fetchMock = vi.fn(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const path = String(input)
+        if (path === "/llm/providers") {
+          return Response.json([
+            { name: "ollama", healthy: true, can_download: true },
+          ])
+        }
+        if (
+          path ===
+          "/workspaces/1/documents?document_type=FILE&document_type=NOTE"
+        ) {
+          return Response.json([])
+        }
+        if (path === "/workspaces/1/chat/threads") {
+          return Response.json([thread])
+        }
+        if (path === "/chat/threads/10/messages") {
+          return Response.json([])
+        }
+        if (
+          path === "/chat/threads/10" &&
+          init?.method === "PATCH" &&
+          typeof init.body === "string"
+        ) {
+          return Response.json({
+            ...thread,
+            title: JSON.parse(init.body).title,
+          })
+        }
+        return Response.json({ detail: "not found" }, { status: 404 })
+      }
+    )
+    vi.stubGlobal("fetch", fetchMock)
+    const user = userEvent.setup()
+
+    render(
+      <TooltipProvider>
+        <DashboardPage
+          selection={{
+            role: "generation",
+            provider: "ollama",
+            name: "llama3.2:1b",
+            updated_at: "2026-09-05T00:00:00Z",
+          }}
+          initialWorkspaces={[workspace]}
+          onModelRequired={vi.fn()}
+        />
+      </TooltipProvider>
+    )
+
+    await screen.findByRole("heading", { name: "Original title" })
+    await user.click(
+      screen.getByRole("button", { name: "Actions for Original title" })
+    )
+    await user.click(screen.getByRole("menuitem", { name: "Rename" }))
+    const input = screen.getByRole("textbox", { name: "Chat name" })
+    await user.clear(input)
+    await user.type(input, "Banking fees")
+    await user.click(screen.getByRole("button", { name: "Rename" }))
+
+    expect(
+      await screen.findByRole("heading", { name: "Banking fees" })
+    ).toBeTruthy()
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/chat/threads/10",
+      expect.objectContaining({
+        method: "PATCH",
+        body: JSON.stringify({ title: "Banking fees" }),
+      })
+    )
+  })
+
   it("keeps composer placement aligned with the conversation lifecycle", async () => {
     let resolveThreads!: (response: Response) => void
     let resolveCreate!: (response: Response) => void

--- a/surfsense_local/frontend/src/features/dashboard/dashboard-page.test.tsx
+++ b/surfsense_local/frontend/src/features/dashboard/dashboard-page.test.tsx
@@ -190,9 +190,13 @@ describe("dashboard chat", () => {
     )
 
     expect(screen.queryByRole("textbox", { name: "Message" })).toBeNull()
+    expect(
+      screen.queryByRole("heading", { name: "New chat" })
+    ).toBeNull()
 
     resolveThreads(Response.json([]))
     const input = await screen.findByRole("textbox", { name: "Message" })
+    expect(screen.getByRole("heading", { name: "New chat" })).toBeTruthy()
     expect(input.closest('[data-composer-placement="center"]')).toBeTruthy()
     expect(
       screen.getByRole("region", { name: "Conversation" }).parentElement

--- a/surfsense_local/frontend/src/features/dashboard/dashboard-page.test.tsx
+++ b/surfsense_local/frontend/src/features/dashboard/dashboard-page.test.tsx
@@ -33,6 +33,16 @@ beforeEach(() => {
     configurable: true,
     value: vi.fn(),
   })
+  Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+    configurable: true,
+    value: vi.fn(),
+  })
+  vi.stubGlobal("surfsense", {
+    apiUrl: "",
+    platform: "darwin",
+    openDocument: vi.fn(async () => ""),
+    revealDocument: vi.fn(async () => ""),
+  })
 })
 
 describe("dashboard chat", () => {
@@ -283,18 +293,6 @@ describe("dashboard chat", () => {
             },
           ])
         }
-        if (path === "/workspaces/1/documents/20") {
-          return Response.json({
-            id: 20,
-            title: "Guide.txt",
-            document_type: "FILE",
-            status: "ready",
-            error_message: null,
-            content: "Grounded\nanswer",
-            created_at: "2026-09-05T00:00:00Z",
-            updated_at: "2026-09-05T00:00:00Z",
-          })
-        }
         if (path === "/workspaces/1/chat/threads" && init?.method === "POST") {
           return Response.json(
             {
@@ -391,12 +389,21 @@ describe("dashboard chat", () => {
 
     expect(await screen.findByText("Grounded answer")).toBeTruthy()
     await user.click(
-      screen.getByRole("button", { name: "Open source 1: Guide.txt" })
+      screen.getByRole("button", { name: "Show source 1: Guide.txt" })
     )
+    const sourceButton = screen.getByRole("button", { name: "Guide.txt" })
+    expect(sourceButton.parentElement?.getAttribute("aria-current")).toBe(
+      "true"
+    )
+    expect(window.surfsense?.openDocument).not.toHaveBeenCalled()
+
+    await user.click(sourceButton)
+    expect(window.surfsense?.openDocument).toHaveBeenCalledWith(1, 20)
     expect(
-      await screen.findByRole("complementary", { name: "Source preview" })
-    ).toBeTruthy()
-    expect(screen.queryByText("Used in answer")).toBeNull()
+      fetchMock.mock.calls.some(
+        ([path]) => String(path) === "/workspaces/1/documents/20"
+      )
+    ).toBe(false)
     resolveCanonical(Response.json([]))
     await screen.findByRole("button", { name: "Send message" })
     await waitFor(() => {

--- a/surfsense_local/frontend/src/features/dashboard/dashboard-page.test.tsx
+++ b/surfsense_local/frontend/src/features/dashboard/dashboard-page.test.tsx
@@ -36,6 +36,131 @@ beforeEach(() => {
 })
 
 describe("dashboard chat", () => {
+  it("keeps composer placement aligned with the conversation lifecycle", async () => {
+    let resolveThreads!: (response: Response) => void
+    let resolveCreate!: (response: Response) => void
+    const threadsResponse = new Promise<Response>((resolve) => {
+      resolveThreads = resolve
+    })
+    const createResponse = new Promise<Response>((resolve) => {
+      resolveCreate = resolve
+    })
+    const fetchMock = vi.fn(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const path = String(input)
+        if (path === "/llm/providers") {
+          return Response.json([
+            { name: "ollama", healthy: true, can_download: true },
+          ])
+        }
+        if (
+          path ===
+          "/workspaces/1/documents?document_type=FILE&document_type=NOTE"
+        ) {
+          return Response.json([])
+        }
+        if (path === "/workspaces/1/chat/threads" && !init?.method) {
+          return threadsResponse
+        }
+        if (path === "/workspaces/1/chat/threads" && init?.method === "POST") {
+          return createResponse
+        }
+        if (path === "/chat/threads/10/messages" && init?.method === "POST") {
+          return new Response(
+            'data: {"type":"accepted","user_message_id":100,"assistant_message_id":101}\n\ndata: [DONE]\n\n',
+            { headers: { "Content-Type": "text/event-stream" } }
+          )
+        }
+        if (path === "/chat/threads/10/messages") {
+          return Response.json([
+            {
+              id: 100,
+              role: "user",
+              content: { text: "Start a chat" },
+              created_at: "2026-09-05T00:00:00Z",
+            },
+            {
+              id: 101,
+              role: "assistant",
+              content: { text: "", citations: [] },
+              created_at: "2026-09-05T00:00:01Z",
+            },
+          ])
+        }
+        return Response.json({ detail: "not found" }, { status: 404 })
+      }
+    )
+    vi.stubGlobal("fetch", fetchMock)
+    const user = userEvent.setup()
+
+    render(
+      <TooltipProvider>
+        <DashboardPage
+          selection={{
+            role: "generation",
+            provider: "ollama",
+            name: "llama3.2:1b",
+            updated_at: "2026-09-05T00:00:00Z",
+          }}
+          initialWorkspaces={[workspace]}
+          onModelRequired={vi.fn()}
+        />
+      </TooltipProvider>
+    )
+
+    expect(screen.queryByRole("textbox", { name: "Message" })).toBeNull()
+
+    resolveThreads(Response.json([]))
+    const input = await screen.findByRole("textbox", { name: "Message" })
+    expect(input.closest('[data-composer-placement="center"]')).toBeTruthy()
+    expect(
+      screen.getByRole("region", { name: "Conversation" }).parentElement
+        ?.className
+    ).toContain("grid-rows-[minmax(0,1fr)]")
+
+    await user.type(input, "Start a chat")
+    await user.click(screen.getByRole("button", { name: "Send message" }))
+    await waitFor(() => {
+      const bottomComposer = screen
+        .getByRole("textbox", { name: "Message" })
+        .closest('[data-composer-placement="bottom"]')
+      expect(bottomComposer).toBeTruthy()
+      expect(bottomComposer?.closest("[data-chat-viewport]")).toBeNull()
+    })
+
+    resolveCreate(
+      Response.json(
+        {
+          id: 10,
+          workspace_id: 1,
+          title: "Start a chat",
+          created_at: "2026-09-05T00:00:00Z",
+          updated_at: "2026-09-05T00:00:00Z",
+        },
+        { status: 201 }
+      )
+    )
+    await screen.findByRole("heading", { name: "Start a chat" })
+    expect(
+      screen
+        .getByRole("textbox", { name: "Message" })
+        .closest('[data-composer-placement="bottom"]')
+    ).toBeTruthy()
+
+    const activeInput = await screen.findByRole("textbox", { name: "Message" })
+    await screen.findByRole("button", { name: "Send message" })
+    await user.type(activeInput, "Discard this draft")
+    await user.click(screen.getByRole("button", { name: "New chat" }))
+
+    await waitFor(() => {
+      const resetInput = screen.getByRole("textbox", { name: "Message" })
+      expect(
+        resetInput.closest('[data-composer-placement="center"]')
+      ).toBeTruthy()
+      expect((resetInput as HTMLTextAreaElement).value).toBe("")
+    })
+  })
+
   it("creates a thread on first send and scopes retrieval to selected sources", async () => {
     let messageSent = false
     let messageReads = 0

--- a/surfsense_local/frontend/src/features/dashboard/dashboard-page.test.tsx
+++ b/surfsense_local/frontend/src/features/dashboard/dashboard-page.test.tsx
@@ -148,7 +148,7 @@ describe("dashboard chat", () => {
         }
         if (path === "/chat/threads/10/messages" && init?.method === "POST") {
           return new Response(
-            'data: {"type":"accepted","user_message_id":100,"assistant_message_id":101}\n\ndata: [DONE]\n\n',
+            'data: {"type":"accepted","user_message_id":100,"assistant_message_id":101,"user_created_at":"2026-09-05T00:00:00Z"}\n\ndata: {"type":"completed","assistant_completed_at":"2026-09-05T00:00:01Z"}\n\ndata: [DONE]\n\n',
             { headers: { "Content-Type": "text/event-stream" } }
           )
         }
@@ -159,12 +159,14 @@ describe("dashboard chat", () => {
               role: "user",
               content: { text: "Start a chat" },
               created_at: "2026-09-05T00:00:00Z",
+              completed_at: null,
             },
             {
               id: 101,
               role: "assistant",
               content: { text: "", citations: [] },
               created_at: "2026-09-05T00:00:01Z",
+              completed_at: "2026-09-05T00:00:01Z",
             },
           ])
         }
@@ -224,6 +226,9 @@ describe("dashboard chat", () => {
       )
     )
     await screen.findByRole("heading", { name: "Start a chat" })
+    await waitFor(() => {
+      expect(document.querySelectorAll("time")).toHaveLength(1)
+    })
     expect(
       screen
         .getByRole("textbox", { name: "Message" })
@@ -305,7 +310,7 @@ describe("dashboard chat", () => {
         if (path === "/chat/threads/10/messages" && init?.method === "POST") {
           messageSent = true
           return new Response(
-            'data: {"type":"accepted","user_message_id":100,"assistant_message_id":101}\n\ndata: {"type":"citation-catalog","items":[{"source_id":1,"chunk_id":30,"document_id":20,"start_line":1,"end_line":2}]}\n\ndata: {"type":"delta","text":"Grounded answer [citation:1]"}\n\ndata: {"type":"citations","items":[{"source_id":1,"chunk_id":30,"document_id":20,"start_line":1,"end_line":2}]}\n\ndata: [DONE]\n\n',
+            'data: {"type":"accepted","user_message_id":100,"assistant_message_id":101,"user_created_at":"2026-09-05T00:00:00Z"}\n\ndata: {"type":"citation-catalog","items":[{"source_id":1,"chunk_id":30,"document_id":20,"start_line":1,"end_line":2}]}\n\ndata: {"type":"delta","text":"Grounded answer [citation:1]"}\n\ndata: {"type":"citations","items":[{"source_id":1,"chunk_id":30,"document_id":20,"start_line":1,"end_line":2}]}\n\ndata: {"type":"completed","assistant_completed_at":"2026-09-05T00:00:01Z"}\n\ndata: [DONE]\n\n',
             { headers: { "Content-Type": "text/event-stream" } }
           )
         }
@@ -323,6 +328,7 @@ describe("dashboard chat", () => {
               role: "user",
               content: { text: "What is indexed?" },
               created_at: "2026-09-05T00:00:00Z",
+              completed_at: null,
             },
             {
               id: 101,
@@ -340,6 +346,7 @@ describe("dashboard chat", () => {
                 ],
               },
               created_at: "2026-09-05T00:00:01Z",
+              completed_at: "2026-09-05T00:00:01Z",
             },
           ])
         }
@@ -395,6 +402,7 @@ describe("dashboard chat", () => {
     await waitFor(() => {
       expect(messageReads).toBe(2)
       expect(screen.getByText("Grounded answer")).toBeTruthy()
+      expect(document.querySelectorAll("time")).toHaveLength(2)
     })
     await waitFor(() => {
       expect(

--- a/surfsense_local/frontend/src/features/dashboard/dashboard-page.test.tsx
+++ b/surfsense_local/frontend/src/features/dashboard/dashboard-page.test.tsx
@@ -190,9 +190,7 @@ describe("dashboard chat", () => {
     )
 
     expect(screen.queryByRole("textbox", { name: "Message" })).toBeNull()
-    expect(
-      screen.queryByRole("heading", { name: "New chat" })
-    ).toBeNull()
+    expect(screen.queryByRole("heading", { name: "New chat" })).toBeNull()
 
     resolveThreads(Response.json([]))
     const input = await screen.findByRole("textbox", { name: "Message" })
@@ -372,10 +370,7 @@ describe("dashboard chat", () => {
     await user.click(screen.getByRole("button", { name: "Send message" }))
 
     expect(await screen.findByText("Grounded answer")).toBeTruthy()
-    expect(await screen.findByText("Used in answer")).toBeTruthy()
-    expect(
-      screen.getByRole("button", { name: "Source 1: Guide.txt" })
-    ).toBeTruthy()
+    expect(screen.queryByText("Used in answer")).toBeNull()
     resolveCanonical(Response.json([]))
     await screen.findByRole("button", { name: "Send message" })
     await waitFor(() => {

--- a/surfsense_local/frontend/src/features/dashboard/dashboard-page.tsx
+++ b/surfsense_local/frontend/src/features/dashboard/dashboard-page.tsx
@@ -18,7 +18,6 @@ import {
 import { SourcesPanel } from "@/features/sources/sources-panel"
 import { useSources } from "@/features/sources/use-sources"
 import { StudioDialog } from "@/features/studio/studio-dialog"
-import type { Citation } from "@/features/chat/sse"
 import type { Workspace } from "@/features/workspaces/api"
 import { useWorkspaces } from "@/features/workspaces/use-workspaces"
 import { WorkspaceRail } from "@/features/workspaces/workspace-rail"
@@ -34,9 +33,9 @@ function WorkspaceDashboard({
   providerAvailable: boolean
   onModelRequired: () => void
 }) {
-  const [selectedCitation, setSelectedCitation] = useState<Citation | null>(
-    null
-  )
+  const [highlightedDocumentId, setHighlightedDocumentId] = useState<
+    number | null
+  >(null)
   const sources = useSources(workspace.id)
   const chat = useChatRuntime({
     workspaceId: workspace.id,
@@ -44,16 +43,6 @@ function WorkspaceDashboard({
     selectedDocumentIds: sources.selectedDocumentIds,
     onModelRequired,
   })
-
-  const closeSourcePreview = () => {
-    setSelectedCitation(null)
-    sources.closePreview()
-  }
-
-  const openSource = (documentId: number, citation?: Citation) => {
-    setSelectedCitation(citation ?? null)
-    void sources.openDocument(documentId)
-  }
 
   return (
     <section className="my-2 mr-2 grid min-h-0 grid-cols-[minmax(232px,272px)_minmax(520px,1fr)_minmax(280px,320px)] grid-rows-[minmax(0,1fr)] overflow-hidden rounded-[16px] border bg-background shadow-sm">
@@ -65,16 +54,16 @@ function WorkspaceDashboard({
         animatingTitleThreadId={chat.animatingTitleThreadId}
         isLoading={chat.isLoadingThreads}
         onNewChat={() => {
-          closeSourcePreview()
+          setHighlightedDocumentId(null)
           chat.startNewChat()
         }}
         onSelect={(threadId) => {
-          if (threadId !== chat.activeThreadId) closeSourcePreview()
+          if (threadId !== chat.activeThreadId) setHighlightedDocumentId(null)
           chat.selectThread(threadId)
         }}
         onRename={chat.rename}
         onDelete={async (threadId) => {
-          if (threadId === chat.activeThreadId) closeSourcePreview()
+          if (threadId === chat.activeThreadId) setHighlightedDocumentId(null)
           await chat.removeThread(threadId)
         }}
         onTitleAnimationComplete={chat.finishTitleAnimation}
@@ -90,25 +79,22 @@ function WorkspaceDashboard({
         isRunning={chat.isRunning}
         animateTitle={chat.activeThreadId === chat.animatingTitleThreadId}
         providerAvailable={providerAvailable}
-        onCitation={(citation) => openSource(citation.document_id, citation)}
+        onCitation={(citation) =>
+          setHighlightedDocumentId(citation.document_id)
+        }
         onModelSetup={onModelRequired}
         onTitleAnimationComplete={chat.finishTitleAnimation}
       />
       <SourcesPanel
         documents={sources.documents}
         selectedDocumentIds={sources.selectedDocumentIds}
-        selectedDocument={sources.selectedDocument}
-        selectedCitation={selectedCitation}
+        highlightedDocumentId={highlightedDocumentId}
         isLoading={sources.isLoading}
-        isLoadingPreview={sources.isLoadingPreview}
         isUploading={sources.isUploading}
         isDeleting={sources.isDeleting}
         error={sources.error}
-        onOpen={openSource}
-        onBack={() => {
-          setSelectedCitation(null)
-          sources.closePreview()
-        }}
+        onOpen={(id) => void sources.openOriginal(id)}
+        onReveal={(id) => void sources.revealOriginal(id)}
         onRetry={(id) => void sources.retry(id)}
         onDeleteSelected={() => void sources.deleteSelected()}
         onSelectionChange={sources.setDocumentSelected}

--- a/surfsense_local/frontend/src/features/dashboard/dashboard-page.tsx
+++ b/surfsense_local/frontend/src/features/dashboard/dashboard-page.tsx
@@ -62,9 +62,11 @@ function WorkspaceDashboard({
         workspaceName={workspace.name}
         threads={chat.threads}
         activeThreadId={chat.activeThreadId}
+        autoNamingThreadId={chat.autoNamingThreadId}
         isLoading={chat.isLoadingThreads}
         onNewChat={chat.startNewChat}
         onSelect={chat.selectThread}
+        onRename={chat.rename}
         onDelete={chat.removeThread}
       />
       <ThreadPanel

--- a/surfsense_local/frontend/src/features/dashboard/dashboard-page.tsx
+++ b/surfsense_local/frontend/src/features/dashboard/dashboard-page.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react"
+import { useEffect, useState } from "react"
 import {
   CircleAlertIcon,
   LayoutGridIcon,
@@ -34,22 +34,21 @@ function WorkspaceDashboard({
   providerAvailable: boolean
   onModelRequired: () => void
 }) {
-  const [citations, setCitations] = useState<Citation[]>([])
   const [selectedCitation, setSelectedCitation] = useState<Citation | null>(
     null
   )
   const sources = useSources(workspace.id)
-  const handleCitations = useCallback((next: Citation[]) => {
-    setCitations(next)
-    setSelectedCitation(null)
-  }, [])
   const chat = useChatRuntime({
     workspaceId: workspace.id,
     canSend: providerAvailable,
     selectedDocumentIds: sources.selectedDocumentIds,
-    onCitations: handleCitations,
     onModelRequired,
   })
+
+  const closeSourcePreview = () => {
+    setSelectedCitation(null)
+    sources.closePreview()
+  }
 
   const openSource = (documentId: number, citation?: Citation) => {
     setSelectedCitation(citation ?? null)
@@ -65,10 +64,19 @@ function WorkspaceDashboard({
         autoNamingThreadId={chat.autoNamingThreadId}
         animatingTitleThreadId={chat.animatingTitleThreadId}
         isLoading={chat.isLoadingThreads}
-        onNewChat={chat.startNewChat}
-        onSelect={chat.selectThread}
+        onNewChat={() => {
+          closeSourcePreview()
+          chat.startNewChat()
+        }}
+        onSelect={(threadId) => {
+          if (threadId !== chat.activeThreadId) closeSourcePreview()
+          chat.selectThread(threadId)
+        }}
         onRename={chat.rename}
-        onDelete={chat.removeThread}
+        onDelete={async (threadId) => {
+          if (threadId === chat.activeThreadId) closeSourcePreview()
+          await chat.removeThread(threadId)
+        }}
         onTitleAnimationComplete={chat.finishTitleAnimation}
       />
       <ThreadPanel
@@ -88,7 +96,6 @@ function WorkspaceDashboard({
       />
       <SourcesPanel
         documents={sources.documents}
-        citations={citations}
         selectedDocumentIds={sources.selectedDocumentIds}
         selectedDocument={sources.selectedDocument}
         selectedCitation={selectedCitation}

--- a/surfsense_local/frontend/src/features/dashboard/dashboard-page.tsx
+++ b/surfsense_local/frontend/src/features/dashboard/dashboard-page.tsx
@@ -120,7 +120,7 @@ function WorkspacesEmpty({
   onCreate: (name: string) => Promise<boolean>
 }) {
   return (
-    <main className="flex h-svh items-center justify-center bg-background p-8">
+    <main className="flex h-full items-center justify-center bg-background p-8">
       <div className="flex max-w-sm flex-col items-center text-center">
         <div className="mb-4 flex size-11 items-center justify-center rounded-xl bg-muted">
           <LayoutGridIcon className="size-5" />
@@ -179,7 +179,7 @@ export function DashboardPage({
   }
 
   return (
-    <main className="relative grid h-svh min-w-[1120px] grid-cols-[56px_minmax(0,1fr)] overflow-hidden bg-app-shell">
+    <main className="relative grid h-full min-w-[1120px] grid-cols-[56px_minmax(0,1fr)] overflow-hidden bg-app-shell">
       <WorkspaceRail
         workspaces={workspaces.workspaces}
         activeWorkspaceId={workspaces.activeWorkspace.id}

--- a/surfsense_local/frontend/src/features/dashboard/dashboard-page.tsx
+++ b/surfsense_local/frontend/src/features/dashboard/dashboard-page.tsx
@@ -57,7 +57,7 @@ function WorkspaceDashboard({
   }
 
   return (
-    <section className="my-2 mr-2 grid min-h-0 grid-cols-[minmax(232px,272px)_minmax(520px,1fr)_minmax(280px,320px)] overflow-hidden rounded-[16px] border bg-background shadow-sm">
+    <section className="my-2 mr-2 grid min-h-0 grid-cols-[minmax(232px,272px)_minmax(520px,1fr)_minmax(280px,320px)] grid-rows-[minmax(0,1fr)] overflow-hidden rounded-[16px] border bg-background shadow-sm">
       <ThreadList
         workspaceName={workspace.name}
         threads={chat.threads}
@@ -70,6 +70,7 @@ function WorkspaceDashboard({
       <ThreadPanel
         runtime={chat.runtime}
         thread={chat.activeThread}
+        view={chat.conversationView}
         model={selection}
         documents={sources.documents}
         error={chat.error}

--- a/surfsense_local/frontend/src/features/dashboard/dashboard-page.tsx
+++ b/surfsense_local/frontend/src/features/dashboard/dashboard-page.tsx
@@ -103,7 +103,6 @@ function WorkspaceDashboard({
         isLoadingPreview={sources.isLoadingPreview}
         isUploading={sources.isUploading}
         isDeleting={sources.isDeleting}
-        uploadOutcome={sources.uploadOutcome}
         error={sources.error}
         onOpen={openSource}
         onBack={() => {
@@ -114,7 +113,6 @@ function WorkspaceDashboard({
         onDeleteSelected={() => void sources.deleteSelected()}
         onSelectionChange={sources.setDocumentSelected}
         onUpload={(files) => void sources.upload(files)}
-        onDismissUploadOutcome={sources.dismissUploadOutcome}
         studioSlot={
           <StudioDialog
             workspaceId={workspace.id}

--- a/surfsense_local/frontend/src/features/dashboard/dashboard-page.tsx
+++ b/surfsense_local/frontend/src/features/dashboard/dashboard-page.tsx
@@ -63,11 +63,13 @@ function WorkspaceDashboard({
         threads={chat.threads}
         activeThreadId={chat.activeThreadId}
         autoNamingThreadId={chat.autoNamingThreadId}
+        animatingTitleThreadId={chat.animatingTitleThreadId}
         isLoading={chat.isLoadingThreads}
         onNewChat={chat.startNewChat}
         onSelect={chat.selectThread}
         onRename={chat.rename}
         onDelete={chat.removeThread}
+        onTitleAnimationComplete={chat.finishTitleAnimation}
       />
       <ThreadPanel
         runtime={chat.runtime}
@@ -78,9 +80,11 @@ function WorkspaceDashboard({
         error={chat.error}
         isLoading={chat.isLoadingMessages}
         isRunning={chat.isRunning}
+        animateTitle={chat.activeThreadId === chat.animatingTitleThreadId}
         providerAvailable={providerAvailable}
         onCitation={(citation) => openSource(citation.document_id, citation)}
         onModelSetup={onModelRequired}
+        onTitleAnimationComplete={chat.finishTitleAnimation}
       />
       <SourcesPanel
         documents={sources.documents}

--- a/surfsense_local/frontend/src/features/model-selection/model-selection-page.tsx
+++ b/surfsense_local/frontend/src/features/model-selection/model-selection-page.tsx
@@ -149,7 +149,7 @@ export function ModelSelectionPage({
   }
 
   return (
-    <main className="flex min-h-svh items-center justify-center bg-muted/30 p-4 sm:p-8">
+    <main className="flex min-h-full items-center justify-center bg-muted/30 p-4 sm:p-8">
       <div className="flex w-full max-w-4xl flex-col gap-4">
         <div className="flex items-center gap-2 px-1">
           <BrainCircuitIcon aria-hidden="true" className="size-5" />

--- a/surfsense_local/frontend/src/features/sources/api.ts
+++ b/surfsense_local/frontend/src/features/sources/api.ts
@@ -16,9 +16,43 @@ export type DocumentDetail = WorkspaceDocument & {
   content: string | null
 }
 
+export const SUPPORTED_SOURCE_EXTENSIONS = [
+  ".pdf",
+  ".docx",
+  ".pptx",
+  ".xlsx",
+  ".html",
+  ".htm",
+  ".csv",
+  ".md",
+  ".markdown",
+  ".txt",
+  ".text",
+  ".png",
+  ".jpg",
+  ".jpeg",
+  ".tif",
+  ".tiff",
+  ".bmp",
+  ".webp",
+] as const
+
+export const SOURCE_FILE_ACCEPT = SUPPORTED_SOURCE_EXTENSIONS.join(",")
+
+const supportedSourceExtensions = new Set<string>(SUPPORTED_SOURCE_EXTENSIONS)
+
+export function isSupportedSourceFile(file: File): boolean {
+  const dot = file.name.lastIndexOf(".")
+  return (
+    dot >= 0 &&
+    supportedSourceExtensions.has(file.name.slice(dot).toLowerCase())
+  )
+}
+
 export type UploadOutcome = {
   created: WorkspaceDocument[]
   duplicates: { filename: string; document_id: number }[]
+  rejected: { filename: string; reason: string }[]
 }
 
 export function listDocuments(

--- a/surfsense_local/frontend/src/features/sources/api.ts
+++ b/surfsense_local/frontend/src/features/sources/api.ts
@@ -12,10 +12,9 @@ export type WorkspaceDocument = {
   updated_at: string
 }
 
-export type DocumentDetail = WorkspaceDocument & {
-  content: string | null
-}
-
+// UX mirror of backend/modules/documents/storage.py UPLOAD_MIME_BY_SUFFIX.
+// Update both when supported formats change; the backend remains authoritative.
+// If formats become dynamic or change often, use a capabilities endpoint.
 export const SUPPORTED_SOURCE_EXTENSIONS = [
   ".pdf",
   ".docx",
@@ -65,23 +64,12 @@ export function listDocuments(
   )
 }
 
-export function readDocument(
-  workspaceId: number,
-  documentId: number,
-  signal?: AbortSignal
-): Promise<DocumentDetail> {
-  return requestJson<DocumentDetail>(
-    `/workspaces/${workspaceId}/documents/${documentId}`,
-    { signal }
-  )
-}
-
 export function retryDocument(
   workspaceId: number,
   documentId: number,
   signal?: AbortSignal
-): Promise<DocumentDetail> {
-  return requestJson<DocumentDetail>(
+): Promise<WorkspaceDocument> {
+  return requestJson<WorkspaceDocument>(
     `/workspaces/${workspaceId}/documents/${documentId}/retry`,
     { method: "POST", signal }
   )

--- a/surfsense_local/frontend/src/features/sources/source-upload.test.tsx
+++ b/surfsense_local/frontend/src/features/sources/source-upload.test.tsx
@@ -1,9 +1,18 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { cleanup, render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
+import { toast } from "sonner"
 
 import { SourcesPanel } from "./sources-panel"
 import { useSources } from "./use-sources"
+
+vi.mock("sonner", () => ({
+  toast: {
+    error: vi.fn(),
+    info: vi.fn(),
+    success: vi.fn(),
+  },
+}))
 
 const pendingDocument = {
   id: 7,
@@ -27,7 +36,6 @@ function SourceHarness() {
       isLoadingPreview={false}
       isUploading={sources.isUploading}
       isDeleting={sources.isDeleting}
-      uploadOutcome={sources.uploadOutcome}
       error={sources.error}
       onOpen={() => undefined}
       onBack={() => undefined}
@@ -35,12 +43,12 @@ function SourceHarness() {
       onDeleteSelected={() => void sources.deleteSelected()}
       onSelectionChange={sources.setDocumentSelected}
       onUpload={(files) => void sources.upload(files)}
-      onDismissUploadOutcome={sources.dismissUploadOutcome}
     />
   )
 }
 
 beforeEach(() => {
+  vi.clearAllMocks()
   vi.stubGlobal(
     "ResizeObserver",
     class {
@@ -57,6 +65,64 @@ afterEach(() => {
 })
 
 describe("source upload", () => {
+  it("uses selection, processing, and retry controls in the icon slot", () => {
+    const ready = {
+      ...pendingDocument,
+      id: 1,
+      title:
+        "A very long ready source name that must stay inside the panel.pdf",
+      status: "ready" as const,
+    }
+    const processing = {
+      ...pendingDocument,
+      id: 2,
+      title: "processing.pdf",
+      status: "processing" as const,
+    }
+    const failed = {
+      ...pendingDocument,
+      id: 3,
+      title: "failed.pdf",
+      status: "failed" as const,
+    }
+
+    render(
+      <SourcesPanel
+        documents={[ready, processing, failed]}
+        selectedDocumentIds={[]}
+        selectedDocument={null}
+        selectedCitation={null}
+        isLoading={false}
+        isLoadingPreview={false}
+        isUploading={false}
+        isDeleting={false}
+        error={null}
+        onOpen={vi.fn()}
+        onBack={vi.fn()}
+        onRetry={vi.fn()}
+        onDeleteSelected={vi.fn()}
+        onSelectionChange={vi.fn()}
+        onUpload={vi.fn()}
+      />
+    )
+
+    expect(screen.getByLabelText(`Select ${ready.title}`)).toBeTruthy()
+    expect(screen.queryByLabelText("Select processing.pdf")).toBeNull()
+    expect(screen.queryByLabelText("Select failed.pdf")).toBeNull()
+    expect(
+      screen.getByRole("status", { name: "Processing processing.pdf" })
+    ).toBeTruthy()
+    expect(
+      screen.getByRole("button", { name: "Retry failed.pdf" })
+    ).toBeTruthy()
+    expect(
+      screen.getAllByRole("button", { name: /^Actions for / })
+    ).toHaveLength(3)
+    const readyButton = screen.getByRole("button", { name: ready.title })
+    expect(readyButton.className).toContain("truncate")
+    expect(readyButton.parentElement?.className).toContain("overflow-hidden")
+  })
+
   it("uploads multipart files, reports duplicates, and polls until ready", async () => {
     let uploaded = false
     const fetchMock = vi.fn(
@@ -103,8 +169,16 @@ describe("source upload", () => {
     await user.upload(screen.getByLabelText("Upload source files"), file)
 
     expect(await screen.findByText("guide.txt")).toBeTruthy()
-    expect(await screen.findByText("pending")).toBeTruthy()
-    expect(await screen.findByText(/Already present: copy\.txt/)).toBeTruthy()
+    expect(
+      await screen.findByRole("status", { name: "Processing guide.txt" })
+    ).toBeTruthy()
+    await waitFor(() =>
+      expect(toast.success).toHaveBeenCalledWith("1 source added", {
+        id: "source-upload-outcome",
+        description:
+          "Ingestion is running in the background. Already present: copy.txt",
+      })
+    )
 
     const uploadCall = fetchMock.mock.calls.find(
       ([path, init]) =>
@@ -117,9 +191,41 @@ describe("source upload", () => {
       false
     )
 
-    await waitFor(() => expect(screen.getByText("ready")).toBeTruthy(), {
-      timeout: 3000,
-    })
+    await waitFor(
+      () => expect(screen.getByLabelText("Select guide.txt")).toBeTruthy(),
+      { timeout: 3000 }
+    )
+  })
+
+  it("shows upload failures in a toast instead of the sources panel", async () => {
+    const fetchMock = vi.fn(
+      async (_input: RequestInfo | URL, init?: RequestInit) => {
+        if (init?.method === "POST") {
+          return Response.json(
+            { detail: "Unsupported file type" },
+            { status: 400 }
+          )
+        }
+        return Response.json([])
+      }
+    )
+    vi.stubGlobal("fetch", fetchMock)
+    const user = userEvent.setup()
+
+    render(<SourceHarness />)
+    await screen.findByText("No sources yet")
+    await user.upload(
+      screen.getByLabelText("Upload source files"),
+      new File(["content"], "unsupported.exe")
+    )
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith("Couldn’t add your source", {
+        id: "source-upload-error",
+        description: "Unsupported file type",
+      })
+    )
+    expect(screen.queryByText("Source action failed")).toBeNull()
   })
 
   it("deletes every selected source after confirmation", async () => {

--- a/surfsense_local/frontend/src/features/sources/source-upload.test.tsx
+++ b/surfsense_local/frontend/src/features/sources/source-upload.test.tsx
@@ -30,15 +30,13 @@ function SourceHarness() {
     <SourcesPanel
       documents={sources.documents}
       selectedDocumentIds={sources.selectedDocumentIds}
-      selectedDocument={null}
-      selectedCitation={null}
+      highlightedDocumentId={null}
       isLoading={sources.isLoading}
-      isLoadingPreview={false}
       isUploading={sources.isUploading}
       isDeleting={sources.isDeleting}
       error={sources.error}
-      onOpen={() => undefined}
-      onBack={() => undefined}
+      onOpen={(id) => void sources.openOriginal(id)}
+      onReveal={(id) => void sources.revealOriginal(id)}
       onRetry={(id) => void sources.retry(id)}
       onDeleteSelected={() => void sources.deleteSelected()}
       onSelectionChange={sources.setDocumentSelected}
@@ -57,6 +55,10 @@ beforeEach(() => {
       disconnect() {}
     }
   )
+  Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+    configurable: true,
+    value: vi.fn(),
+  })
 })
 
 afterEach(() => {
@@ -90,15 +92,13 @@ describe("source upload", () => {
       <SourcesPanel
         documents={[ready, processing, failed]}
         selectedDocumentIds={[]}
-        selectedDocument={null}
-        selectedCitation={null}
+        highlightedDocumentId={ready.id}
         isLoading={false}
-        isLoadingPreview={false}
         isUploading={false}
         isDeleting={false}
         error={null}
         onOpen={vi.fn()}
-        onBack={vi.fn()}
+        onReveal={vi.fn()}
         onRetry={vi.fn()}
         onDeleteSelected={vi.fn()}
         onSelectionChange={vi.fn()}
@@ -121,6 +121,7 @@ describe("source upload", () => {
     const readyButton = screen.getByRole("button", { name: ready.title })
     expect(readyButton.className).toContain("truncate")
     expect(readyButton.parentElement?.className).toContain("overflow-hidden")
+    expect(readyButton.parentElement?.getAttribute("aria-current")).toBe("true")
   })
 
   it("uploads multipart files, reports duplicates, and polls until ready", async () => {

--- a/surfsense_local/frontend/src/features/sources/source-upload.test.tsx
+++ b/surfsense_local/frontend/src/features/sources/source-upload.test.tsx
@@ -144,6 +144,12 @@ describe("source upload", () => {
             {
               created: [pendingDocument],
               duplicates: [{ filename: "copy.txt", document_id: 7 }],
+              rejected: [
+                {
+                  filename: "broken.pdf",
+                  reason: "file contents do not match .pdf",
+                },
+              ],
             },
             { status: 201 }
           )
@@ -166,7 +172,10 @@ describe("source upload", () => {
     const file = new File(["local research"], "guide.txt", {
       type: "text/plain",
     })
-    await user.upload(screen.getByLabelText("Upload source files"), file)
+    const input = screen.getByLabelText("Upload source files")
+    expect(input.getAttribute("accept")).toContain(".pdf")
+    expect(input.getAttribute("accept")).toContain(".webp")
+    await user.upload(input, file)
 
     expect(await screen.findByText("guide.txt")).toBeTruthy()
     expect(
@@ -176,7 +185,8 @@ describe("source upload", () => {
       expect(toast.success).toHaveBeenCalledWith("1 source added", {
         id: "source-upload-outcome",
         description:
-          "Ingestion is running in the background. Already present: copy.txt",
+          "Ingestion is running in the background. Already present: copy.txt " +
+          "Rejected: broken.pdf (file contents do not match .pdf)",
       })
     )
 
@@ -197,7 +207,7 @@ describe("source upload", () => {
     )
   })
 
-  it("shows upload failures in a toast instead of the sources panel", async () => {
+  it("rejects unsupported selections before uploading", async () => {
     const fetchMock = vi.fn(
       async (_input: RequestInfo | URL, init?: RequestInit) => {
         if (init?.method === "POST") {
@@ -210,7 +220,7 @@ describe("source upload", () => {
       }
     )
     vi.stubGlobal("fetch", fetchMock)
-    const user = userEvent.setup()
+    const user = userEvent.setup({ applyAccept: false })
 
     render(<SourceHarness />)
     await screen.findByText("No sources yet")
@@ -222,8 +232,12 @@ describe("source upload", () => {
     await waitFor(() =>
       expect(toast.error).toHaveBeenCalledWith("Couldn’t add your source", {
         id: "source-upload-error",
-        description: "Unsupported file type",
+        description: "Unsupported file type: unsupported.exe",
       })
+    )
+    expect(fetchMock).not.toHaveBeenCalledWith(
+      "/workspaces/1/documents/upload",
+      expect.anything()
     )
     expect(screen.queryByText("Source action failed")).toBeNull()
   })

--- a/surfsense_local/frontend/src/features/sources/source-upload.test.tsx
+++ b/surfsense_local/frontend/src/features/sources/source-upload.test.tsx
@@ -20,7 +20,6 @@ function SourceHarness() {
   return (
     <SourcesPanel
       documents={sources.documents}
-      citations={[]}
       selectedDocumentIds={sources.selectedDocumentIds}
       selectedDocument={null}
       selectedCitation={null}

--- a/surfsense_local/frontend/src/features/sources/sources-panel.tsx
+++ b/surfsense_local/frontend/src/features/sources/sources-panel.tsx
@@ -348,8 +348,8 @@ export function SourcesPanel({
             </Button>
           </div>
         </header>
-        <ScrollArea className="min-h-0 flex-1">
-          <div className="space-y-3 p-3">
+        <ScrollArea className="min-h-0 flex-1 [&_[data-slot=scroll-area-viewport]>div]:h-full">
+          <div className="flex min-h-full flex-col gap-3 p-3">
             {uploadOutcome ? (
               <Alert>
                 <CheckCircle2Icon />
@@ -452,7 +452,7 @@ export function SourcesPanel({
               </section>
             ) : null}
             {!isLoading && documents.length === 0 ? (
-              <Empty className="border-0 px-2 py-12">
+              <Empty className="min-h-0 border-0 px-2">
                 <EmptyHeader>
                   <EmptyMedia variant="icon">
                     <FilePlus2Icon />

--- a/surfsense_local/frontend/src/features/sources/sources-panel.tsx
+++ b/surfsense_local/frontend/src/features/sources/sources-panel.tsx
@@ -1,7 +1,7 @@
 import { useRef, useState, type ChangeEvent, type ReactNode } from "react"
 import {
   ArrowLeftIcon,
-  CheckCircle2Icon,
+  EllipsisIcon,
   FileIcon,
   FilePlus2Icon,
   NotebookTextIcon,
@@ -20,9 +20,15 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog"
-import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
 import {
   Empty,
   EmptyDescription,
@@ -32,18 +38,11 @@ import {
 } from "@/components/ui/empty"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { Skeleton } from "@/components/ui/skeleton"
-import type { UploadOutcome, DocumentDetail, WorkspaceDocument } from "./api"
+import type { DocumentDetail, WorkspaceDocument } from "./api"
 import type { Citation } from "@/features/chat/sse"
 import { Input } from "@/components/ui/input"
 import { Spinner } from "@/components/ui/spinner"
 import { cn } from "@/lib/utils"
-
-const statusVariant = {
-  pending: "outline",
-  processing: "secondary",
-  ready: "secondary",
-  failed: "destructive",
-} as const
 
 function SelectableSourceRow({
   document,
@@ -58,60 +57,106 @@ function SelectableSourceRow({
   onRetry: () => void
   onSelectedChange: (selected: boolean) => void
 }) {
-  const selectable = document.status === "ready"
+  const ready = document.status === "ready"
+  const failed = document.status === "failed"
+  const processing =
+    document.status === "pending" || document.status === "processing"
 
   return (
     <div
       className={cn(
-        "flex items-center gap-2 rounded-lg px-2 py-1.5 hover:bg-accent",
+        "group/source flex w-full min-w-0 items-center gap-2 overflow-hidden rounded-lg px-2 py-1.5 focus-within:bg-accent hover:bg-accent",
         selected && "bg-accent"
       )}
     >
+      <span className="relative flex size-7 shrink-0 items-center justify-center">
+        {ready ? (
+          <>
+            <span
+              className={cn(
+                "absolute inset-0 flex items-center justify-center text-muted-foreground transition-opacity duration-150",
+                selected
+                  ? "opacity-0"
+                  : "opacity-100 group-focus-within/source:opacity-0 group-hover/source:opacity-0"
+              )}
+            >
+              {document.document_type === "NOTE" ? (
+                <NotebookTextIcon />
+              ) : (
+                <FileIcon />
+              )}
+            </span>
+            <Checkbox
+              checked={selected}
+              aria-label={`Select ${document.title}`}
+              className={cn(
+                "absolute transition-opacity duration-150",
+                selected
+                  ? "opacity-100"
+                  : "pointer-events-none opacity-0 group-focus-within/source:pointer-events-auto group-focus-within/source:opacity-100 group-hover/source:pointer-events-auto group-hover/source:opacity-100 focus-visible:pointer-events-auto focus-visible:opacity-100"
+              )}
+              onClick={(event) => event.stopPropagation()}
+              onCheckedChange={(checked) => onSelectedChange(checked === true)}
+            />
+          </>
+        ) : null}
+        {processing ? (
+          <Spinner
+            className="text-muted-foreground"
+            aria-label={`Processing ${document.title}`}
+          />
+        ) : null}
+        {failed ? (
+          <Button
+            type="button"
+            size="icon-sm"
+            variant="ghost"
+            aria-label={`Retry ${document.title}`}
+            onClick={onRetry}
+          >
+            <RefreshCwIcon />
+          </Button>
+        ) : null}
+      </span>
       <button
         type="button"
-        className="flex min-w-0 flex-1 items-center gap-2 text-left outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
-        onClick={onOpen}
+        disabled={!ready}
+        className="min-w-0 flex-1 truncate rounded-sm text-left text-sm font-medium outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:cursor-default"
+        onClick={ready ? onOpen : undefined}
       >
-        <span className="flex size-7 shrink-0 items-center justify-center rounded-md bg-muted">
-          {document.document_type === "NOTE" ? (
-            <NotebookTextIcon className="size-3.5" />
-          ) : (
-            <FileIcon className="size-3.5" />
-          )}
-        </span>
-        <span className="min-w-0 flex-1">
-          <span className="block truncate text-sm font-medium">
-            {document.title}
-          </span>
-          <span className="mt-0.5 flex items-center gap-1.5">
-            <span className="text-[11px] text-muted-foreground">
-              {document.document_type === "NOTE" ? "Note" : "File"}
-            </span>
-            <Badge
-              variant={statusVariant[document.status]}
-              className="h-4 px-1.5 text-[10px]"
-            >
-              {document.status}
-            </Badge>
-          </span>
-        </span>
+        {document.title}
       </button>
-      {document.status === "failed" ? (
-        <Button
-          size="icon-xs"
-          variant="ghost"
-          aria-label={`Retry ${document.title}`}
-          onClick={onRetry}
-        >
-          <RefreshCwIcon />
-        </Button>
-      ) : null}
-      <Checkbox
-        checked={selected}
-        disabled={!selectable}
-        aria-label={`Select ${document.title}`}
-        onCheckedChange={(checked) => onSelectedChange(checked === true)}
-      />
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            type="button"
+            size="icon-sm"
+            variant="ghost"
+            className="shrink-0"
+            aria-label={`Actions for ${document.title}`}
+          >
+            <EllipsisIcon />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuGroup>
+            {ready ? (
+              <>
+                <DropdownMenuItem onSelect={onOpen}>Open</DropdownMenuItem>
+                <DropdownMenuItem onSelect={() => onSelectedChange(!selected)}>
+                  {selected ? "Deselect" : "Select"}
+                </DropdownMenuItem>
+              </>
+            ) : null}
+            {failed ? (
+              <DropdownMenuItem onSelect={onRetry}>Retry</DropdownMenuItem>
+            ) : null}
+            {processing ? (
+              <DropdownMenuItem disabled>Processing</DropdownMenuItem>
+            ) : null}
+          </DropdownMenuGroup>
+        </DropdownMenuContent>
+      </DropdownMenu>
     </div>
   )
 }
@@ -186,7 +231,6 @@ export function SourcesPanel({
   isLoadingPreview,
   isUploading,
   isDeleting,
-  uploadOutcome,
   error,
   onOpen,
   onBack,
@@ -194,7 +238,6 @@ export function SourcesPanel({
   onDeleteSelected,
   onSelectionChange,
   onUpload,
-  onDismissUploadOutcome,
   studioSlot,
 }: {
   documents: WorkspaceDocument[]
@@ -205,7 +248,6 @@ export function SourcesPanel({
   isLoadingPreview: boolean
   isUploading: boolean
   isDeleting: boolean
-  uploadOutcome: UploadOutcome | null
   error: string | null
   onOpen: (documentId: number, citation?: Citation) => void
   onBack: () => void
@@ -213,7 +255,6 @@ export function SourcesPanel({
   onDeleteSelected: () => void
   onSelectionChange: (documentId: number, selected: boolean) => void
   onUpload: (files: File[]) => void
-  onDismissUploadOutcome: () => void
   studioSlot?: ReactNode
 }) {
   const fileInput = useRef<HTMLInputElement>(null)
@@ -271,39 +312,8 @@ export function SourcesPanel({
             </Button>
           </div>
         </header>
-        <ScrollArea className="min-h-0 flex-1 [&_[data-slot=scroll-area-viewport]>div]:h-full">
-          <div className="flex min-h-full flex-col gap-3 p-3">
-            {uploadOutcome ? (
-              <Alert>
-                <CheckCircle2Icon />
-                <AlertTitle>
-                  {uploadOutcome.created.length > 0
-                    ? `${uploadOutcome.created.length} source${uploadOutcome.created.length === 1 ? "" : "s"} added`
-                    : "No new sources added"}
-                </AlertTitle>
-                <AlertDescription>
-                  {uploadOutcome.created.length > 0 ? (
-                    <p>Ingestion is running in the background.</p>
-                  ) : null}
-                  {uploadOutcome.duplicates.length > 0 ? (
-                    <p>
-                      Already present:{" "}
-                      {uploadOutcome.duplicates
-                        .map((duplicate) => duplicate.filename)
-                        .join(", ")}
-                    </p>
-                  ) : null}
-                  <Button
-                    variant="link"
-                    size="xs"
-                    className="mt-1 h-auto p-0"
-                    onClick={onDismissUploadOutcome}
-                  >
-                    Dismiss
-                  </Button>
-                </AlertDescription>
-              </Alert>
-            ) : null}
+        <ScrollArea className="min-h-0 flex-1 [&_[data-slot=scroll-area-viewport]>div]:!block [&_[data-slot=scroll-area-viewport]>div]:h-full [&_[data-slot=scroll-area-viewport]>div]:w-full">
+          <div className="flex min-h-full w-full min-w-0 flex-col gap-3 overflow-hidden p-3">
             {error ? (
               <Alert variant="destructive">
                 <AlertTitle>Source action failed</AlertTitle>
@@ -316,7 +326,10 @@ export function SourcesPanel({
                 ))
               : null}
             {!isLoading && documents.length > 0 ? (
-              <section aria-labelledby="all-sources">
+              <section
+                className="w-full min-w-0 overflow-hidden"
+                aria-labelledby="all-sources"
+              >
                 <div className="mb-2 flex min-h-7 items-center justify-between gap-2 px-1">
                   <h3
                     id="all-sources"

--- a/surfsense_local/frontend/src/features/sources/sources-panel.tsx
+++ b/surfsense_local/frontend/src/features/sources/sources-panel.tsx
@@ -38,7 +38,11 @@ import {
 } from "@/components/ui/empty"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { Skeleton } from "@/components/ui/skeleton"
-import type { DocumentDetail, WorkspaceDocument } from "./api"
+import {
+  SOURCE_FILE_ACCEPT,
+  type DocumentDetail,
+  type WorkspaceDocument,
+} from "./api"
 import type { Citation } from "@/features/chat/sse"
 import { Input } from "@/components/ui/input"
 import { Spinner } from "@/components/ui/spinner"
@@ -294,6 +298,7 @@ export function SourcesPanel({
             ref={fileInput}
             type="file"
             multiple
+            accept={SOURCE_FILE_ACCEPT}
             className="sr-only"
             aria-label="Upload source files"
             disabled={isUploading}

--- a/surfsense_local/frontend/src/features/sources/sources-panel.tsx
+++ b/surfsense_local/frontend/src/features/sources/sources-panel.tsx
@@ -31,7 +31,6 @@ import {
   EmptyTitle,
 } from "@/components/ui/empty"
 import { ScrollArea } from "@/components/ui/scroll-area"
-import { Separator } from "@/components/ui/separator"
 import { Skeleton } from "@/components/ui/skeleton"
 import type { UploadOutcome, DocumentDetail, WorkspaceDocument } from "./api"
 import type { Citation } from "@/features/chat/sse"
@@ -45,73 +44,6 @@ const statusVariant = {
   ready: "secondary",
   failed: "destructive",
 } as const
-
-function SourceRow({
-  document,
-  citationNumber,
-  onOpen,
-  onRetry,
-}: {
-  document: WorkspaceDocument
-  citationNumber?: number
-  onOpen: () => void
-  onRetry: () => void
-}) {
-  return (
-    <div className="rounded-lg border bg-card p-2.5">
-      <button
-        type="button"
-        className="flex w-full min-w-0 items-start gap-2 text-left outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
-        onClick={onOpen}
-      >
-        <span className="mt-0.5 flex size-7 shrink-0 items-center justify-center rounded-md bg-muted">
-          {document.document_type === "NOTE" ? (
-            <NotebookTextIcon className="size-3.5" />
-          ) : (
-            <FileIcon className="size-3.5" />
-          )}
-        </span>
-        <span className="min-w-0 flex-1">
-          <span className="flex items-start justify-between gap-2">
-            <span className="line-clamp-2 text-sm font-medium">
-              {document.title}
-            </span>
-            {citationNumber ? (
-              <Badge variant="outline">[{citationNumber}]</Badge>
-            ) : null}
-          </span>
-          <span className="mt-1 flex items-center gap-1.5">
-            <span className="text-[11px] text-muted-foreground">
-              {document.document_type === "NOTE" ? "Note" : "File"}
-            </span>
-            <Badge
-              variant={statusVariant[document.status]}
-              className="h-4 px-1.5 text-[10px]"
-            >
-              {document.status}
-            </Badge>
-          </span>
-        </span>
-      </button>
-      {document.status !== "ready" && document.status !== "failed" ? (
-        <p className="mt-2 text-xs text-muted-foreground">
-          This source is not searchable until indexing finishes.
-        </p>
-      ) : null}
-      {document.status === "failed" ? (
-        <div className="mt-2 flex items-start justify-between gap-2">
-          <p className="text-xs text-destructive">
-            {document.error_message || "Indexing failed."}
-          </p>
-          <Button size="xs" variant="outline" onClick={onRetry}>
-            <RefreshCwIcon />
-            Retry
-          </Button>
-        </div>
-      ) : null}
-    </div>
-  )
-}
 
 function SelectableSourceRow({
   document,
@@ -247,7 +179,6 @@ function DocumentPreview({
 
 export function SourcesPanel({
   documents,
-  citations,
   selectedDocumentIds,
   selectedDocument,
   selectedCitation,
@@ -267,7 +198,6 @@ export function SourcesPanel({
   studioSlot,
 }: {
   documents: WorkspaceDocument[]
-  citations: Citation[]
   selectedDocumentIds: number[]
   selectedDocument: DocumentDetail | null
   selectedCitation: Citation | null
@@ -309,13 +239,6 @@ export function SourcesPanel({
     )
   }
 
-  const documentById = new Map(
-    documents.map((document) => [document.id, document])
-  )
-  const citedDocuments = citations.flatMap((citation, index) => {
-    const document = documentById.get(citation.document_id)
-    return document ? [{ document, citation, number: index + 1 }] : []
-  })
   const selectedDocumentIdSet = new Set(selectedDocumentIds)
 
   return (
@@ -392,28 +315,6 @@ export function SourcesPanel({
                   <Skeleton key={item} className="h-20 w-full" />
                 ))
               : null}
-            {!isLoading && citedDocuments.length > 0 ? (
-              <section aria-labelledby="used-in-answer">
-                <h3
-                  id="used-in-answer"
-                  className="mb-2 px-1 text-xs font-medium text-muted-foreground"
-                >
-                  Used in answer
-                </h3>
-                <div className="space-y-2">
-                  {citedDocuments.map(({ document, citation, number }) => (
-                    <SourceRow
-                      key={`${citation.chunk_id}-${number}`}
-                      document={document}
-                      citationNumber={number}
-                      onOpen={() => onOpen(document.id, citation)}
-                      onRetry={() => onRetry(document.id)}
-                    />
-                  ))}
-                </div>
-                <Separator className="my-4" />
-              </section>
-            ) : null}
             {!isLoading && documents.length > 0 ? (
               <section aria-labelledby="all-sources">
                 <div className="mb-2 flex min-h-7 items-center justify-between gap-2 px-1">

--- a/surfsense_local/frontend/src/features/sources/sources-panel.tsx
+++ b/surfsense_local/frontend/src/features/sources/sources-panel.tsx
@@ -1,6 +1,11 @@
-import { useRef, useState, type ChangeEvent, type ReactNode } from "react"
 import {
-  ArrowLeftIcon,
+  useEffect,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type ReactNode,
+} from "react"
+import {
   EllipsisIcon,
   FileIcon,
   FilePlus2Icon,
@@ -38,12 +43,7 @@ import {
 } from "@/components/ui/empty"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { Skeleton } from "@/components/ui/skeleton"
-import {
-  SOURCE_FILE_ACCEPT,
-  type DocumentDetail,
-  type WorkspaceDocument,
-} from "./api"
-import type { Citation } from "@/features/chat/sse"
+import { SOURCE_FILE_ACCEPT, type WorkspaceDocument } from "./api"
 import { Input } from "@/components/ui/input"
 import { Spinner } from "@/components/ui/spinner"
 import { cn } from "@/lib/utils"
@@ -51,13 +51,19 @@ import { cn } from "@/lib/utils"
 function SelectableSourceRow({
   document,
   selected,
+  highlighted,
+  rowRef,
   onOpen,
+  onReveal,
   onRetry,
   onSelectedChange,
 }: {
   document: WorkspaceDocument
   selected: boolean
+  highlighted: boolean
+  rowRef: (node: HTMLDivElement | null) => void
   onOpen: () => void
+  onReveal: () => void
   onRetry: () => void
   onSelectedChange: (selected: boolean) => void
 }) {
@@ -65,12 +71,15 @@ function SelectableSourceRow({
   const failed = document.status === "failed"
   const processing =
     document.status === "pending" || document.status === "processing"
+  const openable = ready && document.document_type === "FILE"
 
   return (
     <div
+      ref={rowRef}
+      aria-current={highlighted ? "true" : undefined}
       className={cn(
         "group/source flex w-full min-w-0 items-center gap-2 overflow-hidden rounded-lg px-2 py-1.5 focus-within:bg-accent hover:bg-accent",
-        selected && "bg-accent"
+        highlighted && "bg-accent"
       )}
     >
       <span className="relative flex size-7 shrink-0 items-center justify-center">
@@ -124,9 +133,9 @@ function SelectableSourceRow({
       </span>
       <button
         type="button"
-        disabled={!ready}
+        disabled={!openable}
         className="min-w-0 flex-1 truncate rounded-sm text-left text-sm font-medium outline-none focus-visible:ring-2 focus-visible:ring-ring/50 disabled:cursor-default"
-        onClick={ready ? onOpen : undefined}
+        onClick={openable ? onOpen : undefined}
       >
         {document.title}
       </button>
@@ -144,13 +153,18 @@ function SelectableSourceRow({
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
           <DropdownMenuGroup>
-            {ready ? (
+            {openable ? (
               <>
                 <DropdownMenuItem onSelect={onOpen}>Open</DropdownMenuItem>
-                <DropdownMenuItem onSelect={() => onSelectedChange(!selected)}>
-                  {selected ? "Deselect" : "Select"}
+                <DropdownMenuItem onSelect={onReveal}>
+                  Show in folder
                 </DropdownMenuItem>
               </>
+            ) : null}
+            {ready ? (
+              <DropdownMenuItem onSelect={() => onSelectedChange(!selected)}>
+                {selected ? "Deselect" : "Select"}
+              </DropdownMenuItem>
             ) : null}
             {failed ? (
               <DropdownMenuItem onSelect={onRetry}>Retry</DropdownMenuItem>
@@ -165,79 +179,16 @@ function SelectableSourceRow({
   )
 }
 
-function DocumentPreview({
-  document,
-  citation,
-  onBack,
-}: {
-  document: DocumentDetail
-  citation: Citation | null
-  onBack: () => void
-}) {
-  const lines = (document.content ?? "").split("\n")
-  return (
-    <>
-      <header className="flex h-14 items-center gap-2 border-b px-3">
-        <Button
-          variant="ghost"
-          size="icon-sm"
-          aria-label="Back to sources"
-          onClick={onBack}
-        >
-          <ArrowLeftIcon />
-        </Button>
-        <h2 className="min-w-0 flex-1 truncate text-sm font-semibold">
-          {document.title}
-        </h2>
-      </header>
-      <ScrollArea className="min-h-0 flex-1">
-        <div className="p-4">
-          {document.content ? (
-            <pre className="font-sans text-xs leading-6 whitespace-pre-wrap">
-              {lines.map((line, index) => {
-                const lineNumber = index + 1
-                const cited =
-                  citation?.start_line != null &&
-                  citation.end_line != null &&
-                  lineNumber >= citation.start_line &&
-                  lineNumber <= citation.end_line
-                return (
-                  <span
-                    key={lineNumber}
-                    id={cited ? `cited-line-${lineNumber}` : undefined}
-                    className={cn(
-                      "block",
-                      cited && "bg-chart-1/15 text-foreground"
-                    )}
-                  >
-                    {line || " "}
-                  </span>
-                )
-              })}
-            </pre>
-          ) : (
-            <p className="text-sm text-muted-foreground">
-              No extracted text is available for this source.
-            </p>
-          )}
-        </div>
-      </ScrollArea>
-    </>
-  )
-}
-
 export function SourcesPanel({
   documents,
   selectedDocumentIds,
-  selectedDocument,
-  selectedCitation,
+  highlightedDocumentId,
   isLoading,
-  isLoadingPreview,
   isUploading,
   isDeleting,
   error,
   onOpen,
-  onBack,
+  onReveal,
   onRetry,
   onDeleteSelected,
   onSelectionChange,
@@ -246,15 +197,13 @@ export function SourcesPanel({
 }: {
   documents: WorkspaceDocument[]
   selectedDocumentIds: number[]
-  selectedDocument: DocumentDetail | null
-  selectedCitation: Citation | null
+  highlightedDocumentId: number | null
   isLoading: boolean
-  isLoadingPreview: boolean
   isUploading: boolean
   isDeleting: boolean
   error: string | null
-  onOpen: (documentId: number, citation?: Citation) => void
-  onBack: () => void
+  onOpen: (documentId: number) => void
+  onReveal: (documentId: number) => void
   onRetry: (documentId: number) => void
   onDeleteSelected: () => void
   onSelectionChange: (documentId: number, selected: boolean) => void
@@ -262,6 +211,7 @@ export function SourcesPanel({
   studioSlot?: ReactNode
 }) {
   const fileInput = useRef<HTMLInputElement>(null)
+  const sourceRows = useRef(new Map<number, HTMLDivElement>())
   const [deleteConfirmationOpen, setDeleteConfirmationOpen] = useState(false)
   const chooseFiles = () => fileInput.current?.click()
   const uploadSelectedFiles = (event: ChangeEvent<HTMLInputElement>) => {
@@ -269,20 +219,12 @@ export function SourcesPanel({
     event.target.value = ""
   }
 
-  if (selectedDocument) {
-    return (
-      <aside
-        className="flex h-full min-w-0 flex-col bg-card/30"
-        aria-label="Source preview"
-      >
-        <DocumentPreview
-          document={selectedDocument}
-          citation={selectedCitation}
-          onBack={onBack}
-        />
-      </aside>
-    )
-  }
+  useEffect(() => {
+    if (highlightedDocumentId === null) return
+    sourceRows.current
+      .get(highlightedDocumentId)
+      ?.scrollIntoView({ block: "nearest" })
+  }, [highlightedDocumentId])
 
   const selectedDocumentIdSet = new Set(selectedDocumentIds)
 
@@ -325,7 +267,7 @@ export function SourcesPanel({
                 <AlertDescription>{error}</AlertDescription>
               </Alert>
             ) : null}
-            {isLoading || isLoadingPreview
+            {isLoading
               ? [0, 1, 2].map((item) => (
                   <Skeleton key={item} className="h-20 w-full" />
                 ))
@@ -360,7 +302,13 @@ export function SourcesPanel({
                       key={document.id}
                       document={document}
                       selected={selectedDocumentIdSet.has(document.id)}
+                      highlighted={highlightedDocumentId === document.id}
+                      rowRef={(node) => {
+                        if (node) sourceRows.current.set(document.id, node)
+                        else sourceRows.current.delete(document.id)
+                      }}
                       onOpen={() => onOpen(document.id)}
+                      onReveal={() => onReveal(document.id)}
                       onRetry={() => onRetry(document.id)}
                       onSelectedChange={(selected) =>
                         onSelectionChange(document.id, selected)

--- a/surfsense_local/frontend/src/features/sources/use-sources.ts
+++ b/surfsense_local/frontend/src/features/sources/use-sources.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react"
+import { toast } from "sonner"
 
 import {
   deleteDocument,
@@ -7,7 +8,6 @@ import {
   retryDocument,
   uploadDocuments,
   type DocumentDetail,
-  type UploadOutcome,
   type WorkspaceDocument,
 } from "./api"
 
@@ -44,7 +44,6 @@ export function useSources(workspaceId: number) {
   const [isLoadingPreview, setIsLoadingPreview] = useState(false)
   const [isUploading, setIsUploading] = useState(false)
   const [isDeleting, setIsDeleting] = useState(false)
-  const [uploadOutcome, setUploadOutcome] = useState<UploadOutcome | null>(null)
   const [error, setError] = useState<string | null>(null)
   const listController = useRef<AbortController | null>(null)
   const detailController = useRef<AbortController | null>(null)
@@ -188,7 +187,6 @@ export function useSources(workspaceId: number) {
     const controller = new AbortController()
     uploadController.current = controller
     setIsUploading(true)
-    setUploadOutcome(null)
     setError(null)
     try {
       const outcome = await uploadDocuments(
@@ -208,10 +206,39 @@ export function useSources(workspaceId: number) {
           ...outcome.created,
         ]
       })
-      setUploadOutcome(outcome)
+      const count = outcome.created.length
+      const title =
+        count > 0
+          ? `${count} source${count === 1 ? "" : "s"} added`
+          : "No new sources added"
+      const description = [
+        count > 0 ? "Ingestion is running in the background." : null,
+        outcome.duplicates.length > 0
+          ? `Already present: ${outcome.duplicates
+              .map((duplicate) => duplicate.filename)
+              .join(", ")}`
+          : null,
+      ]
+        .filter(Boolean)
+        .join(" ")
+      const options = {
+        id: "source-upload-outcome",
+        description: description || undefined,
+      }
+      if (count > 0) {
+        toast.success(title, options)
+      } else {
+        toast.info(title, options)
+      }
     } catch (cause) {
       if (!isAbort(cause) && uploadController.current === controller) {
-        setError(messageFrom(cause))
+        toast.error(
+          `Couldn’t add your source${files.length === 1 ? "" : "s"}`,
+          {
+            id: "source-upload-error",
+            description: messageFrom(cause),
+          }
+        )
       }
     } finally {
       if (uploadController.current === controller) {
@@ -278,7 +305,6 @@ export function useSources(workspaceId: number) {
     isLoadingPreview,
     isUploading,
     isDeleting,
-    uploadOutcome,
     error,
     refresh,
     openDocument,
@@ -291,6 +317,5 @@ export function useSources(workspaceId: number) {
     deleteSelected,
     setDocumentSelected,
     upload,
-    dismissUploadOutcome: () => setUploadOutcome(null),
   }
 }

--- a/surfsense_local/frontend/src/features/sources/use-sources.ts
+++ b/surfsense_local/frontend/src/features/sources/use-sources.ts
@@ -5,10 +5,8 @@ import {
   deleteDocument,
   isSupportedSourceFile,
   listDocuments,
-  readDocument,
   retryDocument,
   uploadDocuments,
-  type DocumentDetail,
   type WorkspaceDocument,
 } from "./api"
 
@@ -39,15 +37,11 @@ export function useSources(workspaceId: number) {
   const [selectedDocumentIdSet, setSelectedDocumentIdSet] = useState(
     () => new Set<number>()
   )
-  const [selectedDocument, setSelectedDocument] =
-    useState<DocumentDetail | null>(null)
   const [isLoading, setIsLoading] = useState(true)
-  const [isLoadingPreview, setIsLoadingPreview] = useState(false)
   const [isUploading, setIsUploading] = useState(false)
   const [isDeleting, setIsDeleting] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const listController = useRef<AbortController | null>(null)
-  const detailController = useRef<AbortController | null>(null)
   const uploadController = useRef<AbortController | null>(null)
   const pollController = useRef<AbortController | null>(null)
   const hasActiveIngestion = documents.some(
@@ -74,7 +68,6 @@ export function useSources(workspaceId: number) {
       })
     return () => {
       controller.abort()
-      detailController.current?.abort()
       uploadController.current?.abort()
       pollController.current?.abort()
     }
@@ -140,30 +133,34 @@ export function useSources(workspaceId: number) {
     }
   }
 
-  const openDocument = async (documentId: number) => {
-    detailController.current?.abort()
-    const controller = new AbortController()
-    detailController.current = controller
-    setIsLoadingPreview(true)
-    setError(null)
+  const runNativeDocumentAction = async (
+    title: string,
+    action: (() => Promise<string>) | undefined
+  ) => {
     try {
-      const detail = await readDocument(
-        workspaceId,
-        documentId,
-        controller.signal
-      )
-      if (detailController.current === controller) {
-        setSelectedDocument(detail)
-      }
+      const error = action
+        ? await action()
+        : "Native file access is unavailable."
+      if (error) throw new Error(error)
     } catch (cause) {
-      if (!isAbort(cause) && detailController.current === controller) {
-        setError(messageFrom(cause))
-      }
-    } finally {
-      if (detailController.current === controller) {
-        setIsLoadingPreview(false)
-      }
+      toast.error(title, { description: messageFrom(cause) })
     }
+  }
+
+  const openOriginal = (documentId: number) => {
+    const bridge = window.surfsense
+    return runNativeDocumentAction(
+      "Couldn’t open source",
+      bridge ? () => bridge.openDocument(workspaceId, documentId) : undefined
+    )
+  }
+
+  const revealOriginal = (documentId: number) => {
+    const bridge = window.surfsense
+    return runNativeDocumentAction(
+      "Couldn’t locate source",
+      bridge ? () => bridge.revealDocument(workspaceId, documentId) : undefined
+    )
   }
 
   const retry = async (documentId: number) => {
@@ -320,19 +317,13 @@ export function useSources(workspaceId: number) {
   return {
     documents,
     selectedDocumentIds,
-    selectedDocument,
     isLoading,
-    isLoadingPreview,
     isUploading,
     isDeleting,
     error,
     refresh,
-    openDocument,
-    closePreview: () => {
-      detailController.current?.abort()
-      setSelectedDocument(null)
-      setIsLoadingPreview(false)
-    },
+    openOriginal,
+    revealOriginal,
     retry,
     deleteSelected,
     setDocumentSelected,

--- a/surfsense_local/frontend/src/features/sources/use-sources.ts
+++ b/surfsense_local/frontend/src/features/sources/use-sources.ts
@@ -3,6 +3,7 @@ import { toast } from "sonner"
 
 import {
   deleteDocument,
+  isSupportedSourceFile,
   listDocuments,
   readDocument,
   retryDocument,
@@ -183,6 +184,17 @@ export function useSources(workspaceId: number) {
     if (files.length === 0) {
       return
     }
+    const supported = files.filter(isSupportedSourceFile)
+    const unsupported = files.filter((file) => !isSupportedSourceFile(file))
+    if (supported.length === 0) {
+      toast.error(`Couldn’t add your source${files.length === 1 ? "" : "s"}`, {
+        id: "source-upload-error",
+        description: `Unsupported file type: ${unsupported
+          .map((file) => file.name)
+          .join(", ")}`,
+      })
+      return
+    }
     uploadController.current?.abort()
     const controller = new AbortController()
     uploadController.current = controller
@@ -191,7 +203,7 @@ export function useSources(workspaceId: number) {
     try {
       const outcome = await uploadDocuments(
         workspaceId,
-        files,
+        supported,
         controller.signal
       )
       if (uploadController.current !== controller) {
@@ -216,6 +228,14 @@ export function useSources(workspaceId: number) {
         outcome.duplicates.length > 0
           ? `Already present: ${outcome.duplicates
               .map((duplicate) => duplicate.filename)
+              .join(", ")}`
+          : null,
+        unsupported.length > 0
+          ? `Not supported: ${unsupported.map((file) => file.name).join(", ")}`
+          : null,
+        outcome.rejected.length > 0
+          ? `Rejected: ${outcome.rejected
+              .map((rejection) => `${rejection.filename} (${rejection.reason})`)
               .join(", ")}`
           : null,
       ]

--- a/surfsense_local/frontend/src/features/studio/studio-dialog.tsx
+++ b/surfsense_local/frontend/src/features/studio/studio-dialog.tsx
@@ -5,7 +5,7 @@ import {
   DownloadIcon,
   SparklesIcon,
   Trash2Icon,
-} from "lucide-react"
+} from "@/components/ui/icons"
 
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { Badge } from "@/components/ui/badge"
@@ -151,15 +151,16 @@ function Composer({
       <Button
         className="w-full"
         disabled={!canGenerate}
-        onClick={() =>
+        onClick={() => {
+          if (format === null) return
           onGenerate({
-            format: format!,
+            format,
             document_ids: [...selected],
             prompt: prompt.trim() || undefined,
           })
-        }
+        }}
       >
-        {isCreating ? <Spinner /> : <SparklesIcon />}
+        {isCreating ? <Spinner /> : <SparklesIcon data-icon="inline-start" />}
         Generate
       </Button>
     </div>
@@ -247,7 +248,7 @@ function Viewer({
         {artifact.files.map((file) => (
           <Button key={file.role} size="xs" variant="outline" asChild>
             <a href={fileUrl(artifact.id, file.role)} download>
-              <DownloadIcon />
+              <DownloadIcon data-icon="inline-start" />
               {file.role}
             </a>
           </Button>
@@ -270,6 +271,7 @@ function Preview({ artifact }: { artifact: ArtifactDetail }) {
 
   const src = fileUrl(artifact.id, primary.role)
   if (primary.mime_type.startsWith("audio/")) {
+    // biome-ignore lint/a11y/useMediaCaption: The generated transcript is rendered directly below the player.
     return <audio className="w-full p-4" controls src={src} />
   }
   if (primary.mime_type.startsWith("image/")) {

--- a/surfsense_local/frontend/src/features/workspaces/workspace-rail.tsx
+++ b/surfsense_local/frontend/src/features/workspaces/workspace-rail.tsx
@@ -141,7 +141,7 @@ export function WorkspaceRail({
 
   return (
     <nav
-      className="flex h-svh flex-col items-center bg-sidebar py-3 text-sidebar-foreground"
+      className="flex h-full flex-col items-center bg-sidebar py-3 text-sidebar-foreground"
       aria-label="Workspaces"
     >
       <ScrollArea className="min-h-0 w-full flex-1">

--- a/surfsense_local/frontend/src/features/workspaces/workspace-rail.tsx
+++ b/surfsense_local/frontend/src/features/workspaces/workspace-rail.tsx
@@ -203,23 +203,23 @@ export function WorkspaceRail({
               </ContextMenu>
             )
           })}
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                size="icon-lg"
+                variant="ghost"
+                className="rounded-xl border border-dashed border-sidebar-border"
+                disabled={isMutating}
+                aria-label="Create workspace"
+                onClick={() => setCreateOpen(true)}
+              >
+                <PlusIcon />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="right">Create workspace</TooltipContent>
+          </Tooltip>
         </div>
       </ScrollArea>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            size="icon-lg"
-            variant="ghost"
-            className="mt-2 rounded-xl border border-dashed"
-            disabled={isMutating}
-            aria-label="Create workspace"
-            onClick={() => setCreateOpen(true)}
-          >
-            <PlusIcon />
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent side="right">Create workspace</TooltipContent>
-      </Tooltip>
 
       <WorkspaceNameDialog
         key={`create-${createOpen}`}

--- a/surfsense_local/frontend/src/index.css
+++ b/surfsense_local/frontend/src/index.css
@@ -60,6 +60,7 @@
 }
 
 :root {
+  color-scheme: light;
   --titlebar-height: 0px;
   --app-shell: #f3f2ee;
   --background: #f7f6f2;
@@ -98,6 +99,7 @@
 }
 
 .dark {
+  color-scheme: dark;
   --app-shell: #101010;
   --background: #141414;
   --foreground: #e8e3da;

--- a/surfsense_local/frontend/src/index.css
+++ b/surfsense_local/frontend/src/index.css
@@ -172,3 +172,63 @@
 .electron-macos #root {
   padding-top: var(--titlebar-height);
 }
+
+[data-streamdown="code-block"] {
+  gap: 0;
+  overflow: visible;
+  border: 0;
+  border-radius: calc(var(--radius) * 0.8);
+  background: var(--accent);
+  padding: 0;
+}
+
+[data-streamdown="code-block-header"] {
+  height: 2.5rem;
+  padding-inline: 1rem;
+  color: var(--accent-foreground);
+  font-weight: 600;
+}
+
+[data-streamdown="code-block-header"] > span {
+  margin-left: 0;
+}
+
+[data-streamdown="code-block-actions"] {
+  position: relative;
+  top: 0.25rem;
+  gap: 0.25rem;
+  border: 0;
+  background: transparent;
+  padding: 0 0.5rem;
+  backdrop-filter: none;
+}
+
+[data-streamdown="code-block-actions"] button {
+  display: inline-flex;
+  width: 2rem;
+  height: 2rem;
+  align-items: center;
+  justify-content: center;
+  border-radius: calc(var(--radius) * 0.6);
+  color: var(--accent-foreground);
+}
+
+[data-streamdown="code-block-actions"] button:hover {
+  background: var(--secondary);
+  color: var(--secondary-foreground);
+}
+
+[data-streamdown="code-block-actions"] button:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: -2px;
+}
+
+[data-streamdown="code-block-body"] {
+  border: 0;
+  border-radius: 0;
+  background: var(--accent);
+}
+
+[data-streamdown="code-block-body"] pre {
+  background: transparent;
+}

--- a/surfsense_local/frontend/src/index.css
+++ b/surfsense_local/frontend/src/index.css
@@ -60,6 +60,7 @@
 }
 
 :root {
+  --titlebar-height: 0px;
   --app-shell: #f3f2ee;
   --background: #f7f6f2;
   --foreground: #1e1e1e;
@@ -138,31 +139,34 @@
   }
   body {
     @apply bg-background text-foreground;
+    margin: 0;
+    padding: 0;
   }
   html {
     @apply font-sans antialiased;
   }
+  #root {
+    height: 100svh;
+  }
+}
+
+.electron-macos {
+  --titlebar-height: 28px;
 }
 
 .electron-macos body {
   background: var(--app-shell);
-  padding-top: 28px;
 }
 
 .electron-macos body::before {
   position: fixed;
   inset: 0 0 auto;
-  height: 28px;
+  height: var(--titlebar-height);
   background: var(--app-shell);
   content: "";
   -webkit-app-region: drag;
 }
 
-.electron-macos #root,
-.electron-macos .h-svh {
-  height: calc(100svh - 28px);
-}
-
-.electron-macos .min-h-svh {
-  min-height: calc(100svh - 28px);
+.electron-macos #root {
+  padding-top: var(--titlebar-height);
 }

--- a/surfsense_local/frontend/src/lib/api.ts
+++ b/surfsense_local/frontend/src/lib/api.ts
@@ -4,7 +4,15 @@ export type Health = {
 
 declare global {
   interface Window {
-    surfsense?: { apiUrl: string; platform: string }
+    surfsense?: {
+      apiUrl: string
+      platform: string
+      openDocument: (workspaceId: number, documentId: number) => Promise<string>
+      revealDocument: (
+        workspaceId: number,
+        documentId: number
+      ) => Promise<string>
+    }
   }
 }
 
@@ -38,11 +46,7 @@ export class ApiError extends Error {
 async function responseError(response: Response): Promise<string> {
   try {
     const body: unknown = await response.json()
-    if (
-      typeof body === "object" &&
-      body !== null &&
-      "detail" in body
-    ) {
+    if (typeof body === "object" && body !== null && "detail" in body) {
       if (typeof body.detail === "string") {
         return body.detail
       }
@@ -57,7 +61,8 @@ async function responseError(response: Response): Promise<string> {
             ? body.detail.required
             : null
         const available =
-          "available" in body.detail && typeof body.detail.available === "number"
+          "available" in body.detail &&
+          typeof body.detail.available === "number"
             ? body.detail.available
             : null
         return required !== null && available !== null

--- a/surfsense_local/frontend/src/main.tsx
+++ b/surfsense_local/frontend/src/main.tsx
@@ -5,6 +5,7 @@ import { QueryClientProvider } from "@tanstack/react-query"
 import "./index.css"
 import App from "./App.tsx"
 import { ThemeProvider } from "@/components/theme-provider.tsx"
+import { Toaster } from "@/components/ui/sonner.tsx"
 import { TooltipProvider } from "@/components/ui/tooltip.tsx"
 import { queryClient } from "@/lib/query-client.ts"
 
@@ -23,6 +24,7 @@ createRoot(root).render(
       <ThemeProvider>
         <TooltipProvider>
           <App />
+          <Toaster position="top-right" />
         </TooltipProvider>
       </ThemeProvider>
     </QueryClientProvider>


### PR DESCRIPTION
<!--- Summarize your pull request in a few sentences -->

## Description
<!--- Clearly describe what has changed in this pull request -->
- Use dynamic development ports and refine Studio actions and icons.
- Normalize Electron layouts, title-bar spacing, theme color schemes, and modal behavior.
- Add dedicated chat composer and viewport components with improved lifecycle, scrolling, sizing, and model controls.
- Generate chat titles through the selected LLM, animate them with a typewriter effect, and support manual renaming.
- Improve streaming Markdown, code highlighting, code controls, and math rendering with Streamdown.
- Add message copy actions, relative backend timestamps, completion timestamps, and supporting database migration.
- Replace legacy citations with stable `[citation:n]` references, validated citation catalogs, and inline citation controls.
- Highlight cited sources in the source panel without opening their contents.
- Redesign source rows with selection, processing, retry, and action states.
- Validate upload extensions, MIME types, file contents, size limits, and rejected-file outcomes.
- Replace persistent upload results with top-right Sonner notifications.
- Open uploaded originals with the default OS application through validated Electron IPC and support revealing them in their folder.
- Remove extracted-document preview APIs, frontend preview state, and stale citation compatibility code.
- Restore saved Electron window bounds and maximized state across launches.
- Refine tooltips, icons, workspace controls, message layout, and responsive source-panel behavior.
- Add and update unit, integration, frontend, modal, typewriter, citation, upload, and Electron file-resolution tests.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If this PR relates to an open issue, please link to the issue here: FIX #123 -->
FIX #


## Screenshots
<!-- If applicable, add screenshots or images to demonstrate the changes visually -->

## API Changes
<!-- Document any API changes if applicable -->
- [ ] This PR includes API changes

## Change Type
<!--- Indicate what kind(s) of changes this PR includes: -->
- [ ] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Dependency/Build system
- [ ] Breaking change
- [ ] Other (specify):

## Testing Performed
<!--- Briefly describe how you have tested these changes and what verification was performed -->
- [ ] Tested locally
- [ ] Manual/QA verification

## Checklist
<!--- Please confirm the following by marking with an 'x' as appropriate -->
- [ ] Follows project coding standards and conventions
- [ ] Documentation updated as needed
- [ ] Dependencies updated as needed
- [ ] No lint/build errors or new warnings
- [ ] All relevant tests are passing

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR introduces a comprehensive local frontend implementation for SurfSense, featuring automatic chat thread naming, improved citation handling with stable source IDs, enhanced file upload validation with MIME type verification, native file operations through Electron IPC, UI refinements including typewriter animations for generated titles and relative timestamps, and better conversation lifecycle management with distinct states for new/creating/active threads. The changes span the full stack from database schema updates to frontend components, with significant security improvements in file upload validation and architectural changes to chat state management.

⏱️ Estimated Review Time: 3+ hours

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_local/backend/alembic/versions/0002_add_chat_message_completed_at.py` |
| 2 | `surfsense_local/backend/modules/chat/models.py` |
| 3 | `surfsense_local/backend/modules/chat/schemas.py` |
| 4 | `surfsense_local/backend/modules/chat/title.py` |
| 5 | `surfsense_local/backend/modules/chat/prompt.py` |
| 6 | `surfsense_local/backend/modules/chat/router.py` |
| 7 | `surfsense_local/backend/modules/llm/providers/protocols.py` |
| 8 | `surfsense_local/backend/modules/llm/providers/ollama/provider.py` |
| 9 | `surfsense_local/backend/modules/llm/providers/openrouter/provider.py` |
| 10 | `surfsense_local/backend/modules/documents/storage.py` |
| 11 | `surfsense_local/backend/modules/documents/schemas.py` |
| 12 | `surfsense_local/backend/modules/documents/router.py` |
| 13 | `surfsense_local/backend/worker/ingestion/parsing.py` |
| 14 | `surfsense_local/backend/tests/unit/chat/test_title.py` |
| 15 | `surfsense_local/backend/tests/unit/chat/test_citations.py` |
| 16 | `surfsense_local/backend/tests/unit/chat/test_prompt.py` |
| 17 | `surfsense_local/backend/tests/unit/documents/test_upload_validation.py` |
| 18 | `surfsense_local/backend/tests/integration/chat/conftest.py` |
| 19 | `surfsense_local/backend/tests/integration/chat/test_chat.py` |
| 20 | `surfsense_local/backend/tests/integration/documents/test_routes.py` |
| 21 | `surfsense_local/backend/tests/integration/documents/test_upload.py` |
| 22 | `surfsense_local/electron/package.json` |
| 23 | `surfsense_local/electron/src/main/window-state.ts` |
| 24 | `surfsense_local/electron/src/main/document-files.mts` |
| 25 | `surfsense_local/electron/src/main/document-files.test.mts` |
| 26 | `surfsense_local/electron/src/main/net.ts` |
| 27 | `surfsense_local/electron/src/main/index.ts` |
| 28 | `surfsense_local/electron/src/preload/index.ts` |
| 29 | `surfsense_local/frontend/package.json` |
| 30 | `surfsense_local/frontend/pnpm-lock.yaml` |
| 31 | `surfsense_local/frontend/src/lib/api.ts` |
| 32 | `surfsense_local/frontend/src/features/sources/api.ts` |
| 33 | `surfsense_local/frontend/src/features/chat/api.ts` |
| 34 | `surfsense_local/frontend/src/features/chat/sse.ts` |
| 35 | `surfsense_local/frontend/src/features/chat/citation-markdown.ts` |
| 36 | `surfsense_local/frontend/src/features/chat/inline-citation.tsx` |
| 37 | `surfsense_local/frontend/src/components/typewriter-text.tsx` |
| 38 | `surfsense_local/frontend/src/components/typewriter-text.test.tsx` |
| 39 | `surfsense_local/frontend/src/components/relative-time.tsx` |
| 40 | `surfsense_local/frontend/src/features/chat/chat-composer.tsx` |
| 41 | `surfsense_local/frontend/src/features/chat/chat-viewport.tsx` |
| 42 | `surfsense_local/frontend/src/features/chat/message.tsx` |
| 43 | `surfsense_local/frontend/src/features/chat/thread-list.tsx` |
| 44 | `surfsense_local/frontend/src/features/chat/thread-panel.tsx` |
| 45 | `surfsense_local/frontend/src/features/chat/use-chat-runtime.ts` |
| 46 | `surfsense_local/frontend/src/features/sources/sources-panel.tsx` |
| 47 | `surfsense_local/frontend/src/features/sources/use-sources.ts` |
| 48 | `surfsense_local/frontend/src/features/dashboard/dashboard-page.tsx` |
| 49 | `surfsense_local/frontend/src/components/ui/dialog.tsx` |
| 50 | `surfsense_local/frontend/src/components/ui/modal-layout.test.tsx` |
| 51 | `surfsense_local/frontend/src/components/ui/tooltip.tsx` |
| 52 | `surfsense_local/frontend/src/components/ui/icons.tsx` |
| 53 | `surfsense_local/frontend/src/components/ui/sonner.tsx` |
| 54 | `surfsense_local/frontend/src/index.css` |
| 55 | `surfsense_local/frontend/src/main.tsx` |
| 56 | `surfsense_local/frontend/src/app/app-bootstrap.tsx` |
| 57 | `surfsense_local/frontend/src/features/model-selection/model-selection-page.tsx` |
| 58 | `surfsense_local/frontend/src/features/studio/studio-dialog.tsx` |
| 59 | `surfsense_local/frontend/src/features/workspaces/workspace-rail.tsx` |
| 60 | `surfsense_local/frontend/src/features/chat/inline-citation.test.ts` |
| 61 | `surfsense_local/frontend/src/features/chat/sse.test.ts` |
| 62 | `surfsense_local/frontend/src/features/sources/source-upload.test.tsx` |
| 63 | `surfsense_local/frontend/src/features/dashboard/dashboard-page.test.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->