### PR TITLE
[Feat|Local] Cloud import and offline license

### DIFF
--- a/surfsense_local/backend/alembic/versions/0005_workspace_cloud_id.py
+++ b/surfsense_local/backend/alembic/versions/0005_workspace_cloud_id.py
@@ -1,0 +1,30 @@
+"""add workspace cloud_id
+
+Revision ID: 0005
+Revises: 0004
+Create Date: 2026-09-10
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "0005"
+down_revision: str | Sequence[str] | None = "0004"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("workspaces") as batch:
+        batch.add_column(sa.Column("cloud_id", sa.Integer(), nullable=True))
+        batch.create_unique_constraint(op.f("uq_workspaces_cloud_id"), ["cloud_id"])
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("workspaces") as batch:
+        batch.drop_constraint(op.f("uq_workspaces_cloud_id"), type_="unique")
+        batch.drop_column("cloud_id")

--- a/surfsense_local/backend/alembic/versions/0006_license_state.py
+++ b/surfsense_local/backend/alembic/versions/0006_license_state.py
@@ -1,0 +1,34 @@
+"""add license state
+
+Revision ID: 0006
+Revises: 0005
+Create Date: 2026-09-10
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "0006"
+down_revision: str | Sequence[str] | None = "0005"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "license_state",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("certificate", sa.String(), nullable=True),
+        sa.Column("imported_at", sa.DateTime(), nullable=True),
+        sa.Column("clock_watermark", sa.DateTime(), nullable=False),
+        sa.CheckConstraint("id = 1", name=op.f("ck_license_state_singleton")),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_license_state")),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("license_state")

--- a/surfsense_local/backend/api/main.py
+++ b/surfsense_local/backend/api/main.py
@@ -11,6 +11,7 @@ from modules.events.broker import EventBroker
 from modules.events.router import router as events_router
 from modules.health.router import router as health_router
 from modules.llm.router import router as llm_router
+from modules.migration.router import router as migration_router
 from modules.workspaces.router import router as workspaces_router
 from modules.workspaces.seed import ensure_default_workspace
 from shared.config import get_storage_settings
@@ -55,4 +56,5 @@ def create_app() -> FastAPI:
     app.include_router(chat_router)
     app.include_router(artifacts_router)
     app.include_router(events_router)
+    app.include_router(migration_router)
     return app

--- a/surfsense_local/backend/api/main.py
+++ b/surfsense_local/backend/api/main.py
@@ -10,6 +10,7 @@ from modules.documents.router import router as documents_router
 from modules.events.broker import EventBroker
 from modules.events.router import router as events_router
 from modules.health.router import router as health_router
+from modules.license.router import router as license_router
 from modules.llm.router import router as llm_router
 from modules.migration.router import router as migration_router
 from modules.workspaces.router import router as workspaces_router
@@ -57,4 +58,5 @@ def create_app() -> FastAPI:
     app.include_router(artifacts_router)
     app.include_router(events_router)
     app.include_router(migration_router)
+    app.include_router(license_router)
     return app

--- a/surfsense_local/backend/modules/license/models.py
+++ b/surfsense_local/backend/modules/license/models.py
@@ -1,0 +1,18 @@
+from datetime import datetime
+
+from sqlalchemy import CheckConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from shared.db import Base
+
+
+class LicenseState(Base):
+    __tablename__ = "license_state"
+    __table_args__ = (CheckConstraint("id = 1", name="singleton"),)
+
+    id: Mapped[int] = mapped_column(primary_key=True, default=1)
+    # The file as imported; state is re-derived from it on every read.
+    certificate: Mapped[str | None]
+    imported_at: Mapped[datetime | None]
+    # Highest instant ever observed; a clock behind it is not trusted.
+    clock_watermark: Mapped[datetime]

--- a/surfsense_local/backend/modules/license/router.py
+++ b/surfsense_local/backend/modules/license/router.py
@@ -1,0 +1,47 @@
+from fastapi import APIRouter, HTTPException, status
+from pydantic import BaseModel
+
+from api.dependencies import SessionDep
+from modules.license.service import (
+    LicenseStatus,
+    import_certificate,
+    remove_certificate,
+)
+from modules.license.service import status as license_status
+from modules.license.verify import LicenseRejectedError
+
+router = APIRouter(prefix="/license", tags=["license"])
+
+
+class LicenseImport(BaseModel):
+    certificate: str
+
+
+@router.get("/status", response_model=LicenseStatus, summary="Read the license")
+def read_status(session: SessionDep) -> LicenseStatus:
+    return license_status(session)
+
+
+@router.put("", response_model=LicenseStatus, summary="Import a license file")
+def put_license(payload: LicenseImport, session: SessionDep) -> LicenseStatus:
+    try:
+        return import_certificate(session, payload.certificate)
+    except LicenseRejectedError as rejected:
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_CONTENT,
+            {"code": rejected.code, "message": REASONS[rejected.code]},
+        ) from rejected
+
+
+@router.delete("", status_code=status.HTTP_204_NO_CONTENT, summary="Remove the license")
+def delete_license(session: SessionDep) -> None:
+    remove_certificate(session)
+
+
+REASONS = {
+    "not_a_license_file": "This is not a SurfSense license file.",
+    "unsupported_algorithm": "This license file uses an algorithm this version cannot check.",
+    "bad_signature": "This license file was not issued by SurfSense, or it was altered.",
+    "clock_untrusted": "This computer's clock is behind the time the license was issued.",
+    "file_expired": "This license file has expired; download it again from your account.",
+}

--- a/surfsense_local/backend/modules/license/service.py
+++ b/surfsense_local/backend/modules/license/service.py
@@ -1,0 +1,80 @@
+from datetime import UTC, datetime
+from typing import Literal
+
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from modules.license.models import LicenseState
+from modules.license.verify import MAX_CLOCK_DRIFT, Verified, verify
+
+State = Literal["none", "active", "license_expired", "clock_untrusted"]
+
+
+class LicenseStatus(BaseModel):
+    state: State
+    plan: str | None = None
+    email: str | None = None
+    expiry: datetime | None = None
+    max_users: int | None = None
+
+
+def now() -> datetime:
+    return datetime.now(UTC)
+
+
+def import_certificate(session: Session, certificate: str) -> LicenseStatus:
+    instant = now()
+    verified = verify(certificate, instant)
+    row = _row(session, instant)
+    row.certificate = certificate
+    row.imported_at = _naive(instant)
+    return _status(row, verified, instant)
+
+
+def remove_certificate(session: Session) -> None:
+    row = _row(session, now())
+    row.certificate = None
+    row.imported_at = None
+
+
+def status(session: Session) -> LicenseStatus:
+    instant = now()
+    row = _row(session, instant)
+    if row.certificate is None:
+        return LicenseStatus(state="none")
+    return _status(row, verify(row.certificate, instant), instant)
+
+
+def _status(row: LicenseState, verified: Verified, instant: datetime) -> LicenseStatus:
+    # ponytail: the watermark lives in user-writable SQLite, so this is honesty
+    # for the UI, not enforcement; the plugin scraper API is where money is kept.
+    row.clock_watermark = max(
+        row.clock_watermark, _naive(instant), _naive(verified.issued)
+    )
+    if _naive(instant) < row.clock_watermark - MAX_CLOCK_DRIFT:
+        state: State = "clock_untrusted"
+    elif verified.expiry > instant:
+        state = "active"
+    else:
+        state = "license_expired"
+    return LicenseStatus(
+        state=state,
+        plan=verified.plan,
+        email=verified.email,
+        expiry=verified.expiry,
+        max_users=verified.max_users,
+    )
+
+
+def _row(session: Session, instant: datetime) -> LicenseState:
+    row = session.get(LicenseState, 1)
+    if row is None:
+        row = LicenseState(clock_watermark=_naive(instant))
+        session.add(row)
+        session.flush()
+    return row
+
+
+def _naive(instant: datetime) -> datetime:
+    """SQLite keeps no offset, so rows hold UTC wall time."""
+    return instant.astimezone(UTC).replace(tzinfo=None)

--- a/surfsense_local/backend/modules/license/verify.py
+++ b/surfsense_local/backend/modules/license/verify.py
@@ -1,0 +1,82 @@
+import base64
+import binascii
+import json
+import re
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+# The Keygen account's Ed25519 public key, as the dashboard shows it. Compiled
+# in, never read from config or disk. Tests swap it for the fixture key.
+# TODO(release): this is the contracts/license-sample TEST key; replace with
+# the account key before v1.0.0.
+KEYGEN_PUBLIC_KEY_HEX = (
+    "26c9700024d49bf40cf51cbc4fe73dd9544597170f5a8682d8166ccd0ad2cbe6"
+)
+
+# A laptop clock a few minutes fast is not tampering; keygen-go uses the same.
+MAX_CLOCK_DRIFT = timedelta(minutes=5)
+
+_PEM_MARKERS = re.compile(r"-----(BEGIN|END) LICENSE FILE-----")
+
+
+class LicenseRejectedError(Exception):
+    """A file the app will not keep; `code` is one of the contract's reasons."""
+
+    def __init__(self, code: str) -> None:
+        super().__init__(code)
+        self.code = code
+
+
+@dataclass(frozen=True)
+class Verified:
+    key: str
+    plan: str
+    email: str
+    expiry: datetime
+    max_users: int | None
+    issued: datetime
+
+
+def verify(certificate: str, now: datetime) -> Verified:
+    """Contract 1 consumer steps, in order, stopping at the first failure."""
+    try:
+        body = base64.b64decode(re.sub(r"\s+", "", _PEM_MARKERS.sub("", certificate)))
+        outer = json.loads(body)
+        enc, sig, alg = outer["enc"], outer["sig"], outer["alg"]
+    except (binascii.Error, UnicodeDecodeError, ValueError, KeyError, TypeError) as e:
+        raise LicenseRejectedError("not_a_license_file") from e
+
+    if alg != "base64+ed25519":
+        raise LicenseRejectedError("unsupported_algorithm")
+
+    try:
+        Ed25519PublicKey.from_public_bytes(bytes.fromhex(KEYGEN_PUBLIC_KEY_HEX)).verify(
+            base64.b64decode(sig), f"license/{enc}".encode()
+        )
+    except (InvalidSignature, binascii.Error) as failure:
+        raise LicenseRejectedError("bad_signature") from failure
+
+    payload = json.loads(base64.b64decode(enc))
+    meta, attributes = payload["meta"], payload["data"]["attributes"]
+
+    if _instant(meta["issued"]) > now + MAX_CLOCK_DRIFT:
+        raise LicenseRejectedError("clock_untrusted")
+    if meta["expiry"] is not None and _instant(meta["expiry"]) < now:
+        raise LicenseRejectedError("file_expired")
+
+    return Verified(
+        key=attributes["key"],
+        plan=attributes["metadata"]["plan"],
+        email=attributes["metadata"]["email"],
+        expiry=_instant(attributes["expiry"]),
+        max_users=attributes["maxUsers"],
+        issued=_instant(meta["issued"]),
+    )
+
+
+def _instant(iso: str) -> datetime:
+    parsed = datetime.fromisoformat(iso)
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=UTC)

--- a/surfsense_local/backend/modules/migration/router.py
+++ b/surfsense_local/backend/modules/migration/router.py
@@ -1,0 +1,83 @@
+from zipfile import BadZipFile, ZipFile
+
+from fastapi import (
+    APIRouter,
+    BackgroundTasks,
+    HTTPException,
+    Request,
+    UploadFile,
+    status,
+)
+from pydantic import ValidationError
+
+from api.dependencies import SessionDep
+from modules.documents.storage import stream_upload
+from modules.migration.schemas import ImportAccepted, ImportedWorkspace, Manifest
+from modules.migration.service import find_or_create_workspaces, import_bundle
+from shared.config import get_storage_settings
+
+router = APIRouter(prefix="/migration", tags=["migration"])
+
+# Zip-bomb guard, read from the directory before anything is extracted. Sized
+# far above any real account (OKF adds index.md and log.md per folder); a
+# legitimate bundle that trips it is a bug report, and the fix is these numbers.
+MAX_BUNDLE_ENTRIES = 250_000
+MAX_BUNDLE_UNPACKED_BYTES = 5 * 1024 * 1024 * 1024
+
+
+@router.post(
+    "/import",
+    response_model=ImportAccepted,
+    status_code=status.HTTP_202_ACCEPTED,
+    summary="Import a SurfSense cloud export bundle",
+)
+def start_import(
+    file: UploadFile,
+    session: SessionDep,
+    request: Request,
+    background: BackgroundTasks,
+) -> ImportAccepted:
+    staged = stream_upload(file, get_storage_settings().data_dir / "imports")
+    try:
+        with ZipFile(staged.path) as archive:
+            entries = archive.infolist()
+            if (
+                len(entries) > MAX_BUNDLE_ENTRIES
+                or sum(entry.file_size for entry in entries) > MAX_BUNDLE_UNPACKED_BYTES
+            ):
+                raise HTTPException(
+                    status.HTTP_413_CONTENT_TOO_LARGE, "bundle is too large to import"
+                )
+            manifest = Manifest.model_validate_json(archive.read("manifest.json"))
+    except (BadZipFile, KeyError, ValidationError) as failure:
+        staged.path.unlink(missing_ok=True)
+        raise HTTPException(
+            status.HTTP_422_UNPROCESSABLE_CONTENT,
+            f"not a SurfSense export bundle: {failure}",
+        ) from failure
+    except BaseException:
+        staged.path.unlink(missing_ok=True)
+        raise
+
+    workspaces = find_or_create_workspaces(session, manifest)
+    # Before the background task, which reads these rows through its own session.
+    session.commit()
+
+    background.add_task(
+        import_bundle,
+        request.app.state.session_factory,
+        staged.path,
+        manifest,
+        {
+            workspace.cloud_id: (workspace.id, created)
+            for workspace, created in workspaces
+        },
+    )
+    return ImportAccepted(
+        workspaces=[
+            ImportedWorkspace(
+                id=workspace.id, cloud_id=workspace.cloud_id, name=workspace.name
+            )
+            for workspace, _ in workspaces
+        ]
+    )

