### PR TITLE
fix(model-connections): classify and probe image-only OpenAI models

### DIFF
--- a/surfsense_backend/app/services/model_connection_service.py
+++ b/surfsense_backend/app/services/model_connection_service.py
@@ -15,6 +15,7 @@ import litellm
 
 from app.db import Connection, Model, ModelSource
 from app.services.context_admission import SURFSENSE_UNKNOWN_MODEL_MAX_INPUT_TOKENS
+from app.services.model_capabilities import has_capability
 from app.services.model_resolver import to_litellm
 from app.services.openrouter_model_normalizer import normalize_openrouter_models
 from app.services.provider_registry import Transport, provider_label, spec_for
@@ -378,6 +379,34 @@ def _ollama_seed_budget(metadata: dict) -> int | None:
     return None
 
 
+def _openai_shaped_capabilities(
+    metadata: dict, facts: dict[str, Any]
+) -> dict[str, Any]:
+    """Xinference-style per-model metadata from an OpenAI-shaped ``/v1/models``
+    entry, as overrides for ``facts``.
+
+    A plain OpenAI-compatible server (vanilla vLLM, LM Studio's OpenAI facade)
+    does not report ``model_type``, so an empty dict leaves ``facts`` as
+    litellm classified them.
+    """
+    model_type = metadata.get("model_type")
+    if not model_type:
+        return {}
+    ability = set(metadata.get("model_ability") or [])
+    if model_type == "image" or "text2image" in ability:
+        return {"supports_chat": False, "supports_image_generation": True}
+    if model_type in {"embedding", "rerank", "audio", "video"}:
+        return {"supports_chat": False}
+    if model_type == "LLM" and ability:
+        return {
+            "supports_chat": "chat" in ability,
+            "supports_image_input": "vision" in ability
+            or facts["supports_image_input"],
+            "supports_tools": "tools" in ability or facts["supports_tools"],
+        }
+    return {}
+
+
 def derive_capabilities(
     conn: Connection, model_id: str, metadata: dict | None = None
 ) -> dict[str, Any]:
@@ -398,6 +427,8 @@ def derive_capabilities(
                 or facts["max_input_tokens"],
             }
         )
+    elif spec.transport == Transport.OPENAI_COMPATIBLE:
+        facts.update(_openai_shaped_capabilities(metadata, facts))
     return facts
 
 
@@ -846,6 +877,22 @@ async def discover_models(conn: Connection) -> list[dict[str, Any]]:
 
 async def test_model(conn: Connection, model: Model) -> VerifyResult:
     model_string, kwargs = to_litellm(conn, model.model_id)