--- a/surfsense_local/backend/modules/migration/schemas.py
+++ b/surfsense_local/backend/modules/migration/schemas.py
@@ -1,0 +1,73 @@
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, TypeAdapter, model_validator
+
+
+class ExportedCitation(BaseModel):
+    title: str
+
+
+class ExportedMessage(BaseModel):
+    role: Literal["user", "assistant"]
+    text: str
+    citations: list[ExportedCitation]
+    created_at: datetime
+
+
+class ExportedThread(BaseModel):
+    id: int
+    title: str
+    created_at: datetime
+    messages: list[ExportedMessage]
+
+
+ExportedThreads = TypeAdapter(list[ExportedThread])
+
+
+class ManifestDocument(BaseModel):
+    id: int
+    path: str
+    title: str
+    source: str
+
+
+class ManifestWorkspace(BaseModel):
+    id: int
+    name: str
+    chats: str
+    documents: list[ManifestDocument]
+
+    @model_validator(mode="after")
+    def paths_stay_under_this_workspace(self) -> "ManifestWorkspace":
+        """Trust boundary: the manifest decides which archive members get opened."""
+        prefix = f"workspaces/{self.id}/documents/"
+        if self.chats != f"workspaces/{self.id}/chats.json":
+            raise ValueError(f"chats must be workspaces/{self.id}/chats.json")
+        for document in self.documents:
+            path = document.path
+            if (
+                not path.startswith(prefix)
+                or "\\" in path
+                or ".." in path.split("/")
+                or not path.endswith(".md")
+            ):
+                raise ValueError(f"{path!r} is outside {prefix}")
+        return self
+
+
+class Manifest(BaseModel):
+    """`manifest.json` of a contract-3 export bundle."""
+
+    format: Literal["surfsense-export/1"]
+    workspaces: list[ManifestWorkspace]
+
+
+class ImportedWorkspace(BaseModel):
+    id: int
+    cloud_id: int
+    name: str
+
+
+class ImportAccepted(BaseModel):
+    workspaces: list[ImportedWorkspace]

--- a/surfsense_local/backend/modules/migration/service.py
+++ b/surfsense_local/backend/modules/migration/service.py
@@ -1,0 +1,157 @@
+import logging
+from pathlib import Path, PurePosixPath
+from zipfile import ZipFile
+
+from fastapi import UploadFile
+from sqlalchemy import select
+from sqlalchemy.orm import Session, sessionmaker
+
+from modules.chat.models import ChatMessage, ChatThread, MessageRole
+from modules.documents.models import Document, DocumentType
+from modules.documents.storage import stream_upload, validate_upload
+from modules.documents.tasks import ingest_document
+from modules.migration.schemas import (
+    ExportedThread,
+    ExportedThreads,
+    Manifest,
+    ManifestDocument,
+)
+from modules.workspaces.models import Workspace
+from shared.config import get_storage_settings
+
+logger = logging.getLogger(__name__)
+
+
+def find_or_create_workspaces(
+    session: Session, manifest: Manifest
+) -> list[tuple[Workspace, bool]]:
+    """One local workspace per exported one, keyed by cloud id across re-imports."""
+    found: list[tuple[Workspace, bool]] = []
+    for exported in manifest.workspaces:
+        workspace = session.scalar(
+            select(Workspace).where(Workspace.cloud_id == exported.id)
+        )
+        if workspace is None:
+            workspace = Workspace(name=exported.name, cloud_id=exported.id)
+            session.add(workspace)
+            session.flush()
+            found.append((workspace, True))
+        else:
+            found.append((workspace, False))
+    return found
+
+
+def import_bundle(
+    session_factory: sessionmaker[Session],
+    bundle_path: Path,
+    manifest: Manifest,
+    workspace_ids: dict[int, tuple[int, bool]],
+) -> None:
+    """The slow half, after the 202: documents to disk and queue, threads to rows."""
+    try:
+        with ZipFile(bundle_path) as archive, session_factory() as session:
+            for exported in manifest.workspaces:
+                workspace_id, created = workspace_ids[exported.id]
+                for document in exported.documents:
+                    _import_document(
+                        session, archive, workspace_id, exported.id, document
+                    )
+                # ponytail: threads have no dedup key, so they travel only with
+                # a workspace's first import. A later export's new threads are
+                # lost; the upgrade is a cloud thread id column on chat_threads.
+                if not created:
+                    continue
+                for thread in ExportedThreads.validate_json(
+                    archive.read(exported.chats)
+                ):
+                    _import_thread(session, workspace_id, thread)
+                session.commit()
+    finally:
+        bundle_path.unlink(missing_ok=True)
+
+
+def _import_document(
+    session: Session,
+    archive: ZipFile,
+    workspace_id: int,
+    cloud_workspace_id: int,
+    exported: ManifestDocument,
+) -> None:
+    storage = get_storage_settings()
+    path = PurePosixPath(exported.path)
+    with archive.open(exported.path) as member:
+        streamed = stream_upload(
+            UploadFile(member, filename=path.name),  # type: ignore[arg-type]
+            storage.workspace_dir(workspace_id),
+        )
+    try:
+        try:
+            mime_type = validate_upload(streamed.path, path.suffix)
+        except ValueError as failure:
+            logger.warning("skipped %s: %s", exported.path, failure)
+            streamed.path.unlink()
+            return
+        twin = session.scalar(
+            select(Document).where(
+                Document.workspace_id == workspace_id,
+                Document.dedup_key == streamed.digest,
+            )
+        )
+        if twin is not None:
+            streamed.path.unlink()
+            return
+
+        # workspaces/<id>/documents/<folder path>/<file>: the hierarchy is kept
+        # as data, since the local schema has no folder table.
+        folder_path = "/".join(path.parts[3:-1])
+        document = Document(
+            workspace_id=workspace_id,
+            title=exported.title,
+            document_type=DocumentType.FILE,
+            dedup_key=streamed.digest,
+            document_metadata={
+                "mime_type": mime_type,
+                "size_bytes": streamed.size,
+                "suffix": path.suffix,
+                "folder_path": folder_path,
+                "source": exported.source,
+                "cloud": {
+                    "workspace_id": cloud_workspace_id,
+                    "document_id": exported.id,
+                },
+            },
+        )
+        session.add(document)
+        session.flush()
+    except BaseException:
+        streamed.path.unlink(missing_ok=True)
+        raise
+
+    destination = storage.document_dir(workspace_id, document.id)
+    destination.mkdir(parents=True, exist_ok=True)
+    streamed.path.replace(destination / f"original{path.suffix}")
+    session.commit()
+    ingest_document(document.id)
+
+
+def _import_thread(
+    session: Session, workspace_id: int, exported: ExportedThread
+) -> None:
+    thread = ChatThread(
+        workspace_id=workspace_id, title=exported.title, created_at=exported.created_at
+    )
+    session.add(thread)
+    session.flush()
+    for message in exported.messages:
+        text = message.text
+        if message.citations:
+            text += "\n\nSources: " + ", ".join(c.title for c in message.citations)
+        session.add(
+            ChatMessage(
+                chat_thread_id=thread.id,
+                role=MessageRole(message.role),
+                content={"text": text, "citations": []},
+                created_at=message.created_at,
+                completed_at=message.created_at,
+            )
+        )

--- a/surfsense_local/backend/modules/workspaces/models.py
+++ b/surfsense_local/backend/modules/workspaces/models.py
@@ -16,6 +16,8 @@ class Workspace(Base):
 
     id: Mapped[int] = mapped_column(primary_key=True)
     name: Mapped[str]
+    # The hosted workspace this one was imported from, so a re-import finds it.
+    cloud_id: Mapped[int | None] = mapped_column(unique=True)
     created_at: Mapped[datetime] = mapped_column(server_default=func.now())
     updated_at: Mapped[datetime] = mapped_column(
         server_default=func.now(), onupdate=func.now()

--- a/surfsense_local/backend/pyproject.toml
+++ b/surfsense_local/backend/pyproject.toml
@@ -6,6 +6,7 @@ requires-python = ">=3.12"
 dependencies = [
     "alembic>=1.13,<1.19",
     "chonkie>=1.7.0",
+    "cryptography>=43",
     "docling>=2.125.0",
     "fastapi>=0.115.8",
     "httpx>=0.28.1",

--- a/surfsense_local/backend/shared/db.py
+++ b/surfsense_local/backend/shared/db.py
@@ -32,6 +32,7 @@ def import_models() -> None:
     import modules.chat.models
     import modules.chunks.models
     import modules.documents.models
+    import modules.license.models
     import modules.llm.models
     import modules.workspaces.models
 

--- a/surfsense_local/backend/tests/integration/license/test_license.py
+++ b/surfsense_local/backend/tests/integration/license/test_license.py
@@ -1,0 +1,211 @@
+"""Importing and reading a contract-1 license file, verified offline."""
+
+import base64
+import json
+import re
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from httpx import AsyncClient, Response
+
+from modules.license import service, verify
+
+pytestmark = pytest.mark.integration
+
+SAMPLE = Path(__file__).resolve().parents[5] / (
+    "plans/community-local/contracts/license-sample"
+)
+# The fixtures were issued 2026-09-10 and the shortest one expires two weeks later.
+TODAY = datetime(2026, 9, 11, 12, 0, tzinfo=UTC)
+
+
+@pytest.fixture(autouse=True)
+def test_key_and_clock(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify with the fixture key on a fixed day, whatever the shipped key and date."""
+    monkeypatch.setattr(
+        verify, "KEYGEN_PUBLIC_KEY_HEX", (SAMPLE / "public-key.hex").read_text().strip()
+    )
+    monkeypatch.setattr(service, "now", lambda: TODAY)
+
+
+async def put_license(client: AsyncClient, certificate: str) -> Response:
+    """Send the file's text, as the renderer does after reading the picked file."""
+    return await client.put("/license", json={"certificate": certificate})
+
+
+async def test_a_valid_file_is_active_and_shows_its_plan(client: AsyncClient) -> None:
+    """The buyer drops the file and Settings tells them who it is for and until when."""
+    response = await put_license(client, (SAMPLE / "individual.lic").read_text())
+
+    assert response.status_code == 200
+    status = (await client.get("/license/status")).json()
+    assert status == {
+        "state": "active",
+        "plan": "individual",
+        "email": "ada@example.com",
+        "expiry": "2027-09-10T00:00:00Z",
+        "max_users": None,
+    }
+
+
+@pytest.mark.parametrize(
+    ("file", "plan", "max_users"),
+    [("team.lic", "team", 12), ("trial.lic", "trial", None)],
+)
+async def test_each_plan_reads_as_itself(
+    client: AsyncClient, file: str, plan: str, max_users: int | None
+) -> None:
+    """Team seats are shown, never enforced; a trial is just a short plan."""
+    response = await put_license(client, (SAMPLE / file).read_text())
+
+    status = response.json()
+    assert (status["state"], status["plan"], status["max_users"]) == (
+        "active",
+        plan,
+        max_users,
+    )
+
+
+async def test_an_expired_license_is_kept_and_marked(client: AsyncClient) -> None:
+    """Expiry is a state, not a rejection: the user sees whose license ran out."""
+    response = await put_license(client, (SAMPLE / "expired.lic").read_text())
+
+    assert response.status_code == 200
+    status = (await client.get("/license/status")).json()
+    assert (status["state"], status["email"]) == ("license_expired", "old@example.com")
+
+
+def certificate_with(certificate: str, **outer_changes: str) -> str:
+    """Re-wrap the fixture with fields of the outer JSON replaced."""
+    body = re.sub(
+        r"\s+", "", re.sub(r"-----(BEGIN|END) LICENSE FILE-----", "", certificate)
+    )
+    outer = json.loads(base64.b64decode(body))
+    outer.update(outer_changes)
+    wrapped = base64.b64encode(json.dumps(outer).encode()).decode()
+    return f"-----BEGIN LICENSE FILE-----\n{wrapped}\n-----END LICENSE FILE-----\n"
+
+
+async def test_a_changed_payload_is_refused_and_nothing_is_kept(
+    client: AsyncClient,
+) -> None:
+    """One byte of enc changed: the signature no longer covers it."""
+    genuine = (SAMPLE / "individual.lic").read_text()
+    body = re.sub(
+        r"\s+", "", re.sub(r"-----(BEGIN|END) LICENSE FILE-----", "", genuine)
+    )
+    enc = json.loads(base64.b64decode(body))["enc"]
+    flipped = enc[:-2] + ("A" if enc[-2] != "A" else "B") + enc[-1]
+
+    response = await put_license(client, certificate_with(genuine, enc=flipped))
+
+    assert response.status_code == 422
+    assert response.json()["detail"]["code"] == "bad_signature"
+    assert (await client.get("/license/status")).json()["state"] == "none"
+
+
+# generate.mjs's fixed seed, so a test can sign a payload the fixtures lack.
+TEST_SEED = b"surfsense-contract-1-test-seed!!"
+
+
+def signed(payload: dict, alg: str = "base64+ed25519") -> str:
+    """A certificate over `payload`, signed the way Keygen signs."""
+    enc = base64.b64encode(json.dumps(payload).encode()).decode()
+    sig = Ed25519PrivateKey.from_private_bytes(TEST_SEED).sign(
+        f"license/{enc}".encode()
+    )
+    outer = {"enc": enc, "sig": base64.b64encode(sig).decode(), "alg": alg}
+    wrapped = base64.b64encode(json.dumps(outer).encode()).decode()
+    return f"-----BEGIN LICENSE FILE-----\n{wrapped}\n-----END LICENSE FILE-----\n"
+
+
+def payload(issued: str, file_expiry: str | None = None) -> dict:
+    """The individual fixture's payload with the file's own timestamps changed."""
+    return {
+        "meta": {"issued": issued, "expiry": file_expiry, "ttl": None},
+        "data": {
+            "attributes": {
+                "key": "TEST-INDV-2026-0001",
+                "expiry": "2027-09-10T00:00:00.000Z",
+                "maxUsers": None,
+                "metadata": {"plan": "individual", "email": "ada@example.com"},
+            }
+        },
+    }
+
+
+@pytest.mark.parametrize(
+    ("certificate", "code"),
+    [
+        ("hello", "not_a_license_file"),
+        (
+            "-----BEGIN LICENSE FILE-----\nbm90IGpzb24=\n-----END LICENSE FILE-----",
+            "not_a_license_file",
+        ),
+        (
+            signed(payload("2026-09-10T00:00:00Z"), alg="aes-256-gcm+ed25519"),
+            "unsupported_algorithm",
+        ),
+        (signed(payload("2026-09-11T12:10:00Z")), "clock_untrusted"),
+        (
+            signed(payload("2026-09-10T00:00:00Z", file_expiry="2026-09-11T00:00:00Z")),
+            "file_expired",
+        ),
+    ],
+)
+async def test_files_that_cannot_be_trusted_are_refused(
+    client: AsyncClient, certificate: str, code: str
+) -> None:
+    """Each contract reason comes back as a code the UI can explain."""
+    response = await put_license(client, certificate)
+
+    assert (response.status_code, response.json()["detail"]["code"]) == (422, code)
+
+
+async def test_a_few_minutes_of_clock_drift_is_not_tampering(
+    client: AsyncClient,
+) -> None:
+    """A laptop clock four minutes fast must not lock a paying user out."""
+    response = await put_license(client, signed(payload("2026-09-11T12:04:00Z")))
+
+    assert response.status_code == 200
+    assert response.json()["state"] == "active"
+
+
+async def test_a_clock_set_back_is_untrusted_until_it_catches_up(
+    client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Winding the clock back cannot revive an expiring license; time only moves on."""
+    clock = {"now": TODAY}
+    monkeypatch.setattr(service, "now", lambda: clock["now"])
+    await put_license(client, (SAMPLE / "individual.lic").read_text())
+
+    clock["now"] = TODAY - timedelta(days=1)
+    rolled_back = (await client.get("/license/status")).json()["state"]
+    clock["now"] = TODAY + timedelta(minutes=1)
+    caught_up = (await client.get("/license/status")).json()["state"]
+
+    assert (rolled_back, caught_up) == ("clock_untrusted", "active")
+
+
+async def test_a_fresh_install_has_no_license(client: AsyncClient) -> None:
+    """Nothing imported, nothing to show; the free app does not nag."""
+    assert (await client.get("/license/status")).json() == {
+        "state": "none",
+        "plan": None,
+        "email": None,
+        "expiry": None,
+        "max_users": None,
+    }
+
+
+async def test_removing_the_license_returns_to_none(client: AsyncClient) -> None:
+    """Handing a laptop on: the file leaves the machine with the user."""
+    await put_license(client, (SAMPLE / "individual.lic").read_text())
+
+    response = await client.delete("/license")
+
+    assert response.status_code == 204
+    assert (await client.get("/license/status")).json()["state"] == "none"

--- a/surfsense_local/backend/tests/integration/migration/test_import.py
+++ b/surfsense_local/backend/tests/integration/migration/test_import.py
@@ -1,0 +1,143 @@
+"""Importing a contract-3 export bundle: what the user gets back locally."""
+
+import json
+from pathlib import Path
+from zipfile import ZipFile
+
+import pytest
+from httpx import AsyncClient, Response
+
+from shared.queue import huey
+
+pytestmark = pytest.mark.integration
+
+SAMPLE = Path(__file__).resolve().parents[5] / (
+    "plans/community-local/contracts/export-sample"
+)
+
+
+def bundle(tmp_path: Path, manifest: dict | None = None) -> Path:
+    """Zip the committed fixture, optionally with a manifest of the test's own."""
+    path = tmp_path / "export.zip"
+    with ZipFile(path, "w") as archive:
+        if manifest is None:
+            archive.write(SAMPLE / "manifest.json", "manifest.json")
+        else:
+            archive.writestr("manifest.json", json.dumps(manifest))
+        for file in sorted(SAMPLE.rglob("*")):
+            if file.is_file() and file.name != "manifest.json":
+                archive.write(file, file.relative_to(SAMPLE).as_posix())
+    return path
+
+
+async def import_bundle(client: AsyncClient, path: Path) -> Response:
+    """Post the file the way the renderer's picker will."""
+    return await client.post(
+        "/migration/import",
+        files={"file": ("export.zip", path.read_bytes(), "application/zip")},
+    )
+
+
+async def test_each_exported_workspace_becomes_a_local_one(
+    client: AsyncClient, tmp_path: Path
+) -> None:
+    """A user with two cloud workspaces finds the same two after importing."""
+    response = await import_bundle(client, bundle(tmp_path))
+
+    assert response.status_code == 202
+    listed = await client.get("/workspaces")
+    assert [workspace["name"] for workspace in listed.json()] == ["Research", "Empty"]
+
+
+async def test_listed_documents_are_created_pending_and_queued(
+    client: AsyncClient, tmp_path: Path
+) -> None:
+    """Only what the manifest lists: OKF index.md and log.md never become documents."""
+    response = await import_bundle(client, bundle(tmp_path))
+    research = response.json()["workspaces"][0]["id"]
+
+    documents = (await client.get(f"/workspaces/{research}/documents")).json()
+    assert sorted(document["title"] for document in documents) == [
+        "Notes",
+        "Notes",
+        "Reading list",
+        "Résumé de réunion",
+        "index",
+    ]
+    assert {document["status"] for document in documents} == {"pending"}
+    assert sorted(job.args[0] for job in huey.pending()) == sorted(
+        document["id"] for document in documents
+    )
+
+
+async def test_threads_arrive_with_their_turns_and_sources_as_text(
+    client: AsyncClient, tmp_path: Path
+) -> None:
+    """Cloud citations cannot be clicked locally, so they are named in the answer."""
+    response = await import_bundle(client, bundle(tmp_path))
+    research = response.json()["workspaces"][0]["id"]
+
+    threads = (await client.get(f"/workspaces/{research}/chat/threads")).json()
+    assert sorted(thread["title"] for thread in threads) == [
+        "Quick hello",
+        "Why scale the dot product?",
+    ]
+    scaling = next(t for t in threads if t["title"].startswith("Why"))
+    messages = (await client.get(f"/chat/threads/{scaling['id']}/messages")).json()
+    assert [message["role"] for message in messages] == ["user", "assistant"]
+    assert messages[1]["content"]["text"].endswith("\n\nSources: Notes")
+    assert messages[1]["content"]["citations"] == []
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "workspaces/12/documents/../../../etc/passwd",
+        "/workspaces/12/documents/Notes.md",
+        "workspaces/13/documents/Notes.md",
+        "workspaces\\12\\documents\\Notes.md",
+    ],
+)
+async def test_a_manifest_escaping_the_tree_is_rejected_before_anything_is_written(
+    client: AsyncClient, tmp_path: Path, data_dir: Path, path: str
+) -> None:
+    """The manifest is untrusted input; one bad path fails the whole bundle."""
+    manifest = json.loads((SAMPLE / "manifest.json").read_text())
+    manifest["workspaces"][0]["documents"][0]["path"] = path
+
+    response = await import_bundle(client, bundle(tmp_path, manifest))
+
+    assert response.status_code == 422
+    assert (await client.get("/workspaces")).json() == []
+    assert not (data_dir / "data").exists()
+
+
+async def test_other_formats_and_non_bundles_are_refused(
+    client: AsyncClient, tmp_path: Path
+) -> None:
+    """Only surfsense-export/1; a future format needs a new reader, not a guess."""
+    manifest = json.loads((SAMPLE / "manifest.json").read_text())
+    manifest["format"] = "surfsense-export/2"
+    other_format = await import_bundle(client, bundle(tmp_path, manifest))
+
+    not_a_zip = tmp_path / "notes.md"
+    not_a_zip.write_text("# just a file")
+    not_a_bundle = await import_bundle(client, not_a_zip)
+
+    assert other_format.status_code == 422
+    assert not_a_bundle.status_code == 422
+    assert (await client.get("/workspaces")).json() == []
+
+
+async def test_importing_the_same_bundle_twice_adds_nothing(
+    client: AsyncClient, tmp_path: Path
+) -> None:
+    """Quitting mid-import and running it again must not double the account."""
+    first = await import_bundle(client, bundle(tmp_path))
+    second = await import_bundle(client, bundle(tmp_path))
+    research = first.json()["workspaces"][0]["id"]
+
+    assert second.json() == first.json()
+    assert len((await client.get("/workspaces")).json()) == 2
+    assert len((await client.get(f"/workspaces/{research}/documents")).json()) == 5
+    assert len((await client.get(f"/workspaces/{research}/chat/threads")).json()) == 2

--- a/surfsense_local/backend/tests/packaging/test_license_key.py
+++ b/surfsense_local/backend/tests/packaging/test_license_key.py
@@ -1,0 +1,19 @@
+"""The shipped verifier must not accept files signed with the public test seed."""
+
+from pathlib import Path
+
+import pytest
+
+from modules.license.verify import KEYGEN_PUBLIC_KEY_HEX
+
+pytestmark = pytest.mark.packaging
+
+FIXTURE_KEY = (
+    Path(__file__).resolve().parents[4]
+    / "plans/community-local/contracts/license-sample/public-key.hex"
+)
+
+
+def test_the_shipped_key_is_not_the_fixture_key() -> None:
+    """Anyone with the repo could sign a license otherwise; blocks a release build."""
+    assert FIXTURE_KEY.read_text().strip() != KEYGEN_PUBLIC_KEY_HEX

--- a/surfsense_local/backend/uv.lock
+++ b/surfsense_local/backend/uv.lock
@@ -7,12 +7,12 @@ resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'linux'",
     "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version < '3.13' and sys_platform == 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
-    "python_full_version < '3.13' and sys_platform == 'emscripten'",
     "python_full_version == '3.13.*' and sys_platform == 'linux'",
-    "python_full_version < '3.13' and sys_platform == 'linux'",
     "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version < '3.13' and sys_platform == 'win32'",
+    "python_full_version < '3.13' and sys_platform == 'emscripten'",
+    "python_full_version < '3.13' and sys_platform == 'linux'",
     "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 
@@ -124,6 +124,91 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/ef/008a1939e372c06329a3fce4279c02f328488f3526744906eeec3da7ad5f/cffi-2.1.1.tar.gz", hash = "sha256:dd31f52ea1086513bb9df30f8fcee9b8918323ae067a3d5b78bc826a000712be", size = 530807, upload-time = "2026-08-03T21:21:18.939Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/69/43965eccfdead3b9220015fd1320e117be8c6ed01a62ffab76eeb752f5d5/cffi-2.1.1-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:c8c69575568085ba0b1b10c0249d779a214aea6f6522e949a0fc9fb0fcb449d0", size = 184821, upload-time = "2026-08-03T21:19:44.887Z" },
+    { url = "https://files.pythonhosted.org/packages/54/7d/16e5a096677b5e313ca80cd5e5170efa3ea44624a82bb111925522da64b1/cffi-2.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f81b3b8f3d4e343550fa4baa0e479bba9f2d29ce9c2e9b51d1ce1718d7442fcf", size = 184719, upload-time = "2026-08-03T21:19:46.129Z" },
+    { url = "https://files.pythonhosted.org/packages/56/e6/8941622732edec876dd17d0453dce07317ae96db34f2ec1436c9d3785986/cffi-2.1.1-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:811bd1e21d32de12efca32393a0ab3f5133b54fce9bd44b8bd77ab07da14bf6a", size = 214799, upload-time = "2026-08-03T21:19:47.218Z" },
+    { url = "https://files.pythonhosted.org/packages/44/de/f98430906df1545ffde0d543dd124a7a439bc2cd32b36b9c53f805df7333/cffi-2.1.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:68e62fe11f30d5ca8289242866f0a5291402d8529ca2178ab8afc5c9694ae890", size = 222389, upload-time = "2026-08-03T21:19:48.331Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/5b/717f1526b9957b34456313c31645c5b82b8fb5c3fe9e4752999be7128bfc/cffi-2.1.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:4a7c934f7360e8cd64fe9efadcbd10c7c6364f531e432b9a4bf5ccbc9e0e8b50", size = 210249, upload-time = "2026-08-03T21:19:49.543Z" },
+    { url = "https://files.pythonhosted.org/packages/64/b3/f8aa4f3e34986c7e4ec45072d1b1b9dd295b6b18007b45518d79726dd725/cffi-2.1.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:3143d81e29e1e20a9ce10901ec369012947876596f75a222235965f2b7ae832e", size = 208775, upload-time = "2026-08-03T21:19:50.918Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/db/dceb9dd5b231e1da801793f8acc9f3c52a7e1afe40bb1aae37e02b0faad5/cffi-2.1.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c1453022f490d2459a11819d83ad1d586e9ff65a12ac3e705ffebd46d3685dcf", size = 221822, upload-time = "2026-08-03T21:19:52.054Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/d2/6cd24ae3be000a634109c247d1475d62e5616d0dc78c82770942ec384248/cffi-2.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:208f941bb9d18e768138677f0a6d2ce01f590df56043dda1df1535ac57c88517", size = 225232, upload-time = "2026-08-03T21:19:53.109Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/52/3fa190537004dd7f0ab860a6dc7c0175b8667f68d1e618a46f5498d30250/cffi-2.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:210019b6c7cf07f081b4c54635c8cf744377001350e29cc0f81c4377b4797735", size = 223597, upload-time = "2026-08-03T21:19:54.515Z" },
+    { url = "https://files.pythonhosted.org/packages/80/fb/0bb75b7039588c074b37ae99f40d9bfddf990ecb2fbc346ebccd2e56b9be/cffi-2.1.1-cp312-cp312-win32.whl", hash = "sha256:046bfc24911b37851ee1b51aab8bffe713d89c68c6a057b09484ce9fd5f69b4e", size = 175292, upload-time = "2026-08-03T21:19:55.566Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/79/615cc094e2fb508cade7de88d3b4f6c4ec2bab695c97bce9153dc65aadf5/cffi-2.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:f53e442b08449d42821fa4a4fba000095af9f62742a500f978a9f557ec44339a", size = 185919, upload-time = "2026-08-03T21:19:56.89Z" },
+    { url = "https://files.pythonhosted.org/packages/70/c6/d0ea84713fe46b243a436a18fcd47d639732747e21635c8a27191b06dc30/cffi-2.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:7bde5e4cc5c10140859842b9d383af292b22639a4dffb725314baf45968cef80", size = 180093, upload-time = "2026-08-03T21:19:58.155Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/f4/035513d4117049066b4779dc3b7c0c0fdad175fa13731c9f4003f1cd1478/cffi-2.1.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:b5bdfd1c873d4e093aabc0ca84c4ca6dbc4f752afb5c86f146d9742580c9da2e", size = 194248, upload-time = "2026-08-03T21:19:59.399Z" },
+    { url = "https://files.pythonhosted.org/packages/76/af/2aeb4dbb5fc41a04161ae9ff1518de7cec08e164f44a8ce6a4cf7fd2cd1d/cffi-2.1.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:31348097ff5bbe827ccc41795d4dd099d9f0625e7def00ee653c137a490c2a6c", size = 196908, upload-time = "2026-08-03T21:20:00.746Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/46/2e5fdde8555706dd98139a910ca11be02809f3f605ce956f655d0214e100/cffi-2.1.1-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:9d2055050ea716bd38b7f7f1579c275386646b4894c155a3e2f3cd62ed41b7c6", size = 184805, upload-time = "2026-08-03T21:20:02.02Z" },
+    { url = "https://files.pythonhosted.org/packages/55/41/4c7042f317b9217502988f0873af87e16ad606dc20f84e546e3e6ce9764c/cffi-2.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:19ee6127ee34de7d83ce3d371ebc5ed91addbdcc39f9ab15ce4eb35a4e534971", size = 184764, upload-time = "2026-08-03T21:20:03.141Z" },
+    { url = "https://files.pythonhosted.org/packages/43/1f/1c3d90d91811c8f86ced9ed637956c54bfe5b79ca98fe976d7f8c8979f6b/cffi-2.1.1-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:6a8dddef476fab96d066d578fc88526767b836ab5ab21754e1d5bf3879c31c7c", size = 214722, upload-time = "2026-08-03T21:20:04.377Z" },
+    { url = "https://files.pythonhosted.org/packages/37/6f/3b5ce4c3b2192d250f04908f2bfd91ef34552ec8f7716a5d4abdb8d67bb2/cffi-2.1.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f16c709686a78c727bbbf059f92b0bf41c6fc60deec706d2dc19f529175a6125", size = 222369, upload-time = "2026-08-03T21:20:05.544Z" },
+    { url = "https://files.pythonhosted.org/packages/02/10/4b3c75dde3d9663c9e02ba05c2668b954f671d4bbe346413ca8c696b295a/cffi-2.1.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:fcd22650c908d7b7da162bbfaab594a1227a15d1643a98c68b122ac642fa2264", size = 210175, upload-time = "2026-08-03T21:20:06.75Z" },
+    { url = "https://files.pythonhosted.org/packages/df/62/14f74b9543e605d17701dc797b815958b8bb70b7624ce1b832ddad48ed6c/cffi-2.1.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:aa9511c62d14da7aacc9b4bf51f3f697a621e83b2d6919008243c3aad168eea3", size = 208670, upload-time = "2026-08-03T21:20:08.04Z" },
+    { url = "https://files.pythonhosted.org/packages/95/95/86342356ff5953b3fb06f7ef7c5bee212d45e770abc7218d451b9148313c/cffi-2.1.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a931079504ecc49efed7744c476a5c343a92fabf66dec2db95edb1b2fdc770e2", size = 221824, upload-time = "2026-08-03T21:20:09.274Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/ff/7b3429ff53aafe931ed8a5fc69f481bbef7ba6de87ddcbb63d08f483f613/cffi-2.1.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a2d7755bef5a12ed488f4ef1f1b69ee9191d7396083b755a5d2295f6edb4768b", size = 225148, upload-time = "2026-08-03T21:20:10.7Z" },
+    { url = "https://files.pythonhosted.org/packages/34/34/a95870b9221e09cf4f2ce3178b1a210abdfe63a1bd357da940418d7b8d15/cffi-2.1.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e0bcb7e0f677f543555d2adff3bf19c05f66cdb4796e5ff602442ab2fe3c4ef7", size = 223564, upload-time = "2026-08-03T21:20:12.165Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ea/839b50531021a647fb5e929f72cf97bc1ff702b5472166164b5b6e76b851/cffi-2.1.1-cp313-cp313-win32.whl", hash = "sha256:334644fbac4eff73d985a17a91226df55d0f394160c4cfb880e084c8f7161cac", size = 175263, upload-time = "2026-08-03T21:20:13.559Z" },
+    { url = "https://files.pythonhosted.org/packages/60/a6/8b149b2c3f2e11aaa1618ef64500b45f50f22c57a977a4dff1aff1f91042/cffi-2.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:1aa5645c30469b09530c4ebca77ebf8f17618293c58f8549cb1a543a50236e7d", size = 185688, upload-time = "2026-08-03T21:20:14.69Z" },
+    { url = "https://files.pythonhosted.org/packages/01/9a/11f687cb39d6a3504060d5242f04f48c735afb4d3d533958a20594890cb2/cffi-2.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:63bbfd5ded17c4840ac07cd8f1c21ba9d9708141f840b324f422f41b207e3973", size = 180078, upload-time = "2026-08-03T21:20:15.917Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/7b/d6bbf82b8b96e7391438898c42f5bd96dd02030fd5b64937d248220003e2/cffi-2.1.1-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:7dbb61fe3a7699468030f71bbe5f8a0e326a151daa91beb11a6fc1f980c55e1c", size = 194064, upload-time = "2026-08-03T21:20:17.148Z" },
+    { url = "https://files.pythonhosted.org/packages/94/e6/bcc91b283be94735e268487a054004f0aa19947b6348fa367db53230abc8/cffi-2.1.1-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:f24fb43132a4c6b4cb4eb029492919b2db645be6808d738f244fd146c03c32cb", size = 196720, upload-time = "2026-08-03T21:20:18.268Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/99/c4b0c17cacdc9c3b8f280026286a9826d6a208c0f047591a3c3ce99b91fd/cffi-2.1.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d28630f5854ab07ab1fd4aba756de52326c82e6be15d414b12793f1975048b54", size = 184964, upload-time = "2026-08-03T21:20:19.708Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/a9/9db617d05d7367c1ad0ab00b3aa6e6f9281edd689b4ee9ea0e5a84e89c97/cffi-2.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:661c298b4821edebead0c91edd2b00374d67ad7c5a1f7a91d4442633b79d6a72", size = 184962, upload-time = "2026-08-03T21:20:20.833Z" },
+    { url = "https://files.pythonhosted.org/packages/67/b8/b42132ca113dc567d37684437b46ca1dafc885902b02a110a02d5b511857/cffi-2.1.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:58acb8ab8e295e6c5ea12f888cbb13cf21511ef2a3303a23f4325c29d17fe5c1", size = 222328, upload-time = "2026-08-03T21:20:22.118Z" },
+    { url = "https://files.pythonhosted.org/packages/80/10/c5c0cbf0a657aecf59ef511409734230bf556f05a0d6c9eed7aa5c0a0166/cffi-2.1.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:456a61fa52d579ebf9df2e9552ead5129855dbaff6c1e5a9b1bc408809bdc062", size = 209985, upload-time = "2026-08-03T21:20:23.401Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/6c/bfa0b87b03b9238148beca990292843c9396ba069b54496596594173de7b/cffi-2.1.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:a4f00aa42f75d6e4595e8866e748cc1705adc0cddfeb2ca86d0d03993d63ba03", size = 208530, upload-time = "2026-08-03T21:20:24.628Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/02/4e7d553a7ac4b4238b38b3c1b80d486e9d4436f8d2acbf87a0997fe3f402/cffi-2.1.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b0431303acaea1089ad4b3e9ce4e6518193def1118d4073ca848635ee4ea2e96", size = 221525, upload-time = "2026-08-03T21:20:25.758Z" },
+    { url = "https://files.pythonhosted.org/packages/82/1d/a4aaf9babd75acb4d5f223bff71533bee748dd770a382619a798960ee9ba/cffi-2.1.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:64faea20f4e2613363a1a9b9c7dd73058f3ecd00133a511e72ad7c511658f527", size = 225053, upload-time = "2026-08-03T21:20:26.985Z" },
+    { url = "https://files.pythonhosted.org/packages/81/10/5dc0e7bdd18e22107054288283380fc97a06ae3f1656a106908d666a3c88/cffi-2.1.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5c58fe613dc5e5336357eff555824a314d8e43282600435c8d1cb6a7a2fedd13", size = 223213, upload-time = "2026-08-03T21:20:28.277Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/e9/d0061c364cde06ee43168a0d076ac1da512cbc380d44767b844ba34fe2b6/cffi-2.1.1-cp314-cp314-win32.whl", hash = "sha256:1a18a57b58cfb21fc28d72e876acf10eaed67a1ed96226f92af4df681d571c4c", size = 177682, upload-time = "2026-08-03T21:20:44.288Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/06/1c3e01e3ba14c39f6d10bfbac52753b7e22259e38088e5cfe1d704918690/cffi-2.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:3222ba5d678f80a030e6afbcc33dc1ae5cb45facabb61cee2c7016b8432fde48", size = 187949, upload-time = "2026-08-03T21:20:45.623Z" },
+    { url = "https://files.pythonhosted.org/packages/87/5b/da4e39efe18eeb89cf580ea9cfc66b6a7c3eadb808fc0cc1d3a295cb5a5d/cffi-2.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:ab36d55f9ed2d067327667c2fea18dda018eb628dd6347aa01dda6cf1f5d3836", size = 182947, upload-time = "2026-08-03T21:20:46.955Z" },
+    { url = "https://files.pythonhosted.org/packages/23/59/40338bf421c5accea1d45158170c87006ef1cd371b05c077e76476949728/cffi-2.1.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:7750c6449dff7864bb9bb27ddfb0267756189201a3afc911d82b3caacd70dfc3", size = 188504, upload-time = "2026-08-03T21:20:29.495Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/47/5ecf1023850036e674c77ec4de86182d309ae344e39e7cba984b7df5d647/cffi-2.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:0beceaabe56af686895136a2de78db54ecd8e4046b236b8fd6d6cb61389e9bf2", size = 188259, upload-time = "2026-08-03T21:20:31.291Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/9c/92934c3bea9f785b23eba304538c0b4d37a2a96d2431eb3a1bc87a11aa19/cffi-2.1.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:49cbc70e6542d4ccccb936558d1064a8012541e78f821f955cff24e357776c94", size = 223864, upload-time = "2026-08-03T21:20:32.571Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/45/ba4c93527bc38616a8bd36488acb69a2212d60486794f0c1f318949bbb76/cffi-2.1.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:e2d65b31f36619cda3999b78b2aa9632e76b78448e7a56fc4240824200e7c4fc", size = 211538, upload-time = "2026-08-03T21:20:33.808Z" },
+    { url = "https://files.pythonhosted.org/packages/80/e9/b6ef565e452acb932fb0cb5443f44a78efbd1233e566f02b5a83855e9115/cffi-2.1.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:28907ab9bfb6aa13184cfc17c6b8e1023c5ab6fd7076d8c20a35e59fe04f8f29", size = 210688, upload-time = "2026-08-03T21:20:34.974Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/95/eff5f0cee78d2eabc7eebffec40d3fc1876b5f3c95582e018bb4b99601f2/cffi-2.1.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:51b31d1c98274844cfd7838ce00bfc27c7423a4dc00fc0772fc3331c2cc90676", size = 223803, upload-time = "2026-08-03T21:20:36.564Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/01/579d39fb8bef00a335a23d83757b44feb24cd6345a2c451b64cb67b9c362/cffi-2.1.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5e7cecbaadb83884793e05828cee59b210b24583b9c7425d0ba6a754fe22eb4e", size = 226763, upload-time = "2026-08-03T21:20:37.816Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/b0/0b44f47c60b01b57b6e2bbd92343f13a85a1d93bc46ccf6e47e244acd99c/cffi-2.1.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:25792eac27877609e7bb06d42ff88278a6624fff2ba9bbb523c09616b117e80f", size = 225688, upload-time = "2026-08-03T21:20:38.959Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d2/3b7176cb570a1d3e27faf67b72f591af508036e0d8b2be2ef9af9e8c84bb/cffi-2.1.1-cp314-cp314t-win32.whl", hash = "sha256:8ef53b2de9bcb9197d31854256575d59dbac0cba72ac627bb291ef5eceb74be4", size = 182868, upload-time = "2026-08-03T21:20:40.388Z" },
+    { url = "https://files.pythonhosted.org/packages/56/78/31f00c1bcd97c9bbf55f1bfdf5bc809a5de8887473e90bb9960dca825e80/cffi-2.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:616f097f2fe415bc92a247f02e11f634e1f9e9a83d327e3c915c15089c87869e", size = 194104, upload-time = "2026-08-03T21:20:41.725Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/1b/58496f2ed0a35de575250c02a43ab3cc2c04d494a88fed31c1cabc0fd176/cffi-2.1.1-cp314-cp314t-win_arm64.whl", hash = "sha256:ad2c86c495b899d862ea0f4b42891b8713a3bd45dd4105c7fd51c2a72f39f3a5", size = 186402, upload-time = "2026-08-03T21:20:43.042Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/8f/9ebe220eab48a093d1a5a5e339ab0dc7316eef3bb04d63c42f0251b61f50/cffi-2.1.1-cp315-cp315-ios_13_0_arm64_iphoneos.whl", hash = "sha256:dddad92b554513a31f272570678ba307fb9f618f05e3d4a5eacafff9eae03e1d", size = 194043, upload-time = "2026-08-03T21:20:48.179Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/69/844bad3ece306c4782c2ecb93597035b6690d48704b803914c199da1e8b3/cffi-2.1.1-cp315-cp315-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:da0e573f9f97159390c89d9f1a9e41908b66d408cc5b58d08cf3847d844c531b", size = 196737, upload-time = "2026-08-03T21:20:49.457Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/8a/af668013284634733f02d683458a0728739c7d6ddb5e14cb0c20832266fe/cffi-2.1.1-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:fb92203a88b3d3053034db775110081c49d28be6551923805e039924093761e4", size = 184933, upload-time = "2026-08-03T21:20:50.639Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/75/2f5207ff6d1a613133b23a5203cc0c2a628313b5eb3974d7956ae3c57950/cffi-2.1.1-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2ae64be792b8966f2c69538199728b290e34726562896df1e5dc8ffd8d8188e8", size = 185002, upload-time = "2026-08-03T21:20:52.173Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/31/9e1313b0a6e30e91b3b3d3fff51ae99c857c07738e3afcce1f7334e1b7ab/cffi-2.1.1-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:507a24c282e0f42f8ed737cf048572cbf580468da5555764a8331735e9c736b6", size = 222271, upload-time = "2026-08-03T21:20:53.462Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e3/f6234a833e6e08c7007003074723c406559eecf9b48dfc97471e5a8eb7a0/cffi-2.1.1-cp315-cp315-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:246fa40ce8645a614ff682e0b70f37134e460eaf93a775e0cbe3cca585a67a80", size = 209919, upload-time = "2026-08-03T21:20:54.783Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/fc/5f74e293fced6edb51af3a46c4ccf6c23c9943774ecb375ddbd522c76add/cffi-2.1.1-cp315-cp315-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:471cee653ae88de62096552e6d24ccb4a5adb8c8c9f10b5054d0122c15bf2779", size = 208529, upload-time = "2026-08-03T21:20:56.066Z" },
+    { url = "https://files.pythonhosted.org/packages/44/16/29e6d01b388bef055ecd6ca8244b3f4d336bd09e92d5d892187b9601084e/cffi-2.1.1-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:aeae0e330c9f6acd681f647d46cefd30c29f93e3392882e792e82080c9691399", size = 221630, upload-time = "2026-08-03T21:20:57.336Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/18/fa7f1f6857d5eb88a4ca99ffcbfb7c387a287ccc154c64a73e86314745d7/cffi-2.1.1-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:42a494cee34437f05546455144f2b5d9ac09b1face62bcfce597d2e521066688", size = 225134, upload-time = "2026-08-03T21:20:58.675Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/9f/e8e3dfa04a1b4c241f8c91faacad872b4d4efd051d49764ad4e2fd4b9fea/cffi-2.1.1-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:cc572dace3f60ef98d7b12ff411d20f5362feb31a0439eab0085bbfd349982d7", size = 223197, upload-time = "2026-08-03T21:20:59.968Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/7e/8debeb04f1ab9fe2a6963964cd6f1aaf7192627b83926586a6a4e089c9fa/cffi-2.1.1-cp315-cp315-win32.whl", hash = "sha256:4f42141fc14250de6dde5ee7ea4432be017252d91f19c5ad043c084cea629cac", size = 177683, upload-time = "2026-08-03T21:21:14.901Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/31/5158704cc474ab65c1647932e88be78dc0873f47130e253be38bcaf13d01/cffi-2.1.1-cp315-cp315-win_amd64.whl", hash = "sha256:e6e8cff14d6fb0be70a09c0bdc58096f501952d04624ebf867e0e56da2df8960", size = 187897, upload-time = "2026-08-03T21:21:16.108Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/4b/b3a2da8570c704ffc0f9762cdc3ec0f02c8573798e0b5cf7f11c82bbb70f/cffi-2.1.1-cp315-cp315-win_arm64.whl", hash = "sha256:27350daa11d4f10c540e6e89dada4c54feb7256ad03e9a4dc075ebad7ba360d1", size = 182935, upload-time = "2026-08-03T21:21:17.271Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/ef/5443574510a1207e6f6bc38ba6e1f1de36cb48fef07b2728bb896a21f430/cffi-2.1.1-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:c26608d2222fb1e94487e4a387d85f13eb55d5ed725cb25a0c589ac4ee60e7bc", size = 188464, upload-time = "2026-08-03T21:21:01.163Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/ae/a56fa8c4686ad50e148fcbc8d3ae0d03915ff5c30d795058988c24118cef/cffi-2.1.1-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:4be96343e422f2dfcd12ab5c9f5aebe03f82f737c6bffeca6830b3875cb44aab", size = 188262, upload-time = "2026-08-03T21:21:02.382Z" },
+    { url = "https://files.pythonhosted.org/packages/53/b2/6187f46f2912276a3ae284076109cc5c8680482f11f766ccf26db4a86427/cffi-2.1.1-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:937c0052c05a31ca1daf18de3158eed4dbfcb9cc107adbea227728d647be701e", size = 223779, upload-time = "2026-08-03T21:21:03.553Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f6/c3ad28bd19f77047a03084424fbd4cbe997303267c14423737324be0385d/cffi-2.1.1-cp315-cp315t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:df423d40ee8654634421812bc3b196da3f9bd7d32929da813f8394c4348a5358", size = 211520, upload-time = "2026-08-03T21:21:04.863Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/cd/ccac9013a5bd9fd764de118674ab9c805b5ca10c19270d90ee273f8b2240/cffi-2.1.1-cp315-cp315t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:a730a083190634c65cca36ba5f489531576ebd79bcd5c8e172130f6453127231", size = 210673, upload-time = "2026-08-03T21:21:06.223Z" },
+    { url = "https://files.pythonhosted.org/packages/52/86/2976131c639aead931c5bee5aba67e4b09fbeb8018b6f282f70803f923a7/cffi-2.1.1-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:363e05fa78e15116c3c32c210ee36884fd6b9afa6d440e47112c3bd511d64cb6", size = 223835, upload-time = "2026-08-03T21:21:07.539Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/0c/33a7aeab2f9c76918c52e084beb39c570db3588133412929e8ec06fab90b/cffi-2.1.1-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:770de9db11e84213beec501cfcaa013b019820ca881e03344dea5844f7876d94", size = 226705, upload-time = "2026-08-03T21:21:08.774Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/26/2cde30fdde421130bfc18f70395731a6e6b2053c6a1978a5258ff04e72fa/cffi-2.1.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:7da0c5eff80f0197f3b3d1232ec5a682a9325f4ae9016a78f5f5ca35f9ced1f5", size = 225539, upload-time = "2026-08-03T21:21:09.911Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/cd/a361394c94b2129d604bb846f624a8e88255a3ee33129c434a00d715e64f/cffi-2.1.1-cp315-cp315t-win32.whl", hash = "sha256:06c72bb76605a4b0cd0aad6930b69d4baf7dd5d806cfc409b824191099700e66", size = 182707, upload-time = "2026-08-03T21:21:11.226Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/b5/ba2b299993c26577d529b6ae29841f9e15b9fcf004d65f423f4fcf94ade9/cffi-2.1.1-cp315-cp315t-win_amd64.whl", hash = "sha256:d9c275eaacd24aa73f94ffd6de08fc3f932424d8b6c376f4bed7cde376fe7bc3", size = 193772, upload-time = "2026-08-03T21:21:12.39Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/29/35e016098c814cd93de9cd320c66b5bfba14dc6ecedd3cb518fa7c408c69/cffi-2.1.1-cp315-cp315t-win_arm64.whl", hash = "sha256:d18e5ac0f2f03f4f518d3e23db0f0cad7faa1da8620e9c09461d443bbf6e6692", size = 186360, upload-time = "2026-08-03T21:21:13.636Z" },
 ]
 
 [[package]]
@@ -335,6 +420,56 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8c/55/ba79756cb90c8d69d599d57785398ac87bba7b19c80e87f4e8a562197c93/colorlog-6.12.0.tar.gz", hash = "sha256:2a7924c1dadf18b22a0eb8b06d1c7b01d5341707ec1641eb6fcc4fde0c3e8e5f", size = 18151, upload-time = "2026-07-23T13:40:40.71Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/19/0b6647bf5e331521e55d2b63bfbdc210bd9cd605189273f03614a05f702d/colorlog-6.12.0-py3-none-any.whl", hash = "sha256:30d392604e9110045a2c2aeefc27d7a017abbab63f3a8aee594eac0801df784e", size = 12239, upload-time = "2026-07-23T13:40:39.562Z" },
+]
+
+[[package]]
+name = "cryptography"
+version = "50.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/ad/5d6702db60b1e40b41ef513b6967ff5848f307d50f8449baf1634f5908f1/cryptography-50.0.1.tar.gz", hash = "sha256:5dd9bda1c12b4162f6ff568eeb5e0ff956c28d14406e875cfe8a63a2d414ff20", size = 880381, upload-time = "2026-08-25T19:45:45.499Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/19/797e2aaac9df6a66f1550f49979dc1b1e39ecd2077501c30efa81e8d5d67/cryptography-50.0.1-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:b8f852c65863251b9e3a1b8c150ce21e59b522dbb6a7d4bc80e680d38388e986", size = 4010153, upload-time = "2026-08-25T19:44:03.155Z" },
+    { url = "https://files.pythonhosted.org/packages/90/34/9ce9a62ed9dc82ca9fd6a34445b6904af56e5f38b3eae2ed32e49c36053d/cryptography-50.0.1-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:53e279950892dc102c6b4e52af03ae5ea92fac572a1ddab78ca73a997f62b69f", size = 4723133, upload-time = "2026-08-25T19:44:05.461Z" },
+    { url = "https://files.pythonhosted.org/packages/57/26/e6d4fc8512a51a5f9ee7bfdbfb853bce1197087df40c9ad993ad370b846f/cryptography-50.0.1-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ff838d62ec1bfce4f9ba7fa16f4a7b554cd8d0c299e6be37502161a660c84eef", size = 4712478, upload-time = "2026-08-25T19:44:07.375Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/de/d3cdc2815697aae84126cbd6a030ca7b6b452e28a88b501b836bd3aa7a86/cryptography-50.0.1-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:e74591e283fe6eb956416c929eb58262a719fe0311fd9054c62c3350ed8760d8", size = 4730726, upload-time = "2026-08-25T19:44:09.294Z" },
+    { url = "https://files.pythonhosted.org/packages/55/32/38c0d344b98c06d34b5df8946565a9c0d6dbf32c8e0730a7f05f0a3c6cab/cryptography-50.0.1-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:5fe002589592ed749ce77fe0695fcbd3500dd61d7d6db5858a7544c612fa8e45", size = 5353524, upload-time = "2026-08-25T19:44:11.96Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/1b/82f0f0d8858d4432be1af790477edf62aef90324041aa07c57e57bef1af7/cryptography-50.0.1-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:51593d180cf6d179bde5c5d065bed81386b1f381656ae7d042b7ffc87a9895ad", size = 4746720, upload-time = "2026-08-25T19:44:14.051Z" },
+    { url = "https://files.pythonhosted.org/packages/29/ba/042ca458b8c64348c768284b5d23e69b92ed53d057ab779fee628564676d/cryptography-50.0.1-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:359e62deae718bce96170e223fdcb6357e4fbd3bb7a3a75f4430763532560e49", size = 4361866, upload-time = "2026-08-25T19:44:16.167Z" },
+    { url = "https://files.pythonhosted.org/packages/39/3b/e96c1ef71edef71057c7e3c3d982ce8fda554e0c52d0cc19c18845cde3eb/cryptography-50.0.1-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:e2ca8fd1b6b4b82a1c4cb02841d0837e3c12336c2e24b520ab8ab3b969733d8f", size = 4730028, upload-time = "2026-08-25T19:44:18.085Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/38/45abd72ef63f2e7d0754a6cacf97bd8b69512ace7f6130d24c39ece65da2/cryptography-50.0.1-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:76de83fbd91ac49c0feaaa983d0748fd7a53176afac5fb3bf7478d244f0eb527", size = 5308405, upload-time = "2026-08-25T19:44:20.197Z" },
+    { url = "https://files.pythonhosted.org/packages/85/66/6ccca4722987ddedaa7fc9c3f4708af7431f5535666c174350830888c6b7/cryptography-50.0.1-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:51afcfceb15597cf2635068e4ac9a56b2abde622edde17f37d85fd7b5306497a", size = 4746230, upload-time = "2026-08-25T19:44:22.376Z" },
+    { url = "https://files.pythonhosted.org/packages/13/0e/b1f92e013228111413f2e6743948b80bc24dfd3c1b87ba98ceea16f5df89/cryptography-50.0.1-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:be224a65493ec5b74a158ff22a5522ce4a5ca1e543c647a3a4730d4a09e5f959", size = 4862596, upload-time = "2026-08-25T19:44:24.472Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/22/c3654cccc856e9d682817b04ac3ee79731cb09ca6f95996a95c904de2883/cryptography-50.0.1-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9ebcdd5519be9b652a46f507817a74591774fc3d6923ac364e4dfa64e36b291b", size = 5014082, upload-time = "2026-08-25T19:44:26.709Z" },
+    { url = "https://files.pythonhosted.org/packages/42/8b/cb12b1b60c91b074ca6bf0fdd59aa8f10d8bc5f73af8faece86ef0421b37/cryptography-50.0.1-cp311-abi3-win_amd64.whl", hash = "sha256:aed8db4f6d71c51efb89530e12d9464e7bf2923d46c3205dc794a2a93f8c0648", size = 3842826, upload-time = "2026-08-25T19:44:28.784Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/f0/424cb557d99aa86ac55da5e2add02e2882e44047b6264f93ade1b975a993/cryptography-50.0.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:30a125032e5642a21ff816e021152bd4e7e94f03eff3f4b7fca41cd22bc3110f", size = 3973525, upload-time = "2026-08-25T19:44:30.7Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/72/3a2711d967977ab5fc80b782837c7e8d1ac7445e764c20c381a265c57ef3/cryptography-50.0.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a0b1a59e3a089064a0ec309e9428c8e3ae4e161419d20ac33600767e83fc658a", size = 4708817, upload-time = "2026-08-25T19:44:32.773Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/f2/bb1f56e10815b789df0b409a69fa4992ff3d3fef9c72747f4a6b26fed38e/cryptography-50.0.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8921d58f426793c5f1b47f0b59575780de9a095214958d0eb37d909593db8367", size = 4697300, upload-time = "2026-08-25T19:44:35.144Z" },
+    { url = "https://files.pythonhosted.org/packages/08/bd/ed5396be499ffcf8807a585bfe38b71a1fbdd1c342b4f9b6d0ef5162a946/cryptography-50.0.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:a8f40ea47330e71b594a7e246898f93177c259490c63183dbaf9e571d71ed9a5", size = 4716039, upload-time = "2026-08-25T19:44:37.192Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/6e/1cf405c5c8e8df7545378048e954792f00b7f2367af8863ce8b8f3e10607/cryptography-50.0.1-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:a255449073358275b64b67d3f595f268bbef70e72b6edb65e0c70c735bf739c9", size = 5332388, upload-time = "2026-08-25T19:44:39.16Z" },
+    { url = "https://files.pythonhosted.org/packages/47/92/b4317e8c32c4f47b062f5398bd79106b220a124546f42be83bf32b761e2a/cryptography-50.0.1-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:8df2de9102026855887e4587084f6eabd80ed0f345b8ad8a7ac27ab9bf4723e0", size = 4730293, upload-time = "2026-08-25T19:44:41.298Z" },
+    { url = "https://files.pythonhosted.org/packages/39/0d/a1e7633e2c744d0f2983320a27e924ef2264c79c56e1a58d5fb0a1cfd413/cryptography-50.0.1-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:ac02b07824d4d1001bd4367599f839c19cb171924c796e52c23508ac14c2c0cc", size = 4346031, upload-time = "2026-08-25T19:44:43.245Z" },
+    { url = "https://files.pythonhosted.org/packages/88/dd/b215616f9bab3fc18510c78a4e5c9f362d77838503c363dc747c7d4f5c6f/cryptography-50.0.1-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:cbf74a81765ee67413503ca6e26dcc4f6f5a519822436cc0a1b97aab6c1b8a17", size = 4715344, upload-time = "2026-08-25T19:44:45.291Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/1b/ec3ebd31741d0e963612c4fe43caa39341b9b1e031e469820e42e4c83918/cryptography-50.0.1-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:16c5ecd954b3330ebfb6605eca4fd952da8bef376551d5cc264534e3770a9ee6", size = 5287201, upload-time = "2026-08-25T19:44:47.297Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/01/0127d11a762b31a9ee0221894f540318761783f3fdc4bc5d057698caebd5/cryptography-50.0.1-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:79bf008d1f9af6071c797ad133e39915dfee7614f18f18f4db9072eb715064a3", size = 4730023, upload-time = "2026-08-25T19:44:49.435Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/b9/e7425ebfb599241a0c1d7000f1b466c3062da66c19d9525031315dff7213/cryptography-50.0.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:330fbb252391c596f1ae42c5754449dc924e6ad012dca8efe0d703f9f2d12ec6", size = 4847362, upload-time = "2026-08-25T19:44:51.94Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/fd/60d0ddf4defa12e482c9d5e0f554384d6e8ab25341fd15f060028fd92e6a/cryptography-50.0.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:42be3bb70596b3abe4ac097b75be223e8b3ab614a0e5de068e3dcc54d71d6149", size = 4999247, upload-time = "2026-08-25T19:44:53.876Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/56/bc4f2b209e766c93372cfcd59b781a0b2b59700f62a969580415b699c2b2/cryptography-50.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:f74455bb086a85d5e81246412602aaa97ed095e504cd40dd261ef50be42205bf", size = 3825806, upload-time = "2026-08-25T19:44:56.209Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a9/ee16a903f13755e914d1eecc482fe64d1f10761c3960e5d8fa6837377aff/cryptography-50.0.1-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ca83d00d9e69cd5eb63f2e69c3a5a59e0cecae5ae14c6ae0b35830fe3b37bad0", size = 4035307, upload-time = "2026-08-25T19:44:58.305Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/a5/9ec7e81e8526c0d7a387d73386b2daed3f39e10d81a85930bd1b6bfba65c/cryptography-50.0.1-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:05ba322c4da95b262a212c345af888ef2c37c88c0509756ea00a0e6d68850f23", size = 4751900, upload-time = "2026-08-25T19:45:00.401Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/3c/0e77bd5ffcf078e9dd27d3074aad6c030d9b10d0bf69329d573c927a188c/cryptography-50.0.1-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e22dfed744bd4002e909464cb23d2f0b05c6f3113a79ef2e9864a53db737c733", size = 4738357, upload-time = "2026-08-25T19:45:02.786Z" },
+    { url = "https://files.pythonhosted.org/packages/27/3a/3c5f80daa4dcd47323c7af8a2fcb90de27a33564d4fcac69846c0972691a/cryptography-50.0.1-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:4c4188f7c0cf655be5c06342b817ed0f9595b69ffa2b12026e5353eed29dea88", size = 4758474, upload-time = "2026-08-25T19:45:04.889Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/2b/214cf0cf93db9628c3c20c896b229f327f6fb1b20e4b3743d8ad3f00af8b/cryptography-50.0.1-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2ebbfb0f1fed745e91796e3e1080a1440423fdae8ece1b995a1d80883a409054", size = 5375862, upload-time = "2026-08-25T19:45:07.163Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/51/3f9701867a46b6c1740c9b52fc4d3bed6cbdcfedcc9b6e64305c07f39cff/cryptography-50.0.1-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:407fe2b6db00939c05c0e945e9914238f2f0a430974839429dafc82b1ee6bee5", size = 4772942, upload-time = "2026-08-25T19:45:09.396Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/5c/13ea642e08e2544d0f5396122055f4820cfacb3203562197b5967125ea97/cryptography-50.0.1-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:2b34d76a652ea2b6faf777c35df230c5637842cd904e04f16230c3f9f03e4361", size = 4383347, upload-time = "2026-08-25T19:45:11.659Z" },
+    { url = "https://files.pythonhosted.org/packages/84/d5/7d1fe1cb93f91c428093ff234e128c89ba8ea61a6f26aab406081f9b996e/cryptography-50.0.1-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:01f41478cf33fc605a6a089cd56d28b45c6c0b45a1928b61797f2621a04bac71", size = 4758050, upload-time = "2026-08-25T19:45:13.745Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/04/557fc5ead96a829e0bc812a3b9dc4a52a2f27e4f7f5950da7ff27653a805/cryptography-50.0.1-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:fc3ed7ebd2a8c96f5b166de0ab9b624996bef3b07bbeb19364dfb78222c22c80", size = 5332955, upload-time = "2026-08-25T19:45:16.193Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/eb/5d7124083e8d8cda8f5b348f544b71ad6f707ad63193758ef4d8e569da02/cryptography-50.0.1-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9dde0a357190eb3b1da1bb9ab750e9c85cba82ca5977aa0836cbb94e92611239", size = 4772694, upload-time = "2026-08-25T19:45:18.315Z" },
+    { url = "https://files.pythonhosted.org/packages/63/8e/f1f955e0921dd2b6d22eae7e8d24a4c4b638d10735ffbf6a71f99eb0fcb8/cryptography-50.0.1-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd3718b960d0b5dd213cdf03f3bcb7000e69dda0de8b956061947ff6bcff5558", size = 4888413, upload-time = "2026-08-25T19:45:20.4Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/ab/89e2b798d2c3925f82e2bb72d5979f3d2f6da2dd22ef4a8cd8b70d920039/cryptography-50.0.1-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:2a93d05e34d5f67fba6f891fe85d929999baa7195e853923ea6d7576c9e68c5e", size = 5044355, upload-time = "2026-08-25T19:45:22.353Z" },
+    { url = "https://files.pythonhosted.org/packages/99/89/87ef49ffe383ef4e147d27b7bf2088fb0b54ea409dd87b5a89442e5828a5/cryptography-50.0.1-cp39-abi3-win_amd64.whl", hash = "sha256:55d16b1ef3ee0958d893a977b19777887e546c9954ea81b200c3301a864013f2", size = 3875429, upload-time = "2026-08-25T19:45:24.418Z" },
 ]
 
 [[package]]