+
+    if has_capability(model, "image_gen") and not has_capability(model, "chat"):
+        try:
+            await litellm.aimage_generation(
+                prompt="test",
+                model=model_string,
+                n=1,
+                timeout=TEST_TIMEOUT_SECONDS,
+                **kwargs,
+            )
+        except Exception as exc:
+            return _model_test_error(conn, model.model_id, exc)
+
+        model.supports_image_generation = True
+        return VerifyResult("OK", True, "Model test succeeded.")
+
     try:
         await litellm.acompletion(
             model=model_string,

--- a/surfsense_backend/tests/unit/services/test_model_connections.py
+++ b/surfsense_backend/tests/unit/services/test_model_connections.py
@@ -1,6 +1,7 @@
 from types import SimpleNamespace
 
 import httpx
+import litellm
 import pytest
 
 from app.routes.model_connections_routes import _apply_model_facts
@@ -121,6 +122,109 @@ def test_derive_capabilities_seeds_a_small_window_verbatim() -> None:
     assert facts["max_input_tokens"] == 4_096
     assert facts["supports_tools"] is True
     assert facts["supports_image_input"] is True
+
+
+def _openai_compatible_conn() -> SimpleNamespace:
+    return SimpleNamespace(
+        provider="openai_compatible",
+        base_url="http://host.docker.internal:9997/v1",
+        api_key=None,
+        extra={},
+    )
+
+
+def test_derive_capabilities_classifies_xinference_image_model() -> None:
+    """Xinference reports an image model's type in its /v1/models entry;
+    litellm has never heard of FLUX.2-klein-4B and would otherwise default it
+    to chat (SurfSense #1518). The full dict is pinned, not just the two
+    changed keys, so over-claiming supports_image_input from the
+    text2image ability (editing, not vision input, per the plan) is caught."""
+    facts = derive_capabilities(
+        _openai_compatible_conn(),
+        "FLUX.2-klein-4B",
+        {
+            "id": "FLUX.2-klein-4B",
+            "model_type": "image",
+            "model_ability": ["text2image"],
+        },
+    )
+
+    assert facts == {
+        "supports_chat": False,
+        "max_input_tokens": None,
+        "supports_image_input": False,
+        "supports_tools": False,
+        "supports_image_generation": True,
+    }
+
+
+def test_derive_capabilities_classifies_xinference_llm_model() -> None:
+    facts = derive_capabilities(
+        _openai_compatible_conn(),
+        "some-vlm",
+        {
+            "id": "some-vlm",
+            "model_type": "LLM",
+            "model_ability": ["generate", "chat", "vision", "tools"],
+        },
+    )
+
+    assert facts["supports_chat"] is True
+    assert facts["supports_image_input"] is True
+    assert facts["supports_tools"] is True
+
+
+def test_derive_capabilities_classifies_xinference_embedding_model() -> None:
+    facts = derive_capabilities(
+        _openai_compatible_conn(),
+        "bge-m3",
+        {"id": "bge-m3", "model_type": "embedding"},
+    )
+
+    assert facts["supports_chat"] is False
+
+
+def test_derive_capabilities_classifies_xinference_video_model() -> None:
+    """Xinference also serves video models (xinference/model/video/core.py,
+    model_type "video"); a user connecting one hits the same reported
+    symptom as an image model if this type is left unhandled."""
+    facts = derive_capabilities(
+        _openai_compatible_conn(),
+        "CogVideoX",
+        {"id": "CogVideoX", "model_type": "video"},
+    )
+
+    assert facts["supports_chat"] is False
+
+
+def test_derive_capabilities_leaves_litellm_facts_when_no_model_type(
+    monkeypatch,
+) -> None:
+    """A plain OpenAI-compatible server (vanilla vLLM, LM Studio's OpenAI
+    facade) does not report model_type; the metadata branch must leave
+    whatever litellm already classified untouched.
+
+    litellm's classification is monkeypatched to a fixed, non-default dict
+    so the assertion pins actual values instead of comparing the branch
+    against itself -- two calls that both lack model_type were previously
+    compared to each other, which stayed green even when the branch
+    unconditionally overwrote supports_chat to False."""
+    fixed_facts = {
+        "supports_chat": True,
+        "max_input_tokens": 4096,
+        "supports_image_input": True,
+        "supports_tools": False,
+        "supports_image_generation": False,
+    }
+    monkeypatch.setattr(
+        model_connection_service,
+        "_classify_from_litellm",
+        lambda _model_string, _model_id: dict(fixed_facts),
+    )
+
+    facts = derive_capabilities(_openai_compatible_conn(), "gpt-4o", {"id": "gpt-4o"})
+
+    assert facts == fixed_facts
 
 
 @pytest.mark.asyncio
@@ -420,6 +524,130 @@ def test_model_test_error_keeps_statusless_connection_failure_unreachable() -> N
 
     assert result.status == "UNREACHABLE"
     assert result.ok is False
+
+
+def _model_stub(
+    model_id: str,
+    *,
+    supports_chat: bool | None,
+    supports_image_generation: bool | None,
+    capabilities_override: dict | None = None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        model_id=model_id,
+        supports_chat=supports_chat,
+        supports_image_generation=supports_image_generation,
+        capabilities_override=capabilities_override or {},
+    )
+
+
+@pytest.mark.asyncio
+async def test_model_test_probes_image_generation_for_an_image_model(
+    monkeypatch,
+) -> None:
+    """An image model must be probed with aimage_generation, never a chat
+    completion -- litellm.acompletion fails on an image-only model, which is
+    exactly the symptom the reporter hit (SurfSense #1518)."""
+    calls = {"acompletion": 0, "aimage_generation": 0}
+
+    async def fake_acompletion(**_kwargs):
+        calls["acompletion"] += 1
+        raise AssertionError("acompletion must not be called for an image model")
+
+    async def fake_aimage_generation(**kwargs):
+        calls["aimage_generation"] += 1
+        assert kwargs["model"] == "openai/FLUX.2-klein-4B"
+        assert kwargs["prompt"] == "test"
+        assert kwargs["n"] == 1
+        assert kwargs["timeout"] == model_connection_service.TEST_TIMEOUT_SECONDS
+        return SimpleNamespace()
+
+    monkeypatch.setattr(litellm, "acompletion", fake_acompletion)
+    monkeypatch.setattr(litellm, "aimage_generation", fake_aimage_generation)
+
+    conn = _openai_compatible_conn()
+    model = _model_stub(
+        "FLUX.2-klein-4B", supports_chat=False, supports_image_generation=True
+    )
+
+    result = await model_connection_service.test_model(conn, model)
+
+    assert result.ok is True
+    assert calls["aimage_generation"] == 1
+    assert calls["acompletion"] == 0
+    assert model.supports_image_generation is True
+
+
+@pytest.mark.asyncio
+async def test_model_test_probes_chat_completion_for_a_chat_model(
+    monkeypatch,
+) -> None:
+    """Regression guard: a chat model's Connect test must keep calling
+    acompletion byte for byte, unaffected by the new image branch."""
+    calls = {"acompletion": 0, "aimage_generation": 0}
+
+    async def fake_acompletion(**kwargs):
+        calls["acompletion"] += 1
+        assert kwargs["messages"] == [{"role": "user", "content": "Hello"}]
+        assert kwargs["timeout"] == model_connection_service.TEST_TIMEOUT_SECONDS
+        return SimpleNamespace()
+
+    async def fake_aimage_generation(**_kwargs):
+        calls["aimage_generation"] += 1
+        raise AssertionError("aimage_generation must not be called for a chat model")
+
+    monkeypatch.setattr(litellm, "acompletion", fake_acompletion)
+    monkeypatch.setattr(litellm, "aimage_generation", fake_aimage_generation)
+
+    conn = _openai_compatible_conn()
+    model = _model_stub("some-llm", supports_chat=True, supports_image_generation=False)
+
+    result = await model_connection_service.test_model(conn, model)
+
+    assert result.ok is True
+    assert calls["acompletion"] == 1
+    assert calls["aimage_generation"] == 0
+    assert model.supports_chat is True
+
+
+@pytest.mark.asyncio
+async def test_model_test_probes_chat_completion_for_a_dual_capability_model(
+    monkeypatch,
+) -> None:
+    """Half of the guard in test_model (`and not has_capability(model,
+    "chat")`) is otherwise untested: a model that is both chat AND
+    image-generation capable (an Xinference LLM entry whose ability list
+    includes text2image, or a capabilities_override that sets both) must
+    still be probed with acompletion, since a dual-capability model is
+    reachable through ordinary chat and the Connect button tests that
+    path."""
+    calls = {"acompletion": 0, "aimage_generation": 0}
+
+    async def fake_acompletion(**kwargs):
+        calls["acompletion"] += 1
+        assert kwargs["messages"] == [{"role": "user", "content": "Hello"}]
+        return SimpleNamespace()
+
+    async def fake_aimage_generation(**_kwargs):
+        calls["aimage_generation"] += 1
+        raise AssertionError(
+            "aimage_generation must not be called for a dual-capability model"
+        )
+
+    monkeypatch.setattr(litellm, "acompletion", fake_acompletion)
+    monkeypatch.setattr(litellm, "aimage_generation", fake_aimage_generation)
+
+    conn = _openai_compatible_conn()
+    model = _model_stub(
+        "dual-capability-model", supports_chat=True, supports_image_generation=True
+    )
+
+    result = await model_connection_service.test_model(conn, model)
+
+    assert result.ok is True
+    assert calls["acompletion"] == 1
+    assert calls["aimage_generation"] == 0
+    assert model.supports_chat is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
An OpenAI-compatible server that reports each model's type in its `/v1/models` entries
(Xinference does) still had every model it exposes classified as chat, and the Connect test
sent a chat completion to image models. This reads the reported type when it is there and
probes image models with an image generation call.

## Description

- `derive_capabilities` now reads Xinference-style `model_type` and `model_ability` from a
  discovered `/v1/models` entry for the OpenAI-compatible transport: `model_type: "image"`
  (or a `text2image` ability) gives `supports_chat: false, supports_image_generation: true`;
  `embedding`, `rerank`, `audio` and `video` give `supports_chat: false`; `LLM` entries take
  `chat`, `vision` and `tools` from `model_ability`, OR'ed with what litellm already knew.
  An entry without `model_type` (vanilla OpenAI, vLLM, LM Studio's OpenAI facade) leaves
  litellm's classification exactly as before.
- `test_model` now probes `litellm.aimage_generation` instead of `acompletion` when the
  model's effective capabilities (override included) say image generation and not chat,
  with the same `TEST_TIMEOUT_SECONDS` bound as the chat probe, and marks
  `supports_image_generation` on success. The chat path is unchanged.

## Motivation and Context

Discovery over an OpenAI-shaped endpoint kept the per-model metadata the server returned
(`metadata: item`) but asked litellm for the classification, and litellm has no entry for a
locally served `FLUX.2-klein-4B`, so the model landed under Chat. Connecting it then ran a
chat completion against an image model and failed with "Could not test model ... on
OpenAI-compatible provider". Same two symptoms as the report. Xinference's `/v1/models`
handler unpacks the model description into each entry (`model_type`, `model_ability`,
`model_name`, `model_family`), which is what this change reads.

FIX #1518

## Screenshots

Backend only, no UI change.

## API Changes

- [ ] This PR includes API changes

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Dependency/Build system
- [ ] Breaking change
- [ ] Other (specify):

## Testing Performed

- [x] Tested locally
- [ ] Manual/QA verification

Eight unit tests added to `tests/unit/services/test_model_connections.py`, written first and
failing on the unmodified `dev` tip for the reported reason (image classified as chat,
`acompletion` called for an image model), then passing:

```
test_derive_capabilities_classifies_xinference_image_model
test_derive_capabilities_classifies_xinference_llm_model
test_derive_capabilities_classifies_xinference_embedding_model
test_derive_capabilities_classifies_xinference_video_model
test_derive_capabilities_leaves_litellm_facts_when_no_model_type
test_model_test_probes_image_generation_for_an_image_model
test_model_test_probes_chat_completion_for_a_chat_model
test_model_test_probes_chat_completion_for_a_dual_capability_model
```

Each piece of the change is guarded by exactly one of these: reverting the
`derive_capabilities` branch fails the four classification tests and nothing else; reverting
the `test_model` branch fails the image probe test; forcing the no-`model_type` path to
change litellm's facts, dropping the `not chat` half of the guard, or removing the timeout
each fails one named test. Full `tests/unit`: 4401 passed on this branch against 4393 on the
base `dev` tip (exactly the eight new tests), same pre-existing failures and collection
errors on both, none in the touched files. `ruff check` and `ruff format --check` clean on
both files.

Not verified against a live Xinference server: the metadata shape in the tests is taken
from Xinference's source (`xinference/api/restful_api.py` `list_models`,
`xinference/model/image/core.py` `to_description`). A confirmation on a real setup would be
welcome.

## Checklist

- [x] Follows project coding standards and conventions
- [x] Documentation updated as needed
- [x] Dependencies updated as needed
- [x] No lint/build errors or new warnings
- [x] All relevant tests are passing


<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR fixes a bug where OpenAI-compatible servers (like Xinference) that report model types in their `/v1/models` endpoint were incorrectly classifying all models as chat models. The fix adds support for reading `model_type` and `model_ability` metadata to correctly classify image, embedding, video, and LLM models. Additionally, the model connection test now probes image-generation models with `aimage_generation` instead of `acompletion`, preventing failures when testing image-only models. The changes are backward compatible—servers that don't report `model_type` (vanilla OpenAI, vLLM, LM Studio) continue using litellm's existing classification logic.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_backend/tests/unit/services/test_model_connections.py` |
| 2 | `surfsense_backend/app/services/model_connection_service.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->