@@ -1009,7 +1144,7 @@ name = "macholib"
 version = "1.16.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "altgraph", marker = "sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'" },
+    { name = "altgraph" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/10/2f/97589876ea967487978071c9042518d28b958d87b17dceb7cdc1d881f963/macholib-1.16.4.tar.gz", hash = "sha256:f408c93ab2e995cd2c46e34fe328b130404be143469e41bc366c807448979362", size = 59427, upload-time = "2025-11-22T08:28:38.373Z" }
 wheels = [
@@ -1585,6 +1720,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/49/df/c4a72d3f62f0ba03ec440c4fff56cd2d674a4334d23c5064cbf41c9583f6/pyclipper-1.4.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:a9f11ad133257c52c40d50de7a0ca3370a0cdd8e3d11eec0604ad3c34ba549e9", size = 141706, upload-time = "2025-12-01T13:15:30.134Z" },
     { url = "https://files.pythonhosted.org/packages/c5/0b/cf55df03e2175e1e2da9db585241401e0bc98f76bee3791bed39d0313449/pyclipper-1.4.0-cp314-cp314t-win32.whl", hash = "sha256:bbc827b77442c99deaeee26e0e7f172355ddb097a5e126aea206d447d3b26286", size = 105308, upload-time = "2025-12-01T13:15:31.225Z" },
     { url = "https://files.pythonhosted.org/packages/8f/dc/53df8b6931d47080b4fe4ee8450d42e660ee1c5c1556c7ab73359182b769/pyclipper-1.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:29dae3e0296dff8502eeb7639fcfee794b0eec8590ba3563aee28db269da6b04", size = 117608, upload-time = "2025-12-01T13:15:32.69Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
 ]
 
 [[package]]
@@ -2539,6 +2683,7 @@ source = { editable = "." }
 dependencies = [
     { name = "alembic" },
     { name = "chonkie" },
+    { name = "cryptography" },
     { name = "docling" },
     { name = "fastapi" },
     { name = "httpx" },
@@ -2572,6 +2717,7 @@ dev = [
 requires-dist = [
     { name = "alembic", specifier = ">=1.13,<1.19" },
     { name = "chonkie", specifier = ">=1.7.0" },
+    { name = "cryptography", specifier = ">=43" },
     { name = "docling", specifier = ">=2.125.0" },
     { name = "fastapi", specifier = ">=0.115.8" },
     { name = "httpx", specifier = ">=0.28.1" },
@@ -2691,20 +2837,20 @@ resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'emscripten'",
     "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version < '3.13' and sys_platform == 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
-    "python_full_version < '3.13' and sys_platform == 'emscripten'",
     "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version < '3.13' and sys_platform == 'win32'",
+    "python_full_version < '3.13' and sys_platform == 'emscripten'",
     "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "filelock", marker = "sys_platform != 'linux'" },
-    { name = "fsspec", marker = "sys_platform != 'linux'" },
-    { name = "jinja2", marker = "sys_platform != 'linux'" },
-    { name = "networkx", marker = "sys_platform != 'linux'" },
-    { name = "setuptools", marker = "sys_platform != 'linux'" },
-    { name = "sympy", marker = "sys_platform != 'linux'" },
-    { name = "typing-extensions", marker = "sys_platform != 'linux'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/17/76/bb4770f56cf6d8971671dbcbb7493e5a6a15ad2825f4e359b02c27c38297/torch-2.14.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:c1f844f1c750e87df4b68bc3afbc0e2b0c7ef19d7b8f666e48bdcf6a0c4f0056", size = 127303200, upload-time = "2026-09-02T13:43:20.311Z" },
@@ -2727,13 +2873,13 @@ resolution-markers = [
     "python_full_version < '3.13' and sys_platform == 'linux'",
 ]
 dependencies = [
-    { name = "filelock", marker = "sys_platform == 'linux'" },
-    { name = "fsspec", marker = "sys_platform == 'linux'" },
-    { name = "jinja2", marker = "sys_platform == 'linux'" },
-    { name = "networkx", marker = "sys_platform == 'linux'" },
-    { name = "setuptools", marker = "sys_platform == 'linux'" },
-    { name = "sympy", marker = "sys_platform == 'linux'" },
-    { name = "typing-extensions", marker = "sys_platform == 'linux'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.14.0%2Bcpu-cp312-cp312-linux_s390x.whl", hash = "sha256:07aefe1a437b6f1b41b0cba15e16583e2f43549ec9d062fcea8e7981a78e014a", upload-time = "2026-09-02T18:31:32Z" },
@@ -2763,16 +2909,16 @@ resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'emscripten'",
     "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version < '3.13' and sys_platform == 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
-    "python_full_version < '3.13' and sys_platform == 'emscripten'",
     "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
+    "python_full_version < '3.13' and sys_platform == 'win32'",
+    "python_full_version < '3.13' and sys_platform == 'emscripten'",
     "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", marker = "sys_platform != 'linux'" },
-    { name = "pillow", marker = "sys_platform != 'linux'" },
-    { name = "torch", version = "2.14.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
+    { name = "numpy" },
+    { name = "pillow" },
+    { name = "torch", version = "2.14.0", source = { registry = "https://pypi.org/simple" } },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/d2/9daad500db2ab880eca0f0a569afd73e1afdd49f22c94560c85546dd87c2/torchvision-0.29.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:994687b818cac0e6d34cb407a41458e2c3262cb7db927465841c9522ba7ebb92", size = 1813740, upload-time = "2026-09-02T13:47:03.933Z" },
@@ -2795,9 +2941,9 @@ resolution-markers = [
     "python_full_version < '3.13' and sys_platform == 'linux'",
 ]
 dependencies = [
-    { name = "numpy", marker = "sys_platform == 'linux'" },
-    { name = "pillow", marker = "sys_platform == 'linux'" },
-    { name = "torch", version = "2.14.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'linux'" },
+    { name = "numpy" },
+    { name = "pillow" },
+    { name = "torch", version = "2.14.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" } },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.29.0%2Bcpu-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:8ac096fe796dfacbd174be86f7ab3595a39eabc341d2ee2e48557032ec1d57c4", upload-time = "2026-09-02T00:27:43Z" },

--- a/surfsense_local/frontend/src/features/dashboard/dashboard-page.tsx
+++ b/surfsense_local/frontend/src/features/dashboard/dashboard-page.tsx
@@ -12,6 +12,8 @@ import { CitationPanel } from "@/features/chat/citation-panel"
 import { ThreadList } from "@/features/chat/thread-list"
 import { ThreadPanel } from "@/features/chat/thread-panel"
 import { useChatRuntime } from "@/features/chat/use-chat-runtime"
+import type { ImportAccepted } from "@/features/migration/api"
+import { ImportBundleButton } from "@/features/migration/import-bundle"
 import {
   getConnectionModels,
   getProviders,
@@ -130,9 +132,11 @@ function WorkspaceDashboard({
 function WorkspacesEmpty({
   isMutating,
   onCreate,
+  onImported,
 }: {
   isMutating: boolean
   onCreate: (name: string) => Promise<boolean>
+  onImported: (accepted: ImportAccepted) => Promise<void>
 }) {
   return (
     <main className="flex h-full items-center justify-center bg-background p-8">
@@ -152,6 +156,9 @@ function WorkspacesEmpty({
           <PlusIcon />
           Create workspace
         </Button>
+        <div className="mt-3">
+          <ImportBundleButton onImported={onImported} />
+        </div>
       </div>
     </main>
   )
@@ -204,11 +211,17 @@ export function DashboardPage({
     return () => controller.abort()
   }, [selection])
 
+  const onImported = async (accepted: ImportAccepted) => {
+    const first = accepted.workspaces[0]
+    await workspaces.reload(first?.id ?? workspaces.activeWorkspace?.id ?? -1)
+  }
+
   if (!workspaces.activeWorkspace) {
     return (
       <WorkspacesEmpty
         isMutating={workspaces.isMutating}
         onCreate={workspaces.create}
+        onImported={onImported}
       />
     )
   }
@@ -240,6 +253,7 @@ export function DashboardPage({
         onSectionChange={setSettingsSection}
         onModelUnavailable={onModelUnavailable}
         onModelSelected={onModelSelected}
+        onImported={onImported}
       />
       {workspaces.error ? (
         <Alert

--- a/surfsense_local/frontend/src/features/license/api.ts
+++ b/surfsense_local/frontend/src/features/license/api.ts
@@ -1,0 +1,28 @@
+import { requestJson, requestVoid } from "@/lib/api"
+
+export type LicenseState =
+  "none" | "active" | "license_expired" | "clock_untrusted"
+
+export type LicenseStatus = {
+  state: LicenseState
+  plan: string | null
+  email: string | null
+  expiry: string | null
+  max_users: number | null
+}
+
+export function readLicense(signal?: AbortSignal): Promise<LicenseStatus> {
+  return requestJson<LicenseStatus>("/license/status", { signal })
+}
+
+export function importLicense(certificate: string): Promise<LicenseStatus> {
+  return requestJson<LicenseStatus>("/license", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ certificate }),
+  })
+}
+
+export function removeLicense(): Promise<void> {
+  return requestVoid("/license", { method: "DELETE" })
+}

--- a/surfsense_local/frontend/src/features/license/license-settings.test.tsx
+++ b/surfsense_local/frontend/src/features/license/license-settings.test.tsx
@@ -1,0 +1,196 @@
+import { useState } from "react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { cleanup, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+
+import { ThemeProvider } from "@/components/theme-provider"
+import {
+  SettingsDialog,
+  type SettingsSectionId,
+} from "@/features/settings/settings-dialog"
+import { render } from "@/test-utils"
+
+import type { LicenseStatus } from "./api"
+
+const NONE: LicenseStatus = {
+  state: "none",
+  plan: null,
+  email: null,
+  expiry: null,
+  max_users: null,
+}
+
+const ACTIVE: LicenseStatus = {
+  state: "active",
+  plan: "individual",
+  email: "ada@example.com",
+  expiry: "2027-09-10T00:00:00Z",
+  max_users: null,
+}
+
+const CERTIFICATE =
+  "-----BEGIN LICENSE FILE-----\neyJlbmMiOiJ4In0=\n-----END LICENSE FILE-----\n"
+
+function stubApi(initial: LicenseStatus, onPut: () => Response) {
+  let current = initial
+  const calls: { method: string; body: unknown }[] = []
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const path = String(input)
+      const method = init?.method ?? "GET"
+      if (path === "/license/status") return Response.json(current)
+      if (path === "/license" && method === "PUT") {
+        calls.push({ method, body: JSON.parse(String(init?.body)) })
+        const response = onPut()
+        if (response.ok)
+          current = (await response.clone().json()) as LicenseStatus
+        return response
+      }
+      if (path === "/license" && method === "DELETE") {
+        calls.push({ method, body: null })
+        current = NONE
+        return new Response(null, { status: 204 })
+      }
+      return Response.json({ detail: "not found" }, { status: 404 })
+    })
+  )
+  return calls
+}
+
+function Harness() {
+  const [section, setSection] = useState<SettingsSectionId>("license")
+  return (
+    <ThemeProvider>
+      <SettingsDialog
+        open
+        section={section}
+        onOpenChange={() => undefined}
+        onSectionChange={setSection}
+        onModelSelected={() => undefined}
+      />
+    </ThemeProvider>
+  )
+}
+
+beforeEach(() => {
+  vi.useFakeTimers({
+    shouldAdvanceTime: true,
+    now: new Date("2026-09-11T12:00:00Z"),
+  })
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    value: vi.fn().mockReturnValue({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }),
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+})
+
+describe("License settings", () => {
+  it("imports a picked .lic file and shows whose plan it is", async () => {
+    const calls = stubApi(NONE, () => Response.json(ACTIVE))
+    const user = userEvent.setup()
+    render(<Harness />)
+
+    expect(await screen.findByText("No license on this device")).toBeTruthy()
+    await user.upload(
+      screen.getByLabelText("Choose license file"),
+      new File([CERTIFICATE], "individual.lic", { type: "text/plain" })
+    )
+
+    expect(await screen.findByText("Individual plan")).toBeTruthy()
+    expect(screen.getByText("ada@example.com")).toBeTruthy()
+    expect(
+      screen.getByText(/Renews 10 Sept 2027|Renews Sep 10, 2027/)
+    ).toBeTruthy()
+    expect(calls).toEqual([
+      { method: "PUT", body: { certificate: CERTIFICATE } },
+    ])
+  })
+
+  it("accepts a pasted certificate", async () => {
+    const calls = stubApi(NONE, () => Response.json(ACTIVE))
+    const user = userEvent.setup()
+    render(<Harness />)
+
+    await user.type(
+      await screen.findByLabelText("Paste license file"),
+      "-----BEGIN LICENSE FILE-----"
+    )
+    await user.click(screen.getByRole("button", { name: "Add license" }))
+
+    expect(await screen.findByText("Individual plan")).toBeTruthy()
+    expect(calls[0]?.body).toEqual({
+      certificate: "-----BEGIN LICENSE FILE-----",
+    })
+  })
+
+  it("explains a refused file and keeps the device unlicensed", async () => {
+    stubApi(NONE, () =>
+      Response.json(
+        {
+          detail: {
+            code: "bad_signature",
+            message:
+              "This license file was not issued by SurfSense, or it was altered.",
+          },
+        },
+        { status: 422 }
+      )
+    )
+    const user = userEvent.setup()
+    render(<Harness />)
+
+    await user.upload(
+      await screen.findByLabelText("Choose license file"),
+      new File(["nope"], "fake.lic", { type: "text/plain" })
+    )
+
+    expect((await screen.findByRole("alert")).textContent).toContain(
+      "not issued by SurfSense"
+    )
+    expect(screen.getByText("No license on this device")).toBeTruthy()
+  })
+
+  it("warns when the license runs out within two weeks", async () => {
+    stubApi({ ...ACTIVE, plan: "trial", expiry: "2026-09-20T00:00:00Z" }, () =>
+      Response.json(ACTIVE)
+    )
+    render(<Harness />)
+
+    expect(await screen.findByText("Trial plan")).toBeTruthy()
+    expect(screen.getByRole("status").textContent).toContain("9 days")
+  })
+
+  it("tells an expired license from an untrusted clock", async () => {
+    stubApi({ ...ACTIVE, state: "license_expired" }, () =>
+      Response.json(ACTIVE)
+    )
+    render(<Harness />)
+
+    expect((await screen.findByRole("status")).textContent).toContain("expired")
+  })
+
+  it("removes the license from this device", async () => {
+    const calls = stubApi(ACTIVE, () => Response.json(ACTIVE))
+    const user = userEvent.setup()
+    render(<Harness />)
+
+    await user.click(
+      await screen.findByRole("button", { name: "Remove license" })
+    )
+
+    await waitFor(() =>
+      expect(screen.getByText("No license on this device")).toBeTruthy()
+    )
+    expect(calls).toEqual([{ method: "DELETE", body: null }])
+  })
+})

--- a/surfsense_local/frontend/src/features/license/license-settings.tsx
+++ b/surfsense_local/frontend/src/features/license/license-settings.tsx
@@ -1,0 +1,189 @@
+import { useEffect, useRef, useState, type ChangeEvent } from "react"
+
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { Button } from "@/components/ui/button"
+import { CircleAlertIcon } from "@/components/ui/icons"
+import { Input } from "@/components/ui/input"
+import { SettingsSection } from "@/features/settings/settings-section"
+
+import {
+  importLicense,
+  readLicense,
+  removeLicense,
+  type LicenseStatus,
+} from "./api"
+
+const DAY = 24 * 60 * 60 * 1000
+const EXPIRY_NOTICE_DAYS = 14
+
+function messageFrom(error: unknown) {
+  return error instanceof Error ? error.message : "An unexpected error occurred"
+}
+
+function planLabel(plan: string) {
+  return `${plan.charAt(0).toUpperCase()}${plan.slice(1)} plan`
+}
+
+function dateLabel(iso: string) {
+  return new Date(iso).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  })
+}
+
+function notice(status: LicenseStatus): string | null {
+  if (status.state === "clock_untrusted") {
+    return "This computer's clock is behind the last time SurfSense ran. Set it right to use your license."
+  }
+  if (status.state === "license_expired") {
+    return "This license has expired. Renew it from your account and add the new file."
+  }
+  if (status.expiry) {
+    const days = Math.ceil((Date.parse(status.expiry) - Date.now()) / DAY)
+    if (days <= EXPIRY_NOTICE_DAYS) {
+      return `This license runs out in ${days} ${days === 1 ? "day" : "days"}.`
+    }
+  }
+  return null
+}
+
+export function LicenseSettings() {
+  const [status, setStatus] = useState<LicenseStatus | null>(null)
+  const [pasted, setPasted] = useState("")
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const fileInput = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    const controller = new AbortController()
+    readLicense(controller.signal)
+      .then(setStatus)
+      .catch((cause: unknown) => {
+        if (!controller.signal.aborted) setError(messageFrom(cause))
+      })
+    return () => controller.abort()
+  }, [])
+
+  const run = async (action: () => Promise<LicenseStatus>) => {
+    setBusy(true)
+    setError(null)
+    try {
+      setStatus(await action())
+      setPasted("")
+    } catch (cause) {
+      setError(messageFrom(cause))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const importPicked = async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0]
+    event.target.value = ""
+    if (!file) return
+    await run(async () => importLicense(await file.text()))
+  }
+
+  const remove = () =>
+    run(async () => {
+      await removeLicense()
+      return readLicense()
+    })
+
+  const shown = status && status.state !== "none" ? notice(status) : null
+
+  return (
+    <SettingsSection
+      title="License"
+      description="Plugins that call paid services need a license file from your SurfSense account. The file is checked on this device; nothing is sent anywhere."
+    >
+      {status?.state === "none" ? (
+        <p className="text-sm text-muted-foreground">
+          No license on this device
+        </p>
+      ) : null}
+
+      {status && status.state !== "none" ? (
+        <div className="flex items-start justify-between gap-8">
+          <div className="flex flex-col gap-1">
+            <h3 className="text-sm font-medium">
+              {planLabel(status.plan ?? "")}
+            </h3>
+            <p className="text-sm text-muted-foreground">{status.email}</p>
+            {status.expiry ? (
+              <p className="text-sm text-muted-foreground">
+                {status.state === "active" ? "Renews" : "Ended"}{" "}
+                {dateLabel(status.expiry)}
+                {status.max_users ? ` · ${status.max_users} seats` : ""}
+              </p>
+            ) : null}
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            disabled={busy}
+            onClick={remove}
+          >
+            Remove license
+          </Button>
+        </div>
+      ) : null}
+
+      {shown ? (
+        <Alert role="status" className="mt-6">
+          <CircleAlertIcon />
+          <AlertTitle>License</AlertTitle>
+          <AlertDescription>{shown}</AlertDescription>
+        </Alert>
+      ) : null}
+
+      <div className="mt-8 flex flex-col gap-3">
+        <h3 className="text-sm font-medium">
+          {status?.state === "none" ? "Add a license" : "Replace the license"}
+        </h3>
+        <Input
+          ref={fileInput}
+          type="file"
+          accept=".lic"
+          className="sr-only"
+          aria-label="Choose license file"
+          disabled={busy}
+          onChange={importPicked}
+        />
+        <div className="flex gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            disabled={busy}
+            onClick={() => fileInput.current?.click()}
+          >
+            Choose license file
+          </Button>
+        </div>
+        <textarea
+          aria-label="Paste license file"
+          className="min-h-24 rounded-md border bg-transparent px-3 py-2 font-mono text-xs"
+          placeholder="-----BEGIN LICENSE FILE-----"
+          value={pasted}
+          disabled={busy}
+          onChange={(event) => setPasted(event.target.value)}
+        />
+        <div>
+          <Button
+            type="button"
+            disabled={busy || pasted.trim() === ""}
+            onClick={() => run(() => importLicense(pasted))}
+          >
+            Add license
+          </Button>
+        </div>
+        {error ? (
+          <p role="alert" className="text-sm text-destructive">
+            {error}
+          </p>
+        ) : null}
+      </div>
+    </SettingsSection>
+  )
+}

--- a/surfsense_local/frontend/src/features/migration/api.ts
+++ b/surfsense_local/frontend/src/features/migration/api.ts
@@ -1,0 +1,24 @@
+import { requestJson } from "@/lib/api"
+
+export type ImportedWorkspace = {
+  id: number
+  cloud_id: number
+  name: string
+}
+
+export type ImportAccepted = {
+  workspaces: ImportedWorkspace[]
+}
+
+export function importBundle(
+  file: File,
+  signal?: AbortSignal
+): Promise<ImportAccepted> {
+  const body = new FormData()
+  body.append("file", file)
+  return requestJson<ImportAccepted>("/migration/import", {
+    method: "POST",
+    body,
+    signal,
+  })
+}

--- a/surfsense_local/frontend/src/features/migration/import-bundle.test.tsx
+++ b/surfsense_local/frontend/src/features/migration/import-bundle.test.tsx
@@ -1,0 +1,172 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { cleanup, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+
+import { ThemeProvider } from "@/components/theme-provider"
+import { TooltipProvider } from "@/components/ui/tooltip"
+import { DashboardPage } from "@/features/dashboard/dashboard-page"
+import { SettingsDialog } from "@/features/settings/settings-dialog"
+import { render } from "@/test-utils"
+
+const research = {
+  id: 1,
+  name: "Research",
+  created_at: "2026-09-10T00:00:00Z",
+  updated_at: "2026-09-10T00:00:00Z",
+}
+const empty = { ...research, id: 2, name: "Empty" }
+
+function stubApi(importResponse: Response) {
+  const fetchMock = vi.fn(
+    async (input: RequestInfo | URL, init?: RequestInit) => {
+      const path = String(input)
+      if (path === "/migration/import" && init?.method === "POST") {
+        return importResponse
+      }
+      if (path === "/workspaces") {
+        return Response.json([research, empty])
+      }
+      if (path.startsWith("/workspaces/1/")) {
+        return Response.json([])
+      }
+      return Response.json({ detail: "not found" }, { status: 404 })
+    }
+  )
+  vi.stubGlobal("fetch", fetchMock)
+  return fetchMock
+}
+
+function renderEmptyDashboard() {
+  return render(
+    <ThemeProvider>
+      <TooltipProvider>
+        <DashboardPage
+          selection={null}
+          initialWorkspaces={[]}
+          onModelSelected={vi.fn()}
+        />
+      </TooltipProvider>
+    </ThemeProvider>
+  )
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    value: vi.fn().mockReturnValue({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }),
+  })
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+  )
+  Object.defineProperty(HTMLElement.prototype, "scrollTo", {
+    configurable: true,
+    value: vi.fn(),
+  })
+  Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+    configurable: true,
+    value: vi.fn(),
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+describe("importing a SurfSense cloud export", () => {
+  it("turns the bundle's workspaces into the user's workspaces", async () => {
+    const fetchMock = stubApi(
+      Response.json(
+        {
+          workspaces: [
+            { id: 1, cloud_id: 12, name: "Research" },
+            { id: 2, cloud_id: 13, name: "Empty" },
+          ],
+        },
+        { status: 202 }
+      )
+    )
+    const user = userEvent.setup()
+    renderEmptyDashboard()
+
+    const bundle = new File(["zip"], "surfsense-export.zip", {
+      type: "application/zip",
+    })
+    await user.upload(
+      screen.getByLabelText("Import from SurfSense cloud"),
+      bundle
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Research" })).toBeTruthy()
+    })
+    expect(screen.getByRole("button", { name: "Empty" })).toBeTruthy()
+    const [, init] = fetchMock.mock.calls.find(
+      ([input]) => String(input) === "/migration/import"
+    )!
+    expect((init?.body as FormData).get("file")).toBe(bundle)
+  })
+
+  it("shows the server's reason when the bundle is refused", async () => {
+    stubApi(
+      Response.json(
+        { detail: "not a SurfSense export bundle: File is not a zip file" },
+        { status: 422 }
+      )
+    )
+    const user = userEvent.setup()
+    renderEmptyDashboard()
+
+    await user.upload(
+      screen.getByLabelText("Import from SurfSense cloud"),
+      new File(["nope"], "broken.zip", { type: "application/zip" })
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert").textContent).toBe(
+        "not a SurfSense export bundle: File is not a zip file"
+      )
+    })
+    expect(screen.getByRole("heading", { name: "No workspaces" })).toBeTruthy()
+  })
+
+  it("is also offered in Settings, for a user who already has workspaces", async () => {
+    const accepted = {
+      workspaces: [{ id: 1, cloud_id: 12, name: "Research" }],
+    }
+    stubApi(Response.json(accepted, { status: 202 }))
+    const onImported = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <ThemeProvider>
+        <SettingsDialog
+          open
+          section="general"
+          onOpenChange={vi.fn()}
+          onSectionChange={vi.fn()}
+          onModelSelected={vi.fn()}
+          onImported={onImported}
+        />
+      </ThemeProvider>
+    )
+
+    await user.upload(
+      screen.getByLabelText("Import from SurfSense cloud"),
+      new File(["zip"], "surfsense-export.zip", { type: "application/zip" })
+    )
+
+    await waitFor(() => {
+      expect(onImported).toHaveBeenCalledWith(accepted)
+    })
+  })
+})

--- a/surfsense_local/frontend/src/features/migration/import-bundle.tsx
+++ b/surfsense_local/frontend/src/features/migration/import-bundle.tsx
@@ -1,0 +1,66 @@
+import { useRef, useState, type ChangeEvent } from "react"
+
+import { Button } from "@/components/ui/button"
+import { DownloadIcon } from "@/components/ui/icons"
+import { Input } from "@/components/ui/input"
+
+import { importBundle, type ImportAccepted } from "./api"
+
+function messageFrom(error: unknown) {
+  return error instanceof Error ? error.message : "An unexpected error occurred"
+}
+
+export function ImportBundleButton({
+  onImported,
+  variant = "outline",
+}: {
+  onImported: (accepted: ImportAccepted) => Promise<void> | void
+  variant?: "outline" | "default"
+}) {
+  const fileInput = useRef<HTMLInputElement>(null)
+  const [isImporting, setIsImporting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const importSelected = async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0]
+    event.target.value = ""
+    if (!file) return
+    setIsImporting(true)
+    setError(null)
+    try {
+      await onImported(await importBundle(file))
+    } catch (cause) {
+      setError(messageFrom(cause))
+    } finally {
+      setIsImporting(false)
+    }
+  }
+
+  return (
+    <div className="flex flex-col items-center gap-2">
+      <Input
+        ref={fileInput}
+        type="file"
+        accept=".zip"
+        className="sr-only"
+        aria-label="Import from SurfSense cloud"
+        disabled={isImporting}
+        onChange={importSelected}
+      />
+      <Button
+        type="button"
+        variant={variant}
+        disabled={isImporting}
+        onClick={() => fileInput.current?.click()}
+      >
+        <DownloadIcon />
+        {isImporting ? "Importing…" : "Import from SurfSense cloud"}
+      </Button>
+      {error ? (
+        <p role="alert" className="text-sm text-destructive">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  )
+}

--- a/surfsense_local/frontend/src/features/settings/settings-dialog.tsx
+++ b/surfsense_local/frontend/src/features/settings/settings-dialog.tsx
@@ -9,6 +9,8 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog"
 import { CpuIcon, Settings2Icon } from "@/components/ui/icons"
+import type { ImportAccepted } from "@/features/migration/api"
+import { ImportBundleButton } from "@/features/migration/import-bundle"
 import type { ModelSelection } from "@/features/model-selection/api"
 import { cn } from "@/lib/utils"
 
@@ -24,7 +26,11 @@ type SettingsNavItem = {
 
 export type SettingsSectionId = "general" | "models"
 
-function GeneralSettings() {
+function GeneralSettings({
+  onImported,
+}: {
+  onImported: (accepted: ImportAccepted) => Promise<void> | void
+}) {
   return (
     <SettingsSection
       title="General"
@@ -38,6 +44,17 @@ function GeneralSettings() {
           </p>
         </div>
         <AppearanceToggle />
+      </div>
+      <div className="mt-8 flex items-center justify-between gap-8">
+        <div className="flex flex-col gap-1">
+          <h3 className="text-sm font-medium">Import from SurfSense cloud</h3>
+          <p className="text-sm text-pretty text-muted-foreground">
+            Load the export bundle downloaded from your hosted account.
+            Documents arrive as markdown and are indexed in the background;
+            original files and live citation links do not travel.
+          </p>
+        </div>
+        <ImportBundleButton onImported={onImported} />
       </div>
     </SettingsSection>
   )
@@ -64,6 +81,7 @@ export function SettingsDialog({
   onSectionChange,
   onModelUnavailable = () => undefined,
   onModelSelected,
+  onImported = () => undefined,
 }: {
   open: boolean
   section: SettingsSectionId
@@ -71,6 +89,7 @@ export function SettingsDialog({
   onSectionChange: (section: SettingsSectionId) => void
   onModelUnavailable?: () => void
   onModelSelected: (selection: ModelSelection) => void
+  onImported?: (accepted: ImportAccepted) => Promise<void> | void
 }) {
   const activeSection =
     SETTINGS_SECTIONS.find((candidate) => candidate.id === section) ??
@@ -117,7 +136,9 @@ export function SettingsDialog({
           </aside>
 
           <section className="min-h-0 min-w-0 overflow-hidden bg-popover text-popover-foreground">
-            {activeSection.id === "general" ? <GeneralSettings /> : null}
+            {activeSection.id === "general" ? (
+              <GeneralSettings onImported={onImported} />
+            ) : null}
             {activeSection.id === "models" ? (
               <ModelsSettings
                 onModelUnavailable={onModelUnavailable}

--- a/surfsense_local/frontend/src/features/settings/settings-dialog.tsx
+++ b/surfsense_local/frontend/src/features/settings/settings-dialog.tsx
@@ -8,7 +8,8 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
-import { CpuIcon, Settings2Icon } from "@/components/ui/icons"
+import { CpuIcon, KeyRoundIcon, Settings2Icon } from "@/components/ui/icons"
+import { LicenseSettings } from "@/features/license/license-settings"
 import type { ImportAccepted } from "@/features/migration/api"
 import { ImportBundleButton } from "@/features/migration/import-bundle"
 import type { ModelSelection } from "@/features/model-selection/api"
@@ -24,7 +25,7 @@ type SettingsNavItem = {
   icon: ComponentType<{ className?: string; strokeWidth?: number }>
 }
 
-export type SettingsSectionId = "general" | "models"
+export type SettingsSectionId = "general" | "models" | "license"
 
 function GeneralSettings({
   onImported,
@@ -71,6 +72,11 @@ const SETTINGS_SECTIONS = [
     id: "models",
     label: "Models",
     icon: CpuIcon,
+  },
+  {
+    id: "license",
+    label: "License",
+    icon: KeyRoundIcon,
   },
 ] satisfies SettingsNavItem[]
 
@@ -145,6 +151,7 @@ export function SettingsDialog({
                 onSelected={onModelSelected}
               />
             ) : null}
+            {activeSection.id === "license" ? <LicenseSettings /> : null}
           </section>
         </div>
       </DialogContent>

--- a/surfsense_local/frontend/src/features/workspaces/use-workspaces.ts
+++ b/surfsense_local/frontend/src/features/workspaces/use-workspaces.ts
@@ -3,6 +3,7 @@ import { useMemo, useState } from "react"
 import {
   createWorkspace,
   deleteWorkspace,
+  listWorkspaces,
   renameWorkspace,
   type Workspace,
 } from "./api"
@@ -117,6 +118,16 @@ export function useWorkspaces(initialWorkspaces: Workspace[]) {
     }
   }
 
+  // After a change made outside this hook (an import); lands on `focusId`.
+  const reload = async (focusId: number) => {
+    const next = await listWorkspaces()
+    setWorkspaces(next)
+    if (next.some((workspace) => workspace.id === focusId)) {
+      rememberWorkspace(focusId)
+      setActiveId(focusId)
+    }
+  }
+
   return {
     workspaces,
     activeWorkspace,
@@ -126,6 +137,7 @@ export function useWorkspaces(initialWorkspaces: Workspace[]) {
     create,
     rename,
     remove,
+    reload,
     clearError: () => setError(null),
   }
 }


### PR DESCRIPTION
## Summary
- Import a SurfSense cloud export bundle (contract 3): one local workspace per exported one, documents queued for indexing, threads with sources as text; re-import is a no-op via `cloud_id`
- Manifest paths are validated before anything is extracted; zip-bomb guard on entry count and unpacked size
- License module (contract 1): verify the `.lic` offline with the Keygen public key, keep it in a singleton row, re-verify on every read, clock-rollback watermark
- `GET /license/status`, `PUT /license`, `DELETE /license`; refusals come back as `detail.code` the UI explains
- Settings gets an import row and a License page (pick or paste the file, plan/email/renewal, ≤14-day notice, remove)
- Ships the contracts' **test** key; `tests/packaging/test_license_key.py` fails until the real Keygen key replaces it

## Test plan
- [ ] Settings › General › Import: pick `contracts/export-sample` zipped; "Research" and "Empty" appear, 5 documents go `ready`, threads show `Sources: Notes`
- [ ] Import the same bundle again: nothing duplicated
- [ ] Settings › License: drop `contracts/license-sample/individual.lic`; shows Individual plan, ada@example.com, renews Sep 10, 2027
- [ ] Drop `expired.lic`: kept, notice says expired; edit one character of a file: refused with "not issued by SurfSense"
- [ ] Set the system clock back a day: status shows the clock warning; set it right: active again
- [ ] Remove license: back to "No license on this device"

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR implements two major features for the local SurfSense application: **offline license verification** and **cloud export import**. The license system uses Ed25519 cryptographic signatures to verify `.lic` files offline against a Keygen public key, with protections against clock tampering through a watermark mechanism. The import feature allows users to bring their SurfSense cloud workspaces, documents, and chat threads into the local app via a zip bundle, with manifest validation, zip-bomb guards, and deduplication via `cloud_id` fields. The UI includes new Settings pages for both features, showing license status with expiry warnings and providing import functionality. Currently ships with a **test** key that must be replaced before release.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_local/backend/modules/license/verify.py` |
| 2 | `surfsense_local/backend/modules/license/models.py` |
| 3 | `surfsense_local/backend/modules/license/service.py` |
| 4 | `surfsense_local/backend/modules/license/router.py` |
| 5 | `surfsense_local/backend/alembic/versions/0006_license_state.py` |
| 6 | `surfsense_local/backend/tests/integration/license/test_license.py` |
| 7 | `surfsense_local/backend/tests/packaging/test_license_key.py` |
| 8 | `surfsense_local/frontend/src/features/license/api.ts` |
| 9 | `surfsense_local/frontend/src/features/license/license-settings.tsx` |
| 10 | `surfsense_local/frontend/src/features/license/license-settings.test.tsx` |
| 11 | `surfsense_local/backend/modules/migration/schemas.py` |
| 12 | `surfsense_local/backend/modules/migration/service.py` |
| 13 | `surfsense_local/backend/modules/migration/router.py` |
| 14 | `surfsense_local/backend/alembic/versions/0005_workspace_cloud_id.py` |
| 15 | `surfsense_local/backend/modules/workspaces/models.py` |
| 16 | `surfsense_local/backend/tests/integration/migration/test_import.py` |
| 17 | `surfsense_local/frontend/src/features/migration/api.ts` |
| 18 | `surfsense_local/frontend/src/features/migration/import-bundle.tsx` |
| 19 | `surfsense_local/frontend/src/features/migration/import-bundle.test.tsx` |
| 20 | `surfsense_local/backend/api/main.py` |
| 21 | `surfsense_local/backend/shared/db.py` |
| 22 | `surfsense_local/backend/pyproject.toml` |
| 23 | `surfsense_local/backend/uv.lock` |
| 24 | `surfsense_local/frontend/src/features/settings/settings-dialog.tsx` |
| 25 | `surfsense_local/frontend/src/features/dashboard/dashboard-page.tsx` |
| 26 | `surfsense_local/frontend/src/features/workspaces/use-workspaces.ts` |
| 27 | `surfsense_local/backend/modules/license/__init__.py` |
| 28 | `surfsense_local/backend/modules/migration/__init__.py` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->