### PR TITLE
feat(app): account export, chat persistence, and dashboard UX refinements

### DIFF
--- a/surfsense_backend/app/routes/export_routes.py
+++ b/surfsense_backend/app/routes/export_routes.py
@@ -9,13 +9,43 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth.context import AuthContext
 from app.db import Permission, get_async_session
-from app.services.export_service import build_export_zip
+from app.services.export_service import build_account_export_zip, build_export_zip
 from app.users import get_auth_context
 from app.utils.rbac import check_permission
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+
+@router.get("/export")
+async def export_account(
+    session: AsyncSession = Depends(get_async_session),
+    auth: AuthContext = Depends(get_auth_context),
+):
+    """Export every workspace the user can access as a contract-3 ZIP."""
+    result = await build_account_export_zip(session, auth.user.id)
+
+    def stream_and_cleanup():
+        try:
+            with open(result.zip_path, "rb") as f:
+                while chunk := f.read(8192):
+                    yield chunk
+        finally:
+            os.unlink(result.zip_path)
+
+    headers = {
+        "Content-Disposition": f'attachment; filename="{result.export_name}.zip"',
+        "Content-Length": str(result.zip_size),
+    }
+    if result.skipped_docs:
+        headers["X-Skipped-Documents"] = str(len(result.skipped_docs))
+
+    return StreamingResponse(
+        stream_and_cleanup(),
+        media_type="application/zip",
+        headers=headers,
+    )
 
 
 @router.get("/workspaces/{workspace_id}/export")

--- a/surfsense_backend/app/services/export_service.py
+++ b/surfsense_backend/app/services/export_service.py
@@ -1,16 +1,31 @@
 """Service for exporting knowledge base content as a ZIP archive."""
 
 import asyncio
+import json
 import logging
 import os
+import re
 import tempfile
 import zipfile
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any
 
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
+from sqlalchemy.orm import selectinload
 
-from app.db import Chunk, Document, Folder
+from app.db import (
+    ARTIFACT_API_SOURCE,
+    Chunk,
+    Document,
+    DocumentType,
+    Folder,
+    NewChatMessageRole,
+    NewChatThread,
+    Workspace,
+    WorkspaceMembership,
+)
 from app.services.folder_service import get_folder_subtree_ids
 from app.services.okf import (
     INDEX_FILENAME,
@@ -23,6 +38,7 @@ from app.services.okf import (
     folder_to_log,
     okf_type,
 )
+from app.utils.content_utils import extract_text_content
 
 logger = logging.getLogger(__name__)
 
@@ -31,11 +47,52 @@ logger = logging.getLogger(__name__)
 _ROOT_INDEX_FRONTMATTER = '---\nokf_version: "0.1"\n---\n\n'
 
 _RESERVED_STEMS = {"index", "log"}
+_ACCOUNT_FORMAT = "surfsense-export/1"
+_SKIP_REASONS = frozenset({"pending", "processing", "empty"})
+_CITATION_RE = re.compile(r"\[citation:\s*([^\]]+?)\s*\]")
+_CHAT_ROLES = frozenset({"user", "assistant"})
 
 
 def _sanitize_filename(title: str) -> str:
     safe = "".join(c if c.isalnum() or c in " -_." else "_" for c in title).strip()
     return safe[:80] or "document"
+
+
+def flatten_message_text(
+    text: str, title_by_payload: dict[str, str]
+) -> tuple[str, list[dict[str, str]]]:
+    """Strip ``[citation:…]`` markers and collect distinct titles in first-seen order."""
+    citations: list[dict[str, str]] = []
+    seen: set[str] = set()
+    for raw in _CITATION_RE.findall(text):
+        title = title_by_payload.get(raw.strip())
+        if not title or title in seen:
+            continue
+        seen.add(title)
+        citations.append({"title": title})
+    return _CITATION_RE.sub("", text), citations
+
+
+def _iso(value: datetime | None) -> str | None:
+    return value.isoformat() if value is not None else None
+
+
+def _document_source(document: Document) -> str:
+    dtype = document.document_type
+    return dtype.value if isinstance(dtype, DocumentType) else str(dtype)
+
+
+def _join_zip_path(prefix: str, rel: str) -> str:
+    if not prefix:
+        return rel
+    return f"{prefix}/{rel}" if rel else prefix
+
+
+def _doc_state(document: Document) -> str:
+    status = document.status or {}
+    if not isinstance(status, dict):
+        return "ready"
+    return status.get("state") or "ready"
 
 
 def _build_folder_path_map(folders: list[Folder]) -> dict[int, str]:
@@ -157,18 +214,52 @@ class ExportResult:
     skipped_docs: list[str] = field(default_factory=list)
 
 
-async def build_export_zip(
+@dataclass
+class _SkippedDoc:
+    id: int
+    title: str
+    reason: str
+
+
+@dataclass
+class _ListedDoc:
+    id: int
+    path: str
+    title: str
+    source: str
+    created_at: str | None
+
+
+@dataclass
+class _WorkspaceWrite:
+    documents: list[_ListedDoc]
+    skipped: list[_SkippedDoc]
+    wrote: bool
+
+
+async def _write_zip_entries(
+    zip_path: str, entries: list[tuple[str, str]], *, fresh: bool
+) -> None:
+    mode = "w" if fresh else "a"
+
+    def _write() -> None:
+        with zipfile.ZipFile(zip_path, mode, zipfile.ZIP_DEFLATED) as zf:
+            for path, content in entries:
+                zf.writestr(path, content)
+
+    await asyncio.to_thread(_write)
+
+
+async def _export_workspace_markdown(
     session: AsyncSession,
     workspace_id: int,
+    zip_path: str,
+    *,
+    path_prefix: str = "",
     folder_id: int | None = None,
-) -> ExportResult:
-    """Build a ZIP archive of markdown documents preserving folder structure.
-
-    Returns an ExportResult with the path to the temp ZIP file.
-    The caller is responsible for streaming and cleaning up the file.
-
-    Raises ValueError if folder_id is provided but not found.
-    """
+    fresh: bool = True,
+) -> _WorkspaceWrite:
+    """Write one workspace's OKF markdown (concepts, index.md, log.md) into zip_path."""
     if folder_id is not None:
         folder = await session.get(Folder, folder_id)
         if not folder or folder.workspace_id != workspace_id:
@@ -185,137 +276,157 @@ async def build_export_zip(
 
     folder_path_map = _build_folder_path_map(folders)
 
-    batch_size = 100
-
     base_doc_query = select(Document).where(Document.workspace_id == workspace_id)
     if target_folder_ids is not None:
         base_doc_query = base_doc_query.where(Document.folder_id.in_(target_folder_ids))
     base_doc_query = base_doc_query.order_by(Document.id)
 
+    used_paths: dict[str, int] = {}
+    skipped: list[_SkippedDoc] = []
+    listed: list[_ListedDoc] = []
+    wrote = False
+    is_first_batch = fresh
+    dir_concepts: dict[str, list[ConceptRef]] = {}
+    dir_logs: dict[str, list[LogEntry]] = {}
+    batch_size = 100
+    offset = 0
+
+    while True:
+        batch_query = base_doc_query.limit(batch_size).offset(offset)
+        batch_result = await session.execute(batch_query)
+        documents = list(batch_result.scalars().all())
+        if not documents:
+            break
+
+        entries: list[tuple[str, str]] = []
+
+        for doc in documents:
+            if doc.document_type == DocumentType.ARTIFACT:
+                continue
+
+            title = doc.title or "Untitled"
+            state = _doc_state(doc)
+            if state in _SKIP_REASONS and state != "empty":
+                skipped.append(_SkippedDoc(id=doc.id, title=title, reason=state))
+                continue
+
+            markdown = await resolve_document_markdown(session, doc)
+            if not markdown or not markdown.strip():
+                skipped.append(_SkippedDoc(id=doc.id, title=title, reason="empty"))
+                continue
+
+            if doc.folder_id and doc.folder_id in folder_path_map:
+                dir_path = folder_path_map[doc.folder_id]
+            else:
+                dir_path = ""
+
+            base_name = _sanitize_filename(title)
+            if base_name.lower() in _RESERVED_STEMS:
+                base_name = f"{base_name}_"
+            rel_path = f"{dir_path}/{base_name}.md" if dir_path else f"{base_name}.md"
+
+            if rel_path in used_paths:
+                used_paths[rel_path] += 1
+                suffix = used_paths[rel_path]
+                base_name = f"{base_name}_{suffix}"
+                rel_path = (
+                    f"{dir_path}/{base_name}.md" if dir_path else f"{base_name}.md"
+                )
+            used_paths[rel_path] = used_paths.get(rel_path, 0) + 1
+
+            zip_rel = _join_zip_path(path_prefix, rel_path)
+            entries.append((zip_rel, document_to_concept(doc, body=markdown)))
+            listed.append(
+                _ListedDoc(
+                    id=doc.id,
+                    path=zip_rel,
+                    title=title,
+                    source=_document_source(doc),
+                    created_at=_iso(doc.created_at),
+                )
+            )
+
+            metadata = (
+                doc.document_metadata
+                if isinstance(doc.document_metadata, dict)
+                else {}
+            )
+            description = metadata.get("description")
+            dir_concepts.setdefault(dir_path, []).append(
+                ConceptRef(
+                    title=title,
+                    filename=f"{base_name}.md",
+                    type=okf_type(doc.document_type),
+                    description=description
+                    if isinstance(description, str) and description.strip()
+                    else None,
+                )
+            )
+
+            changed_at = doc.updated_at or doc.created_at
+            dir_logs.setdefault(dir_path, []).append(
+                LogEntry(
+                    title=title,
+                    timestamp=_iso(changed_at),
+                )
+            )
+
+        if entries:
+            await _write_zip_entries(zip_path, entries, fresh=is_first_batch)
+            is_first_batch = False
+            wrote = True
+
+        offset += batch_size
+
+    index_files = [
+        (_join_zip_path(path_prefix, rel), body)
+        for rel, body in _build_index_files(dir_concepts)
+    ]
+    if index_files:
+        await _write_zip_entries(zip_path, index_files, fresh=is_first_batch)
+        is_first_batch = False
+        wrote = True
+
+    log_files = [
+        (_join_zip_path(path_prefix, rel), body)
+        for rel, body in _build_log_files(dir_logs)
+    ]
+    if log_files:
+        await _write_zip_entries(zip_path, log_files, fresh=is_first_batch)
+        wrote = True
+
+    return _WorkspaceWrite(documents=listed, skipped=skipped, wrote=wrote)
+
+
+async def build_export_zip(
+    session: AsyncSession,
+    workspace_id: int,
+    folder_id: int | None = None,
+) -> ExportResult:
+    """Build a ZIP archive of markdown documents preserving folder structure.
+
+    Returns an ExportResult with the path to the temp ZIP file.
+    The caller is responsible for streaming and cleaning up the file.
+
+    Raises ValueError if folder_id is provided but not found.
+    """
     fd, tmp_path = tempfile.mkstemp(suffix=".zip")
     os.close(fd)
 
-    used_paths: dict[str, int] = {}
-    skipped_docs: list[str] = []
-    is_first_batch = True
-    # dir path -> concepts it holds, accumulated across batches for index.md.
-    dir_concepts: dict[str, list[ConceptRef]] = {}
-    # dir path -> log entries it holds, accumulated across batches for log.md.
-    dir_logs: dict[str, list[LogEntry]] = {}
-
     try:
-        offset = 0
-        while True:
-            batch_query = base_doc_query.limit(batch_size).offset(offset)
-            batch_result = await session.execute(batch_query)
-            documents = list(batch_result.scalars().all())
-            if not documents:
-                break
-
-            entries: list[tuple[str, str]] = []
-
-            for doc in documents:
-                status = doc.status or {}
-                state = (
-                    status.get("state", "ready")
-                    if isinstance(status, dict)
-                    else "ready"
-                )
-                if state in ("pending", "processing"):
-                    skipped_docs.append(doc.title or "Untitled")
-                    continue
-
-                markdown = await resolve_document_markdown(session, doc)
-                if not markdown or not markdown.strip():
-                    continue
-
-                if doc.folder_id and doc.folder_id in folder_path_map:
-                    dir_path = folder_path_map[doc.folder_id]
-                else:
-                    dir_path = ""
-
-                base_name = _sanitize_filename(doc.title or "Untitled")
-                # Never collide with reserved OKF filenames (index.md, log.md).
-                if base_name.lower() in _RESERVED_STEMS:
-                    base_name = f"{base_name}_"
-                file_path = (
-                    f"{dir_path}/{base_name}.md" if dir_path else f"{base_name}.md"
-                )
-
-                if file_path in used_paths:
-                    used_paths[file_path] += 1
-                    suffix = used_paths[file_path]
-                    base_name = f"{base_name}_{suffix}"
-                    file_path = (
-                        f"{dir_path}/{base_name}.md" if dir_path else f"{base_name}.md"
-                    )
-                used_paths[file_path] = used_paths.get(file_path, 0) + 1
-
-                concept = document_to_concept(doc, body=markdown)
-                entries.append((file_path, concept))
-
-                metadata = (
-                    doc.document_metadata
-                    if isinstance(doc.document_metadata, dict)
-                    else {}
-                )
-                description = metadata.get("description")
-                dir_concepts.setdefault(dir_path, []).append(
-                    ConceptRef(
-                        title=doc.title or "Untitled",
-                        filename=f"{base_name}.md",
-                        type=okf_type(doc.document_type),
-                        description=description
-                        if isinstance(description, str) and description.strip()
-                        else None,
-                    )
-                )
-
-                changed_at = doc.updated_at or doc.created_at
-                dir_logs.setdefault(dir_path, []).append(
-                    LogEntry(
-                        title=doc.title or "Untitled",
-                        timestamp=changed_at.isoformat() if changed_at else None,
-                    )
-                )
-
-            if entries:
-                mode = "w" if is_first_batch else "a"
-                batch_entries = entries
-
-                def _write_batch(m: str = mode, e: list = batch_entries) -> None:
-                    with zipfile.ZipFile(tmp_path, m, zipfile.ZIP_DEFLATED) as zf:
-                        for path, content in e:
-                            zf.writestr(path, content)
-
-                await asyncio.to_thread(_write_batch)
-                is_first_batch = False
-
-            offset += batch_size
-
-        index_files = _build_index_files(dir_concepts)
-        if index_files:
-            mode = "w" if is_first_batch else "a"
-
-            def _write_indexes(m: str = mode, e: list = index_files) -> None:
-                with zipfile.ZipFile(tmp_path, m, zipfile.ZIP_DEFLATED) as zf:
-                    for path, content in e:
-                        zf.writestr(path, content)
-
-            await asyncio.to_thread(_write_indexes)
-            is_first_batch = False
-
-        log_files = _build_log_files(dir_logs)
-        if log_files:
-            mode = "w" if is_first_batch else "a"
-
-            def _write_logs(m: str = mode, e: list = log_files) -> None:
-                with zipfile.ZipFile(tmp_path, m, zipfile.ZIP_DEFLATED) as zf:
-                    for path, content in e:
-                        zf.writestr(path, content)
-
-            await asyncio.to_thread(_write_logs)
-            is_first_batch = False
+        written = await _export_workspace_markdown(
+            session,
+            workspace_id,
+            tmp_path,
+            folder_id=folder_id,
+            fresh=True,
+        )
+        folder_path_map = {}
+        if folder_id is not None:
+            folder_result = await session.execute(
+                select(Folder).where(Folder.workspace_id == workspace_id)
+            )
+            folder_path_map = _build_folder_path_map(list(folder_result.scalars().all()))
 
         export_name = "knowledge-base"
         if folder_id is not None and folder_id in folder_path_map:
@@ -325,10 +436,207 @@ async def build_export_zip(
             zip_path=tmp_path,
             export_name=export_name,
             zip_size=os.path.getsize(tmp_path),
-            skipped_docs=skipped_docs,
+            skipped_docs=[row.title for row in written.skipped],
         )
-
     except Exception:
         if os.path.exists(tmp_path):
             os.unlink(tmp_path)
+        raise
+
+
+async def _member_workspaces(session: AsyncSession, user_id: Any) -> list[Workspace]:
+    not_deleting = ~Workspace.name.startswith("[DELETING] ")
+    result = await session.execute(
+        select(Workspace)
+        .join(
+            WorkspaceMembership,
+            WorkspaceMembership.workspace_id == Workspace.id,
+        )
+        .where(WorkspaceMembership.user_id == user_id, not_deleting)
+        .order_by(Workspace.id)
+    )
+    return list(result.scalars().unique().all())
+
+
+async def _citation_titles(
+    session: AsyncSession, workspace_id: int, payloads: set[str]
+) -> dict[str, str]:
+    chunk_ids: list[int] = []
+    for payload in payloads:
+        try:
+            chunk_ids.append(int(payload))
+        except ValueError:
+            continue
+    if not chunk_ids:
+        return {}
+    result = await session.execute(
+        select(Chunk.id, Document.title)
+        .join(Document, Document.id == Chunk.document_id)
+        .where(Chunk.id.in_(chunk_ids), Document.workspace_id == workspace_id)
+    )
+    return {str(chunk_id): title for chunk_id, title in result.all()}
+
+
+def _role_value(role: Any) -> str:
+    return role.value if isinstance(role, NewChatMessageRole) else str(role)
+
+
+async def flatten_workspace_chats(
+    session: AsyncSession, workspace_id: int
+) -> list[dict[str, Any]]:
+    """Flatten new_chat JSONB into contract-3 chats.json threads."""
+    result = await session.execute(
+        select(NewChatThread)
+        .where(
+            NewChatThread.workspace_id == workspace_id,
+            NewChatThread.source != ARTIFACT_API_SOURCE,
+        )
+        .options(selectinload(NewChatThread.messages))
+        .order_by(NewChatThread.id)
+    )
+    threads = list(result.scalars().unique().all())
+
+    payloads: set[str] = set()
+    for thread in threads:
+        for message in thread.messages:
+            if _role_value(message.role) not in _CHAT_ROLES:
+                continue
+            payloads.update(
+                raw.strip()
+                for raw in _CITATION_RE.findall(extract_text_content(message.content))
+            )
+    title_by_payload = await _citation_titles(session, workspace_id, payloads)
+
+    exported: list[dict[str, Any]] = []
+    for thread in threads:
+        messages_out: list[dict[str, Any]] = []
+        ordered = sorted(
+            thread.messages, key=lambda item: (item.created_at, item.id)
+        )
+        for message in ordered:
+            role = _role_value(message.role)
+            if role not in _CHAT_ROLES:
+                continue
+            text, citations = flatten_message_text(
+                extract_text_content(message.content), title_by_payload
+            )
+            if not text.strip() and not citations:
+                continue
+            messages_out.append(
+                {
+                    "role": role,
+                    "text": text,
+                    "citations": citations,
+                    "created_at": _iso(message.created_at),
+                }
+            )
+        if not messages_out:
+            continue
+        exported.append(
+            {
+                "id": thread.id,
+                "title": thread.title,
+                "created_at": _iso(thread.created_at),
+                "messages": messages_out,
+            }
+        )
+    return exported
+
+
+def _manifest_first_zip(staging_path: str, manifest: dict[str, Any]) -> str:
+    fd, final_path = tempfile.mkstemp(suffix=".zip")
+    os.close(fd)
+    try:
+        with zipfile.ZipFile(final_path, "w", zipfile.ZIP_DEFLATED) as dst:
+            dst.writestr(
+                "manifest.json",
+                json.dumps(manifest, ensure_ascii=False, indent=2),
+            )
+            if os.path.getsize(staging_path) > 0:
+                with zipfile.ZipFile(staging_path, "r") as src:
+                    for info in src.infolist():
+                        dst.writestr(info, src.read(info.filename))
+    except Exception:
+        if os.path.exists(final_path):
+            os.unlink(final_path)
+        raise
+    finally:
+        if os.path.exists(staging_path):
+            os.unlink(staging_path)
+    return final_path
+
+
+async def build_account_export_zip(
+    session: AsyncSession, user_id: Any
+) -> ExportResult:
+    """Build a contract-3 ZIP of every workspace the user is a member of."""
+    workspaces = await _member_workspaces(session, user_id)
+    fd, staging_path = tempfile.mkstemp(suffix=".zip")
+    os.close(fd)
+    fresh = True
+    manifest_workspaces: list[dict[str, Any]] = []
+    skipped_titles: list[str] = []
+
+    try:
+        for workspace in workspaces:
+            prefix = f"workspaces/{workspace.id}/documents"
+            written = await _export_workspace_markdown(
+                session,
+                workspace.id,
+                staging_path,
+                path_prefix=prefix,
+                fresh=fresh,
+            )
+            if written.wrote:
+                fresh = False
+
+            chats = await flatten_workspace_chats(session, workspace.id)
+            chats_path = f"workspaces/{workspace.id}/chats.json"
+            await _write_zip_entries(
+                staging_path,
+                [(chats_path, json.dumps(chats, ensure_ascii=False, indent=2))],
+                fresh=fresh,
+            )
+            fresh = False
+
+            skipped_titles.extend(row.title for row in written.skipped)
+            manifest_workspaces.append(
+                {
+                    "id": workspace.id,
+                    "name": workspace.name,
+                    "created_at": _iso(workspace.created_at),
+                    "chats": chats_path,
+                    "documents": [
+                        {
+                            "id": doc.id,
+                            "path": doc.path,
+                            "title": doc.title,
+                            "source": doc.source,
+                            "created_at": doc.created_at,
+                        }
+                        for doc in written.documents
+                    ],
+                    "skipped": [
+                        {"id": row.id, "title": row.title, "reason": row.reason}
+                        for row in written.skipped
+                    ],
+                }
+            )
+
+        manifest = {
+            "format": _ACCOUNT_FORMAT,
+            "exported_at": datetime.now(UTC).isoformat(),
+            "workspaces": manifest_workspaces,
+        }
+        zip_path = _manifest_first_zip(staging_path, manifest)
+        staging_path = ""
+        return ExportResult(
+            zip_path=zip_path,
+            export_name="surfsense-export",
+            zip_size=os.path.getsize(zip_path),
+            skipped_docs=skipped_titles,
+        )
+    except Exception:
+        if staging_path and os.path.exists(staging_path):
+            os.unlink(staging_path)
         raise

--- a/surfsense_backend/tests/integration/test_account_export.py
+++ b/surfsense_backend/tests/integration/test_account_export.py
@@ -1,0 +1,263 @@
+"""Contract-3 producer: account ZIP from a real DB."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import zipfile
+from pathlib import Path
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db import (
+    Chunk,
+    Document,
+    DocumentStatus,
+    DocumentType,
+    Folder,
+    NewChatMessage,
+    NewChatMessageRole,
+    NewChatThread,
+    User,
+    Workspace,
+)
+from app.routes.workspaces_routes import create_default_roles_and_membership
+from app.services.export_service import build_account_export_zip
+
+pytestmark = pytest.mark.integration
+
+
+def _contracts_dir() -> Path:
+    for parent in Path(__file__).resolve().parents:
+        candidate = parent / "plans" / "community-local" / "contracts"
+        if candidate.is_dir():
+            return candidate
+    raise RuntimeError("plans/community-local/contracts not found")
+
+
+def _check_export_sample(root: Path) -> int:
+    spec = importlib.util.spec_from_file_location(
+        "check_export_sample", _contracts_dir() / "check-export-sample.py"
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.main(root)
+
+
+async def _add_doc(
+    session: AsyncSession,
+    *,
+    workspace: Workspace,
+    user: User,
+    title: str,
+    folder_id: int | None,
+    uid: str,
+    document_type: DocumentType = DocumentType.FILE,
+    status: dict | None = None,
+    markdown: str | None = "# Body\n",
+) -> Document:
+    doc = Document(
+        title=title,
+        document_type=document_type,
+        document_metadata={},
+        content=markdown or "",
+        content_hash=uid,
+        unique_identifier_hash=uid,
+        source_markdown=markdown,
+        workspace_id=workspace.id,
+        created_by_id=user.id,
+        folder_id=folder_id,
+        status=status if status is not None else DocumentStatus.ready(),
+    )
+    session.add(doc)
+    await session.flush()
+    return doc
+
+
+async def test_account_export_matches_contract_and_skips_pending(
+    db_session: AsyncSession, db_user: User, db_workspace: Workspace, tmp_path: Path
+):
+    research = Folder(name="Research", position="0", workspace_id=db_workspace.id)
+    db_session.add(research)
+    await db_session.flush()
+    ai = Folder(
+        name="AI",
+        position="0",
+        workspace_id=db_workspace.id,
+        parent_id=research.id,
+    )
+    db_session.add(ai)
+    await db_session.flush()
+
+    notes = await _add_doc(
+        db_session,
+        workspace=db_workspace,
+        user=db_user,
+        title="Notes",
+        folder_id=ai.id,
+        uid="acct-notes",
+        document_type=DocumentType.FILE,
+    )
+    await _add_doc(
+        db_session,
+        workspace=db_workspace,
+        user=db_user,
+        title="Notes",
+        folder_id=ai.id,
+        uid="acct-notes-2",
+        document_type=DocumentType.NOTE,
+    )
+    await _add_doc(
+        db_session,
+        workspace=db_workspace,
+        user=db_user,
+        title="index",
+        folder_id=research.id,
+        uid="acct-index",
+        document_type=DocumentType.NOTION_CONNECTOR,
+    )
+    await _add_doc(
+        db_session,
+        workspace=db_workspace,
+        user=db_user,
+        title="Résumé de réunion",
+        folder_id=None,
+        uid="acct-unicode",
+        document_type=DocumentType.SLACK_CONNECTOR,
+    )
+    pending = await _add_doc(
+        db_session,
+        workspace=db_workspace,
+        user=db_user,
+        title="Draft",
+        folder_id=None,
+        uid="acct-pending",
+        status=DocumentStatus.processing(),
+        markdown="# still cooking",
+    )
+
+    empty = Workspace(name="Empty", user_id=db_user.id)
+    db_session.add(empty)
+    await db_session.flush()
+    await create_default_roles_and_membership(db_session, empty.id, db_user.id)
+
+    cited = await _add_doc(
+        db_session,
+        workspace=db_workspace,
+        user=db_user,
+        title="Alpha",
+        folder_id=None,
+        uid="acct-alpha",
+        document_type=DocumentType.FILE,
+    )
+    beta = await _add_doc(
+        db_session,
+        workspace=db_workspace,
+        user=db_user,
+        title="Beta",
+        folder_id=None,
+        uid="acct-beta",
+        document_type=DocumentType.FILE,
+    )
+    gamma = await _add_doc(
+        db_session,
+        workspace=db_workspace,
+        user=db_user,
+        title="Gamma",
+        folder_id=None,
+        uid="acct-gamma",
+        document_type=DocumentType.FILE,
+    )
+    chunks = []
+    for source_doc in (cited, beta, gamma):
+        chunk = Chunk(content="passage", document_id=source_doc.id, position=0)
+        db_session.add(chunk)
+        chunks.append(chunk)
+    await db_session.flush()
+
+    thread = NewChatThread(
+        title="Citations",
+        workspace_id=db_workspace.id,
+        created_by_id=db_user.id,
+    )
+    db_session.add(thread)
+    await db_session.flush()
+    db_session.add(
+        NewChatMessage(
+            thread_id=thread.id,
+            role=NewChatMessageRole.USER,
+            content=[{"type": "text", "text": "compare these"}],
+            author_id=db_user.id,
+        )
+    )
+    marker_text = (
+        f"See [citation:{chunks[0].id}] then "
+        f"[citation:{chunks[1].id}] and [citation:{chunks[2].id}]."
+    )
+    db_session.add(
+        NewChatMessage(
+            thread_id=thread.id,
+            role=NewChatMessageRole.ASSISTANT,
+            content=[{"type": "text", "text": marker_text}],
+            author_id=db_user.id,
+        )
+    )
+    db_session.add(
+        NewChatMessage(
+            thread_id=thread.id,
+            role=NewChatMessageRole.SYSTEM,
+            content=[{"type": "text", "text": "ignored"}],
+            author_id=db_user.id,
+        )
+    )
+    await db_session.flush()
+
+    result = await build_account_export_zip(db_session, db_user.id)
+    try:
+        with zipfile.ZipFile(result.zip_path) as zf:
+            names = zf.namelist()
+            assert names[0] == "manifest.json"
+            zf.extractall(tmp_path)
+    finally:
+        os.unlink(result.zip_path)
+
+    assert _check_export_sample(tmp_path) == 0
+
+    manifest = json.loads((tmp_path / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["format"] == "surfsense-export/1"
+    by_id = {ws["id"]: ws for ws in manifest["workspaces"]}
+    assert set(by_id) == {db_workspace.id, empty.id}
+
+    research_ws = by_id[db_workspace.id]
+    listed_ids = {doc["id"] for doc in research_ws["documents"]}
+    assert pending.id not in listed_ids
+    assert {"id": pending.id, "title": "Draft", "reason": "processing"} in research_ws[
+        "skipped"
+    ]
+    paths = {doc["path"] for doc in research_ws["documents"]}
+    assert any(path.endswith("Notes.md") and "Notes_2.md" not in path for path in paths)
+    assert any(path.endswith("Notes_2.md") for path in paths)
+    assert any(path.endswith("index_.md") for path in paths)
+    assert any("Résumé de réunion.md" in path for path in paths)
+    assert notes.id in listed_ids
+
+    empty_ws = by_id[empty.id]
+    assert empty_ws["documents"] == []
+    assert empty_ws["skipped"] == []
+    assert empty_ws["chats"] == f"workspaces/{empty.id}/chats.json"
+    assert json.loads((tmp_path / empty_ws["chats"]).read_text(encoding="utf-8")) == []
+
+    chats = json.loads((tmp_path / research_ws["chats"]).read_text(encoding="utf-8"))
+    assert len(chats) == 1
+    assistant = chats[0]["messages"][1]
+    assert assistant["role"] == "assistant"
+    assert "[citation:" not in assistant["text"]
+    assert assistant["citations"] == [
+        {"title": "Alpha"},
+        {"title": "Beta"},
+        {"title": "Gamma"},
+    ]
+    assert all(msg["role"] in {"user", "assistant"} for msg in chats[0]["messages"])

--- a/surfsense_backend/tests/unit/routes/test_legacy_reports_demolition.py
+++ b/surfsense_backend/tests/unit/routes/test_legacy_reports_demolition.py
@@ -47,6 +47,7 @@ def test_document_exports_are_absent_but_workspace_export_remains() -> None:
         not in route_paths
     )
     assert "/workspaces/{workspace_id}/export" in route_paths
+    assert "/export" in route_paths
 
     template_imports: list[str] = []
     for path in (BACKEND_ROOT / "app").rglob("*.py"):

--- a/surfsense_backend/tests/unit/services/test_account_export.py
+++ b/surfsense_backend/tests/unit/services/test_account_export.py
@@ -1,0 +1,61 @@
+"""Contract-3 producer: citation flattening and the committed fixture."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from app.services.export_service import flatten_message_text
+
+pytestmark = pytest.mark.unit
+
+def _contracts_dir() -> Path:
+    for parent in Path(__file__).resolve().parents:
+        candidate = parent / "plans" / "community-local" / "contracts"
+        if candidate.is_dir():
+            return candidate
+    raise RuntimeError("plans/community-local/contracts not found")
+
+
+def test_committed_export_sample_matches_the_contract():
+    spec = importlib.util.spec_from_file_location(
+        "check_export_sample", _contracts_dir() / "check-export-sample.py"
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    assert module.main(_contracts_dir() / "export-sample") == 0
+
+
+def test_three_citation_markers_export_with_none_and_three_titles():
+    text = (
+        "A [citation:11] then [citation:22] and [citation:33] done."
+    )
+    titles = {"11": "Alpha", "22": "Beta", "33": "Gamma"}
+    stripped, citations = flatten_message_text(text, titles)
+    assert "[citation:" not in stripped
+    assert citations == [
+        {"title": "Alpha"},
+        {"title": "Beta"},
+        {"title": "Gamma"},
+    ]
+
+
+def test_duplicate_citation_titles_keep_first_seen_order():
+    stripped, citations = flatten_message_text(
+        "See [citation:1] and again [citation:1] then [citation:2].",
+        {"1": "Notes", "2": "Other"},
+    )
+    assert "[citation:" not in stripped
+    assert citations == [{"title": "Notes"}, {"title": "Other"}]
+
+
+def test_unresolved_citation_is_stripped_without_a_title():
+    stripped, citations = flatten_message_text(
+        "Unknown [citation:https://example.com] marker.",
+        {},
+    )
+    assert "[citation:" not in stripped
+    assert citations == []

--- a/surfsense_local/electron/src/main/index.ts
+++ b/surfsense_local/electron/src/main/index.ts
@@ -1,6 +1,6 @@
 import { join } from "node:path"
 
-import { app, BrowserWindow, ipcMain, shell } from "electron"
+import { app, BrowserWindow, ipcMain, Menu, shell } from "electron"
 
 import { managedOriginalPath } from "./document-files.mts"
 import { getFreePort, waitForHealth } from "./net.ts"
@@ -173,6 +173,47 @@ function applyTitleBarOverlay(
   })
 }
 
+// Packaged only. Dev keeps Electron's default View menu (Cmd/Ctrl+R).
+// https://www.electronjs.org/docs/latest/tutorial/application-menu
+function installProductionMenu(): void {
+  if (!app.isPackaged) return
+
+  Menu.setApplicationMenu(
+    Menu.buildFromTemplate([
+      ...(process.platform === "darwin" ? [{ role: "appMenu" as const }] : []),
+      { role: "fileMenu" },
+      { role: "editMenu" },
+      {
+        label: "View",
+        submenu: [
+          {
+            label: "Reload",
+            click: (_item, win) => {
+              if (win instanceof BrowserWindow) win.reload()
+            },
+          },
+          {
+            label: "Force Reload",
+            click: (_item, win) => {
+              if (win instanceof BrowserWindow) {
+                win.webContents.reloadIgnoringCache()
+              }
+            },
+          },
+          { role: "toggleDevTools" },
+          { type: "separator" },
+          { role: "resetZoom" },
+          { role: "zoomIn" },
+          { role: "zoomOut" },
+          { type: "separator" },
+          { role: "togglefullscreen" },
+        ],
+      },
+      { role: "windowMenu" },
+    ])
+  )
+}
+
 function createWindow(apiUrl: string): void {
   const savedState = app.isPackaged ? loadWindowState() : null
   const win = new BrowserWindow({
@@ -238,6 +279,7 @@ function main(): void {
     .then(async () => {
       const boot = await bootSidecars()
       registerDocumentHandlers(boot.dataDir)
+      installProductionMenu()
       createWindow(boot.apiUrl)
       app.on("activate", () => {
         if (BrowserWindow.getAllWindows().length === 0)

--- a/surfsense_local/electron/src/main/index.ts
+++ b/surfsense_local/electron/src/main/index.ts
@@ -173,7 +173,7 @@ function applyTitleBarOverlay(
   })
 }
 
-// Packaged only. Dev keeps Electron's default View menu (Cmd/Ctrl+R).
+// Packaged only. Dev keeps Electron's default View menu (reload + DevTools).
 // https://www.electronjs.org/docs/latest/tutorial/application-menu
 function installProductionMenu(): void {
   if (!app.isPackaged) return
@@ -200,7 +200,6 @@ function installProductionMenu(): void {
               }
             },
           },
-          { role: "toggleDevTools" },
           { type: "separator" },
           { role: "resetZoom" },
           { role: "zoomIn" },
@@ -225,6 +224,8 @@ function createWindow(apiUrl: string): void {
     webPreferences: {
       preload: join(__dirname, "../preload/index.js"),
       additionalArguments: [`--surfsense-api-url=${apiUrl}`],
+      // https://www.electronjs.org/docs/latest/api/structures/web-preferences
+      ...(app.isPackaged && { devTools: false }),
     },
   })
   mainWindow = win

--- a/surfsense_local/electron/src/main/index.ts
+++ b/surfsense_local/electron/src/main/index.ts
@@ -13,6 +13,27 @@ import { loadWindowState, saveWindowState } from "./window-state.ts"
 
 const DEV_RENDERER_URL = "http://localhost:5173"
 
+function allowedExternalUrl(url: string): string | null {
+  try {
+    const parsed = new URL(url)
+    if (
+      parsed.protocol === "https:" &&
+      (parsed.hostname === "surfsense.com" ||
+        parsed.hostname === "www.surfsense.com")
+    ) {
+      return parsed.href
+    }
+  } catch {
+    return null
+  }
+  return null
+}
+
+function openAllowedExternal(url: string): void {
+  const allowed = allowedExternalUrl(url)
+  if (allowed) void shell.openExternal(allowed)
+}
+
 // Dev keeps its own dir so testing never leaks into the real install's ~/.surfsense.
 const DATA_DIR = join(
   app.getPath("home"),
@@ -108,6 +129,18 @@ function registerDocumentHandlers(dataDir: string): void {
     }
   })
 
+  ipcMain.handle("shell:open-external", async (event, url) => {
+    if (
+      !trusted(event.sender) ||
+      event.senderFrame !== event.sender.mainFrame ||
+      typeof url !== "string"
+    ) {
+      return
+    }
+    const allowed = allowedExternalUrl(url)
+    if (allowed) await shell.openExternal(allowed)
+  })
+
   ipcMain.handle("documents:reveal", async (event, workspaceId, documentId) => {
     if (
       !trusted(event.sender) ||
@@ -184,7 +217,22 @@ async function shutdown(): Promise<void> {
   if (sidecars) await stopAll(sidecars)
 }
 
+function denyAppWindows(contents: Electron.WebContents): void {
+  contents.setWindowOpenHandler(({ url }) => {
+    openAllowedExternal(url)
+    return { action: "deny" }
+  })
+  contents.on("will-navigate", (event, url) => {
+    if (!url.startsWith("https:")) return
+    event.preventDefault()
+    openAllowedExternal(url)
+  })
+}
+
 function main(): void {
+  app.on("web-contents-created", (_event, contents) => {
+    denyAppWindows(contents)
+  })
   app
     .whenReady()
     .then(async () => {

--- a/surfsense_local/electron/src/preload/index.ts
+++ b/surfsense_local/electron/src/preload/index.ts
@@ -16,4 +16,6 @@ contextBridge.exposeInMainWorld("surfsense", {
     color: string
     symbolColor: string
   }): Promise<void> => ipcRenderer.invoke("shell:titlebar-overlay", overlay),
+  openExternal: (url: string): Promise<void> =>
+    ipcRenderer.invoke("shell:open-external", url),
 })

--- a/surfsense_local/frontend/src/app/app-bootstrap.tsx
+++ b/surfsense_local/frontend/src/app/app-bootstrap.tsx
@@ -25,6 +25,7 @@ type BootstrapState =
   | {
       status: "ready"
       selection: ModelSelection | null
+      providerAvailable: boolean
       workspaces: Workspace[]
     }
   | { status: "error"; message: string }
@@ -66,7 +67,12 @@ async function fetchBootstrapState(): Promise<BootstrapState> {
         ? selection
         : null
     }
-    return { status: "ready", selection: currentSelection, workspaces }
+    return {
+      status: "ready",
+      selection: currentSelection,
+      providerAvailable: currentSelection !== null,
+      workspaces,
+    }
   } catch (error) {
     return { status: "error", message: messageFrom(error) }
   }
@@ -125,7 +131,12 @@ export function AppBootstrap() {
           setState({ status: "loading" })
           void listWorkspaces()
             .then((workspaces) =>
-              setState({ status: "ready", selection, workspaces })
+              setState({
+                status: "ready",
+                selection,
+                providerAvailable: true,
+                workspaces,
+              })
             )
             .catch((error: unknown) =>
               setState({ status: "error", message: messageFrom(error) })
@@ -163,6 +174,7 @@ export function AppBootstrap() {
     <Suspense fallback={<GlobalLoader />}>
       <DashboardPage
         selection={state.selection}
+        initialProviderAvailable={state.providerAvailable}
         initialWorkspaces={state.workspaces}
         onModelUnavailable={() =>
           setState((current) =>

--- a/surfsense_local/frontend/src/components/relative-time.tsx
+++ b/surfsense_local/frontend/src/components/relative-time.tsx
@@ -86,7 +86,7 @@ export function RelativeTime({
         <time
           dateTime={date.toISOString()}
           className={cn(
-            "inline-flex h-7 cursor-default items-center text-xs",
+            "inline-flex h-7 cursor-default items-center text-xs select-none",
             className
           )}
         >

--- a/surfsense_local/frontend/src/components/theme-provider.tsx
+++ b/surfsense_local/frontend/src/components/theme-provider.tsx
@@ -18,6 +18,7 @@ type ThemeProviderState = {
 
 const COLOR_SCHEME_QUERY = "(prefers-color-scheme: dark)"
 const THEME_VALUES: Theme[] = ["dark", "light", "system"]
+export const THEME_STORAGE_KEY = "surfsense:theme:v1"
 
 const ThemeProviderContext = React.createContext<
   ThemeProviderState | undefined
@@ -92,7 +93,7 @@ function isEditableTarget(target: EventTarget | null) {
 export function ThemeProvider({
   children,
   defaultTheme = "system",
-  storageKey = "theme",
+  storageKey = THEME_STORAGE_KEY,
   disableTransitionOnChange = true,
   ...props
 }: ThemeProviderProps) {

--- a/surfsense_local/frontend/src/components/ui/icons.tsx
+++ b/surfsense_local/frontend/src/components/ui/icons.tsx
@@ -28,8 +28,8 @@ import {
   FolderOpenIcon as FolderOpenIconData,
   Image01Icon as Image01IconData,
   InformationCircleIcon as InformationCircleIconData,
-  KeyRoundIcon as KeyRoundIconData,
   LayoutGridIcon as LayoutGridIconData,
+  LicenseIcon as LicenseIconData,
   Loading03Icon,
   MessageSquareIcon as MessageSquareIconData,
   Moon02Icon as Moon02IconData,
@@ -112,8 +112,8 @@ export const FolderLibraryIcon = createIcon(FolderLibraryIconData)
 export const FolderOpenIcon = createIcon(FolderOpenIconData)
 export const Image01Icon = createIcon(Image01IconData)
 export const InformationCircleIcon = createIcon(InformationCircleIconData)
-export const KeyRoundIcon = createIcon(KeyRoundIconData)
 export const LayoutGridIcon = createIcon(LayoutGridIconData)
+export const LicenseIcon = createIcon(LicenseIconData)
 export const Loader2Icon = createIcon(Loading03Icon)
 export const MessageSquareIcon = createIcon(MessageSquareIconData)
 export const MoonIcon = createIcon(Moon02IconData)

--- a/surfsense_local/frontend/src/components/ui/icons.tsx
+++ b/surfsense_local/frontend/src/components/ui/icons.tsx
@@ -27,6 +27,7 @@ import {
   FolderLibraryIcon as FolderLibraryIconData,
   FolderOpenIcon as FolderOpenIconData,
   Image01Icon as Image01IconData,
+  InformationCircleIcon as InformationCircleIconData,
   KeyRoundIcon as KeyRoundIconData,
   LayoutGridIcon as LayoutGridIconData,
   Loading03Icon,
@@ -51,6 +52,7 @@ import {
   SquareDashedMousePointerIcon as SquareDashedMousePointerIconData,
   StopCircleIcon,
   Sun03Icon as Sun03IconData,
+  Upload01Icon as Upload01IconData,
   ComputerIcon as ComputerIconData,
   ViewIcon as ViewIconData,
   WebDesign01Icon as WebDesign01IconData,
@@ -109,6 +111,7 @@ export const FileTextIcon = createIcon(FileTextIconData)
 export const FolderLibraryIcon = createIcon(FolderLibraryIconData)
 export const FolderOpenIcon = createIcon(FolderOpenIconData)
 export const Image01Icon = createIcon(Image01IconData)
+export const InformationCircleIcon = createIcon(InformationCircleIconData)
 export const KeyRoundIcon = createIcon(KeyRoundIconData)
 export const LayoutGridIcon = createIcon(LayoutGridIconData)
 export const Loader2Icon = createIcon(Loading03Icon)
@@ -131,6 +134,7 @@ export const Settings2Icon = createIcon(Settings02Icon)
 export const Shapes01Icon = createIcon(Shapes01IconData)
 export const SparklesIcon = createIcon(SparklesIconData)
 export const SunIcon = createIcon(Sun03IconData)
+export const Upload01Icon = createIcon(Upload01IconData)
 export const ComputerIcon = createIcon(ComputerIconData)
 export const SquareDashedMousePointerIcon = createIcon(
   SquareDashedMousePointerIconData

--- a/surfsense_local/frontend/src/components/ui/skeleton.tsx
+++ b/surfsense_local/frontend/src/components/ui/skeleton.tsx
@@ -10,4 +10,16 @@ function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
-export { Skeleton }
+const SLAB_WIDTHS = ["w-[88%]", "w-[62%]", "w-[76%]", "w-[54%]"]
+
+function SkeletonSlabs() {
+  return (
+    <div className="flex flex-col gap-1.5">
+      {SLAB_WIDTHS.map((width) => (
+        <Skeleton key={width} className={cn("h-8 rounded-xl", width)} />
+      ))}
+    </div>
+  )
+}
+
+export { Skeleton, SkeletonSlabs }

--- a/surfsense_local/frontend/src/features/chat/chat-composer.tsx
+++ b/surfsense_local/frontend/src/features/chat/chat-composer.tsx
@@ -167,6 +167,8 @@ export function ChatComposer({
           />
         ) : null}
         <ComposerPrimitive.Input
+          autoFocus
+          unstable_focusOnThreadSwitched
           disabled={!model}
           className={cn(
             "max-h-44 resize-none bg-transparent px-2 py-2.5 text-sm outline-none placeholder:text-muted-foreground",

--- a/surfsense_local/frontend/src/features/chat/message.tsx
+++ b/surfsense_local/frontend/src/features/chat/message.tsx
@@ -101,7 +101,7 @@ function MessageActions({
   return (
     <div
       className={cn(
-        "relative flex h-7 items-center gap-2 text-muted-foreground",
+        "relative flex h-7 items-center gap-2 text-muted-foreground select-none",
         className
       )}
     >

--- a/surfsense_local/frontend/src/features/chat/model-picker.tsx
+++ b/surfsense_local/frontend/src/features/chat/model-picker.tsx
@@ -29,7 +29,7 @@ import { cn } from "@/lib/utils"
 
 const installedModelsQueryKey = ["installed-generation-models"] as const
 export const modelControlButtonClassName =
-  "flex shrink-0 cursor-pointer select-none items-center gap-1.5 rounded-lg px-1.5 py-1 text-[11px] font-normal text-muted-foreground hover:bg-accent hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/20 focus-visible:outline-none"
+  "flex shrink-0 cursor-pointer select-none items-center gap-1.5 rounded-lg px-1.5 py-1 text-[11px] font-normal text-muted-foreground hover:bg-accent hover:text-foreground aria-expanded:bg-accent aria-expanded:text-foreground focus-visible:ring-2 focus-visible:ring-ring/20 focus-visible:outline-none"
 
 export function ModelPicker({
   model,

--- a/surfsense_local/frontend/src/features/chat/thread-list.test.tsx
+++ b/surfsense_local/frontend/src/features/chat/thread-list.test.tsx
@@ -130,8 +130,8 @@ describe("ThreadList", () => {
 
     expect(screen.getByRole("button", { name: "Recents" })).toBeTruthy()
     expect(
-      screen.getByText("Start a conversation to see it here")
-    ).toBeTruthy()
+      screen.getByText("Start a conversation to see it here").className
+    ).toContain("select-none")
     expect(screen.queryByText("No chats yet")).toBeNull()
   })
 })

--- a/surfsense_local/frontend/src/features/chat/thread-list.tsx
+++ b/surfsense_local/frontend/src/features/chat/thread-list.tsx
@@ -58,6 +58,7 @@ export function RenameChatDialog({
   return (
     <Dialog open onOpenChange={(open) => !open && onClose()}>
       <DialogContent
+        className="select-none"
         onOpenAutoFocus={(event) => {
           event.preventDefault()
           const input = inputRef.current
@@ -145,7 +146,7 @@ export function ThreadList({
         <div className="flex w-full max-w-full min-w-0 flex-col gap-1">
           <button
             type="button"
-            className="group flex min-h-7 items-center gap-1 px-2 text-xs font-medium text-muted-foreground transition-colors select-none hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            className="group flex min-h-7 items-center gap-1 px-2 text-xs font-semibold text-muted-foreground transition-colors select-none hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             aria-expanded={recentsOpen}
             onClick={() => setRecentsOpen((open) => !open)}
           >
@@ -165,7 +166,7 @@ export function ThreadList({
                   ))
                 : null}
               {!isLoading && threads.length === 0 ? (
-                <p className="px-2 py-1 text-sm text-muted-foreground">
+                <p className="px-2 py-1 text-sm text-muted-foreground select-none">
                   Start a conversation to see it here
                 </p>
               ) : null}

--- a/surfsense_local/frontend/src/features/chat/thread-list.tsx
+++ b/surfsense_local/frontend/src/features/chat/thread-list.tsx
@@ -26,7 +26,7 @@ import {
 } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
 import { ScrollShadow } from "@/components/ui/scroll-shadow"
-import { Skeleton } from "@/components/ui/skeleton"
+import { SkeletonSlabs } from "@/components/ui/skeleton"
 import { TypewriterText } from "@/components/typewriter-text"
 import { cn } from "@/lib/utils"
 
@@ -160,11 +160,7 @@ export function ThreadList({
           </button>
           {recentsOpen ? (
             <>
-              {isLoading
-                ? [0, 1, 2, 3].map((item) => (
-                    <Skeleton key={item} className="h-11 w-full" />
-                  ))
-                : null}
+              {isLoading ? <SkeletonSlabs /> : null}
               {!isLoading && threads.length === 0 ? (
                 <p className="px-2 py-1 text-sm text-muted-foreground select-none">
                   Start a conversation to see it here

--- a/surfsense_local/frontend/src/features/chat/thread-panel.tsx
+++ b/surfsense_local/frontend/src/features/chat/thread-panel.tsx
@@ -176,11 +176,7 @@ export function ThreadPanel({
         aria-label="Conversation"
       >
         <header className="flex h-14 shrink-0 items-center px-5">
-          {thread == null ? (
-            <h2 className="px-1.5 font-heading text-base font-medium">
-              New chat
-            </h2>
-          ) : editing ? (
+          {thread == null ? null : editing ? (
             <Input
               ref={titleInputRef}
               value={draft}

--- a/surfsense_local/frontend/src/features/chat/thread-panel.tsx
+++ b/surfsense_local/frontend/src/features/chat/thread-panel.tsx
@@ -115,18 +115,20 @@ export function ThreadPanel({
   onRename: (id: number, title: string) => Promise<boolean>
   onDelete: (id: number) => Promise<void>
 }) {
-  const titleButtonRef = useRef<HTMLButtonElement>(null)
   const titleInputRef = useRef<HTMLInputElement>(null)
   const ignoreMenuFocusRef = useRef(false)
-  const [editing, setEditing] = useState(false)
+  const [editingThreadId, setEditingThreadId] = useState<number | null>(null)
   const [draft, setDraft] = useState("")
-  const threadId = thread?.id
   const title = thread?.title || "New chat"
+  const conversationId =
+    view.status === "active" ? `thread:${view.threadId}` : view.status
+  const editing = thread != null && editingThreadId === thread.id
   const canRename =
     thread != null && thread.id !== autoNamingThreadId && !animateTitle
   const bottomComposer = view.status === "creating" || view.status === "active"
   const composer = (placement: "center" | "bottom") => (
     <ChatComposer
+      key={conversationId}
       placement={placement}
       model={model}
       isRunning={isRunning}
@@ -139,13 +141,6 @@ export function ThreadPanel({
   )
 
   useEffect(() => {
-    setEditing(false)
-    if (threadId !== undefined) {
-      titleButtonRef.current?.focus()
-    }
-  }, [threadId])
-
-  useEffect(() => {
     if (editing) {
       const input = titleInputRef.current
       if (!input) return
@@ -155,20 +150,20 @@ export function ThreadPanel({
   }, [editing])
 
   const startEditing = () => {
-    if (!canRename || title == null) return
+    if (!canRename || thread == null) return
     setDraft(title)
-    setEditing(true)
+    setEditingThreadId(thread.id)
   }
 
   const cancelEditing = () => {
-    setEditing(false)
-    setDraft(title ?? "")
+    setEditingThreadId(null)
+    setDraft(title)
   }
 
   const commitEditing = () => {
     if (!thread || !editing) return
     const next = draft.trim()
-    setEditing(false)
+    setEditingThreadId(null)
     if (!next || next === (thread.title || "New chat")) return
     void onRename(thread.id, next)
   }
@@ -205,7 +200,6 @@ export function ThreadPanel({
           ) : (
             <ButtonGroup aria-label="Chat">
               <Button
-                ref={titleButtonRef}
                 type="button"
                 variant="ghost"
                 disabled={!canRename}

--- a/surfsense_local/frontend/src/features/chat/thread-panel.tsx
+++ b/surfsense_local/frontend/src/features/chat/thread-panel.tsx
@@ -175,9 +175,12 @@ export function ThreadPanel({
         className="flex h-full min-w-0 flex-col bg-background"
         aria-label="Conversation"
       >
-        {thread != null ? (
         <header className="flex h-14 shrink-0 items-center px-5">
-          {editing ? (
+          {thread == null ? (
+            <h2 className="px-1.5 font-heading text-base font-medium">
+              New chat
+            </h2>
+          ) : editing ? (
             <Input
               ref={titleInputRef}
               value={draft}
@@ -261,7 +264,6 @@ export function ThreadPanel({
             </ButtonGroup>
           )}
         </header>
-        ) : null}
 
         {error ? (
           <Alert variant="destructive" className="m-4 mb-0 w-auto">
@@ -282,9 +284,15 @@ export function ThreadPanel({
             footer={bottomComposer ? composer("bottom") : undefined}
           >
             {view.status === "initializing" || isLoading ? (
-              <div className="mx-auto w-full max-w-2xl space-y-4 p-6">
-                <Skeleton className="ml-auto h-16 w-2/3" />
-                <Skeleton className="h-24 w-4/5" />
+              <div className="mx-auto flex w-full max-w-xl flex-col">
+                <div className="flex flex-col items-end px-6 py-3">
+                  <Skeleton className="h-10 w-[42%] rounded-2xl rounded-br-md" />
+                </div>
+                <div className="flex flex-col items-start gap-2 px-6 py-4">
+                  <Skeleton className="h-4 w-[92%]" />
+                  <Skeleton className="h-4 w-[80%]" />
+                  <Skeleton className="h-4 w-[58%]" />
+                </div>
               </div>
             ) : null}
 

--- a/surfsense_local/frontend/src/features/chat/thread-panel.tsx
+++ b/surfsense_local/frontend/src/features/chat/thread-panel.tsx
@@ -67,7 +67,7 @@ function ComposerDraftLifecycle({ view }: { view: ConversationView }) {
     view.status === "active" ? `thread:${view.threadId}` : view.status
 
   useEffect(() => {
-    if (conversationId === "initializing" || conversationId === "creating") {
+    if (conversationId === "creating") {
       return
     }
     void aui.thread.composer().reset()
@@ -279,7 +279,7 @@ export function ThreadPanel({
           <ChatViewport
             footer={bottomComposer ? composer("bottom") : undefined}
           >
-            {view.status === "initializing" || isLoading ? (
+            {isLoading ? (
               <div className="mx-auto flex w-full max-w-xl flex-col">
                 <div className="flex flex-col items-end px-6 py-3">
                   <Skeleton className="h-10 w-[42%] rounded-2xl rounded-br-md" />

--- a/surfsense_local/frontend/src/features/chat/use-chat-runtime.ts
+++ b/surfsense_local/frontend/src/features/chat/use-chat-runtime.ts
@@ -40,7 +40,7 @@ const EMPTY_THREADS: ChatThread[] = []
 const EMPTY_MESSAGES: ChatMessage[] = []
 
 function lastThreadKey(workspaceId: number) {
-  return `surfsense-local:last-thread:${workspaceId}:v1`
+  return `surfsense:last-thread:${workspaceId}:v1`
 }
 
 function rememberThread(workspaceId: number, threadId: number | null) {

--- a/surfsense_local/frontend/src/features/chat/use-chat-runtime.ts
+++ b/surfsense_local/frontend/src/features/chat/use-chat-runtime.ts
@@ -43,28 +43,36 @@ function lastThreadKey(workspaceId: number) {
   return `surfsense:last-thread:${workspaceId}:v1`
 }
 
+const NEW_CHAT = "new"
+
+export type ConversationView =
+  | { status: "new" }
+  | { status: "creating" }
+  | { status: "active"; threadId: number }
+
 function rememberThread(workspaceId: number, threadId: number | null) {
   try {
-    if (threadId === null) {
-      localStorage.removeItem(lastThreadKey(workspaceId))
-    } else {
-      localStorage.setItem(lastThreadKey(workspaceId), String(threadId))
-    }
+    localStorage.setItem(
+      lastThreadKey(workspaceId),
+      threadId === null ? NEW_CHAT : String(threadId)
+    )
   } catch {
     // Selection remains valid for this session when storage is unavailable.
   }
 }
 
-function initialThreadId(workspaceId: number, threads: ChatThread[]) {
+function readStoredView(workspaceId: number): ConversationView {
   try {
-    const stored = Number(localStorage.getItem(lastThreadKey(workspaceId)))
-    if (threads.some((thread) => thread.id === stored)) {
-      return stored
+    const stored = localStorage.getItem(lastThreadKey(workspaceId))
+    if (stored === NEW_CHAT) return { status: "new" }
+    const id = Number(stored)
+    if (Number.isInteger(id) && id > 0) {
+      return { status: "active", threadId: id }
     }
   } catch {
-    // The newest thread below is a safe fallback.
+    // Private browsing: treat as a new chat.
   }
-  return threads[0]?.id ?? null
+  return { status: "new" }
 }
 
 function hasCanonicalTurn(
@@ -105,12 +113,6 @@ function toRuntimeMessage(message: ChatMessage): ThreadMessageLike {
   }
 }
 
-export type ConversationView =
-  | { status: "initializing" }
-  | { status: "new" }
-  | { status: "creating" }
-  | { status: "active"; threadId: number }
-
 export function useChatRuntime({
   workspaceId,
   canSend,
@@ -123,8 +125,8 @@ export function useChatRuntime({
   onModelRequired: () => void
 }) {
   const queryClient = useQueryClient()
-  const [selectedView, setConversationView] = useState<ConversationView | null>(
-    null
+  const [conversationView, setConversationView] = useState<ConversationView>(
+    () => readStoredView(workspaceId)
   )
   const [liveMessages, setLiveMessages] = useState<ChatMessage[] | null>(null)
   const [isRunning, setIsRunning] = useState(false)
@@ -143,16 +145,6 @@ export function useChatRuntime({
     queryFn: ({ signal }) => listThreads(workspaceId, signal),
   })
   const threads = threadsQuery.data ?? EMPTY_THREADS
-  const initialView = useMemo<ConversationView>(() => {
-    if (!threadsQuery.isSuccess) {
-      return { status: "initializing" }
-    }
-    const threadId = initialThreadId(workspaceId, threads)
-    return threadId === null
-      ? { status: "new" }
-      : { status: "active", threadId }
-  }, [threads, threadsQuery.isSuccess, workspaceId])
-  const conversationView = selectedView ?? initialView
   const activeThreadId =
     conversationView.status === "active" ? conversationView.threadId : null
 
@@ -219,6 +211,23 @@ export function useChatRuntime({
     setAnimatingTitleThreadId(null)
   }, [workspaceId])
 
+  useEffect(() => {
+    if (!threadsQuery.isSuccess) return
+    if (conversationView.status !== "active") return
+    if (threads.some((thread) => thread.id === conversationView.threadId)) {
+      return
+    }
+    const fallback = threads[0]
+    if (fallback) selectThread(fallback.id)
+    else startNewChat()
+  }, [
+    conversationView,
+    selectThread,
+    startNewChat,
+    threads,
+    threadsQuery.isSuccess,
+  ])
+
   const removeThread = async (threadId: number) => {
     try {
       await deleteThreadMutation.mutateAsync(threadId)
@@ -264,7 +273,6 @@ export function useChatRuntime({
         !text ||
         isRunning ||
         !canSend ||
-        conversationView.status === "initializing" ||
         conversationView.status === "creating"
       ) {
         return

--- a/surfsense_local/frontend/src/features/dashboard/chrome-prefs.ts
+++ b/surfsense_local/frontend/src/features/dashboard/chrome-prefs.ts
@@ -1,0 +1,38 @@
+import type { RightTab } from "./right-panel"
+
+export const RIGHT_RAIL_KEY = "surfsense:right-rail:v1"
+export const RIGHT_TAB_KEY = "surfsense:right-tab:v1"
+
+export function readRightRailOpen() {
+  try {
+    return localStorage.getItem(RIGHT_RAIL_KEY) !== "collapsed"
+  } catch {
+    return true
+  }
+}
+
+export function writeRightRailOpen(open: boolean) {
+  try {
+    localStorage.setItem(RIGHT_RAIL_KEY, open ? "open" : "collapsed")
+  } catch {
+    // Private browsing and full disks throw.
+  }
+}
+
+export function readRightTab(): RightTab {
+  try {
+    return localStorage.getItem(RIGHT_TAB_KEY) === "artifacts"
+      ? "artifacts"
+      : "sources"
+  } catch {
+    return "sources"
+  }
+}
+
+export function writeRightTab(tab: RightTab) {
+  try {
+    localStorage.setItem(RIGHT_TAB_KEY, tab)
+  } catch {
+    // Private browsing and full disks throw.
+  }
+}

--- a/surfsense_local/frontend/src/features/dashboard/dashboard-page.test.tsx
+++ b/surfsense_local/frontend/src/features/dashboard/dashboard-page.test.tsx
@@ -23,6 +23,13 @@ const workspace = {
   updated_at: "2026-09-05T00:00:00Z",
 }
 
+function rememberOpenThread(workspaceId: number, threadId: number) {
+  localStorage.setItem(
+    `surfsense:last-thread:${workspaceId}:v1`,
+    String(threadId)
+  )
+}
+
 afterEach(() => {
   cleanup()
   vi.useRealTimers()
@@ -107,6 +114,7 @@ describe("dashboard chat", () => {
     )
     vi.stubGlobal("fetch", fetchMock)
     const user = userEvent.setup()
+    rememberOpenThread(1, 10)
 
     render(
       <ThemeProvider>
@@ -186,6 +194,7 @@ describe("dashboard chat", () => {
       })
     )
     const user = userEvent.setup()
+    rememberOpenThread(1, 10)
 
     render(
       <ThemeProvider>
@@ -305,7 +314,15 @@ describe("dashboard chat", () => {
       </TooltipProvider>
     )
 
-    expect(screen.queryByRole("textbox", { name: "Message" })).toBeNull()
+    const conversationWhileLoading = screen.getByRole("region", {
+      name: "Conversation",
+    })
+    expect(
+      await screen.findByRole("textbox", { name: "Message" })
+    ).toBeTruthy()
+    expect(
+      conversationWhileLoading.querySelector('[data-slot="skeleton"]')
+    ).toBeNull()
     expect(screen.queryByRole("heading", { name: "New chat" })).toBeNull()
 
     resolveThreads(Response.json([]))
@@ -397,6 +414,154 @@ describe("dashboard chat", () => {
       ).toBeTruthy()
       expect((resetInput as HTMLTextAreaElement).value).toBe("")
     })
+  })
+
+  it("keeps a new chat after remount", async () => {
+    const thread = {
+      id: 10,
+      workspace_id: 1,
+      title: "Original title",
+      created_at: "2026-09-05T00:00:00Z",
+      updated_at: "2026-09-05T00:00:00Z",
+    }
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const path = String(input)
+      if (path === "/llm/providers") {
+        return Response.json([
+          { name: "ollama", healthy: true, can_download: true },
+        ])
+      }
+      if (
+        path === "/workspaces/1/documents?document_type=FILE&document_type=NOTE"
+      ) {
+        return Response.json([])
+      }
+      if (path === "/workspaces/1/chat/threads") return Response.json([thread])
+      if (path === "/chat/threads/10/messages") return Response.json([])
+      return Response.json({ detail: "not found" }, { status: 404 })
+    })
+    vi.stubGlobal("fetch", fetchMock)
+    const user = userEvent.setup()
+    rememberOpenThread(1, 10)
+    const page = (
+      <TooltipProvider>
+        <DashboardPage
+          selection={{
+            role: "generation",
+            provider: "ollama",
+            connection_id: null,
+            name: "llama3.2:1b",
+            updated_at: "2026-09-05T00:00:00Z",
+          }}
+          initialWorkspaces={[workspace]}
+          onModelSelected={vi.fn()}
+        />
+      </TooltipProvider>
+    )
+
+    render(page)
+    expect(
+      await within(screen.getByRole("region", { name: "Conversation" })).findByRole(
+        "button",
+        { name: "Original title" }
+      )
+    ).toBeTruthy()
+    await user.click(screen.getByRole("button", { name: "New chat" }))
+    await waitFor(() => {
+      expect(
+        screen
+          .getByRole("textbox", { name: "Message" })
+          .closest('[data-composer-placement="center"]')
+      ).toBeTruthy()
+    })
+    expect(
+      within(screen.getByRole("region", { name: "Conversation" })).queryByRole(
+        "button",
+        { name: "Original title" }
+      )
+    ).toBeNull()
+
+    cleanup()
+    render(page)
+    const input = await screen.findByRole("textbox", { name: "Message" })
+    expect(input.closest('[data-composer-placement="center"]')).toBeTruthy()
+    expect(
+      within(screen.getByRole("region", { name: "Conversation" })).queryByRole(
+        "button",
+        { name: "Original title" }
+      )
+    ).toBeNull()
+  })
+
+  it("shows message skeletons only while a loaded chat’s messages load", async () => {
+    const thread = {
+      id: 10,
+      workspace_id: 1,
+      title: "Original title",
+      created_at: "2026-09-05T00:00:00Z",
+      updated_at: "2026-09-05T00:00:00Z",
+    }
+    let resolveMessages!: (response: Response) => void
+    const messagesResponse = new Promise<Response>((resolve) => {
+      resolveMessages = resolve
+    })
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const path = String(input)
+        if (path === "/llm/providers") {
+          return Response.json([
+            { name: "ollama", healthy: true, can_download: true },
+          ])
+        }
+        if (
+          path ===
+          "/workspaces/1/documents?document_type=FILE&document_type=NOTE"
+        ) {
+          return Response.json([])
+        }
+        if (path === "/workspaces/1/chat/threads") return Response.json([thread])
+        if (path === "/chat/threads/10/messages") return messagesResponse
+        return Response.json({ detail: "not found" }, { status: 404 })
+      })
+    )
+    rememberOpenThread(1, 10)
+
+    render(
+      <TooltipProvider>
+        <DashboardPage
+          selection={{
+            role: "generation",
+            provider: "ollama",
+            connection_id: null,
+            name: "llama3.2:1b",
+            updated_at: "2026-09-05T00:00:00Z",
+          }}
+          initialWorkspaces={[workspace]}
+          onModelSelected={vi.fn()}
+        />
+      </TooltipProvider>
+    )
+
+    const conversation = screen.getByRole("region", { name: "Conversation" })
+    await waitFor(() => {
+      expect(conversation.querySelector('[data-slot="skeleton"]')).toBeTruthy()
+    })
+    expect(
+      screen
+        .queryByRole("textbox", { name: "Message" })
+        ?.closest('[data-composer-placement="center"]')
+    ).toBeNull()
+
+    resolveMessages(Response.json([]))
+    await waitFor(() => {
+      expect(conversation.querySelector('[data-slot="skeleton"]')).toBeNull()
+    })
+    expect(
+      screen
+        .getByRole("textbox", { name: "Message" })
+        .closest('[data-composer-placement="bottom"]')
+    ).toBeTruthy()
   })
 
   it("creates a thread on first send and scopes retrieval to selected sources", async () => {

--- a/surfsense_local/frontend/src/features/dashboard/dashboard-page.test.tsx
+++ b/surfsense_local/frontend/src/features/dashboard/dashboard-page.test.tsx
@@ -13,6 +13,7 @@ import { DETAIL_RAIL_WIDTH, MAIN_RAIL_WIDTH } from "@/components/ui/slide-rail"
 import { TooltipProvider } from "@/components/ui/tooltip"
 import { render } from "@/test-utils"
 
+import { RIGHT_TAB_KEY } from "./chrome-prefs"
 import { DashboardPage } from "./dashboard-page"
 
 const workspace = {
@@ -1018,6 +1019,62 @@ describe("dashboard chat", () => {
       screen
         .getByRole("tab", { name: "Artifacts" })
         .getAttribute("aria-selected")
+    ).toBe("true")
+  })
+
+  it("remembers the sources and artifacts tab across remounts", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const path = String(input)
+      if (path === "/llm/providers") {
+        return Response.json([
+          { name: "ollama", healthy: true, can_download: true },
+        ])
+      }
+      if (
+        path === "/workspaces/1/documents?document_type=FILE&document_type=NOTE"
+      ) {
+        return Response.json([])
+      }
+      if (path === "/workspaces/1/chat/threads") return Response.json([])
+      if (path === "/workspaces/1/studio/formats") return Response.json([])
+      if (path === "/workspaces/1/artifacts") return Response.json([])
+      return Response.json({ detail: "not found" }, { status: 404 })
+    })
+    vi.stubGlobal("fetch", fetchMock)
+    const user = userEvent.setup()
+    const page = (
+      <TooltipProvider>
+        <DashboardPage
+          selection={{
+            role: "generation",
+            provider: "ollama",
+            connection_id: null,
+            name: "llama3.2:1b",
+            updated_at: "2026-09-05T00:00:00Z",
+          }}
+          initialWorkspaces={[workspace]}
+          onModelSelected={vi.fn()}
+        />
+      </TooltipProvider>
+    )
+
+    render(page)
+    expect(
+      await screen.findByRole("complementary", { name: "Workspace sources" })
+    ).toBeTruthy()
+    await user.click(screen.getByRole("tab", { name: "Artifacts" }))
+    expect(localStorage.getItem(RIGHT_TAB_KEY)).toBe("artifacts")
+    expect(
+      screen.getByRole("tab", { name: "Artifacts" }).getAttribute("aria-selected")
+    ).toBe("true")
+
+    cleanup()
+    render(page)
+    expect(
+      await screen.findByRole("complementary", { name: "Workspace artifacts" })
+    ).toBeTruthy()
+    expect(
+      screen.getByRole("tab", { name: "Artifacts" }).getAttribute("aria-selected")
     ).toBe("true")
   })
 })

--- a/surfsense_local/frontend/src/features/dashboard/dashboard-page.test.tsx
+++ b/surfsense_local/frontend/src/features/dashboard/dashboard-page.test.tsx
@@ -305,12 +305,12 @@ describe("dashboard chat", () => {
     )
 
     expect(screen.queryByRole("textbox", { name: "Message" })).toBeNull()
-    expect(screen.queryByRole("heading", { name: "New chat" })).toBeNull()
+    expect(screen.getByRole("heading", { name: "New chat" })).toBeTruthy()
 
     resolveThreads(Response.json([]))
     const input = await screen.findByRole("textbox", { name: "Message" })
     const addSources = screen.getByRole("button", { name: "Add sources" })
-    expect(screen.queryByRole("heading", { name: "New chat" })).toBeNull()
+    expect(screen.getByRole("heading", { name: "New chat" })).toBeTruthy()
     expect(input.closest('[data-composer-placement="center"]')).toBeTruthy()
     expect(
       addSources.closest('[data-composer-placement="center"]')
@@ -323,7 +323,7 @@ describe("dashboard chat", () => {
       '[data-slot="scroll-shadow-top"]'
     )
     expect(conversation.parentElement?.className).toContain("flex-1")
-    expect(conversation.querySelector("header")).toBeNull()
+    expect(conversation.querySelector("header")).toBeTruthy()
     expect(topShadow).toBeTruthy()
     expect(
       conversation.querySelector('[data-slot="scroll-shadow-bottom"]')

--- a/surfsense_local/frontend/src/features/dashboard/dashboard-page.test.tsx
+++ b/surfsense_local/frontend/src/features/dashboard/dashboard-page.test.tsx
@@ -152,6 +152,83 @@ describe("dashboard chat", () => {
     expect(screen.getByRole("heading", { name: "Appearance" })).toBeTruthy()
   })
 
+  it("focuses the composer when opening a chat, not the title", async () => {
+    const thread = {
+      id: 10,
+      workspace_id: 1,
+      title: "Original title",
+      created_at: "2026-09-05T00:00:00Z",
+      updated_at: "2026-09-05T00:00:00Z",
+    }
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const path = String(input)
+        if (path === "/llm/providers") {
+          return Response.json([
+            { name: "ollama", healthy: true, can_download: true },
+          ])
+        }
+        if (
+          path ===
+          "/workspaces/1/documents?document_type=FILE&document_type=NOTE"
+        ) {
+          return Response.json([])
+        }
+        if (path === "/workspaces/1/chat/threads") {
+          return Response.json([thread])
+        }
+        if (path === "/chat/threads/10/messages") {
+          return Response.json([])
+        }
+        return Response.json({ detail: "not found" }, { status: 404 })
+      })
+    )
+    const user = userEvent.setup()
+
+    render(
+      <ThemeProvider>
+        <TooltipProvider>
+          <DashboardPage
+            selection={{
+              role: "generation",
+              provider: "ollama",
+              connection_id: null,
+              name: "llama3.2:1b",
+              updated_at: "2026-09-05T00:00:00Z",
+            }}
+            initialWorkspaces={[workspace]}
+            onModelSelected={vi.fn()}
+          />
+        </TooltipProvider>
+      </ThemeProvider>
+    )
+
+    const conversation = screen.getByRole("region", { name: "Conversation" })
+    await waitFor(() => {
+      expect(document.activeElement).toBe(
+        screen.getByRole("textbox", { name: "Message" })
+      )
+    })
+    expect(
+      within(conversation).getByRole("button", { name: "Original title" })
+    ).not.toBe(document.activeElement)
+
+    await user.click(screen.getByRole("button", { name: "New chat" }))
+    await waitFor(() => {
+      expect(document.activeElement).toBe(
+        screen.getByRole("textbox", { name: "Message" })
+      )
+    })
+
+    await user.click(screen.getByRole("button", { name: "Original title" }))
+    await waitFor(() => {
+      expect(document.activeElement).toBe(
+        screen.getByRole("textbox", { name: "Message" })
+      )
+    })
+  })
+
   it("keeps composer placement aligned with the conversation lifecycle", async () => {
     let resolveThreads!: (response: Response) => void
     let resolveCreate!: (response: Response) => void

--- a/surfsense_local/frontend/src/features/dashboard/dashboard-page.test.tsx
+++ b/surfsense_local/frontend/src/features/dashboard/dashboard-page.test.tsx
@@ -306,12 +306,12 @@ describe("dashboard chat", () => {
     )
 
     expect(screen.queryByRole("textbox", { name: "Message" })).toBeNull()
-    expect(screen.getByRole("heading", { name: "New chat" })).toBeTruthy()
+    expect(screen.queryByRole("heading", { name: "New chat" })).toBeNull()
 
     resolveThreads(Response.json([]))
     const input = await screen.findByRole("textbox", { name: "Message" })
     const addSources = screen.getByRole("button", { name: "Add sources" })
-    expect(screen.getByRole("heading", { name: "New chat" })).toBeTruthy()
+    expect(screen.queryByRole("heading", { name: "New chat" })).toBeNull()
     expect(input.closest('[data-composer-placement="center"]')).toBeTruthy()
     expect(
       addSources.closest('[data-composer-placement="center"]')

--- a/surfsense_local/frontend/src/features/dashboard/dashboard-page.test.tsx
+++ b/surfsense_local/frontend/src/features/dashboard/dashboard-page.test.tsx
@@ -120,6 +120,7 @@ describe("dashboard chat", () => {
       <ThemeProvider>
         <TooltipProvider>
           <DashboardPage
+            initialProviderAvailable={true}
             selection={{
               role: "generation",
               provider: "ollama",
@@ -200,6 +201,7 @@ describe("dashboard chat", () => {
       <ThemeProvider>
         <TooltipProvider>
           <DashboardPage
+            initialProviderAvailable={true}
             selection={{
               role: "generation",
               provider: "ollama",
@@ -301,6 +303,7 @@ describe("dashboard chat", () => {
     render(
       <TooltipProvider>
         <DashboardPage
+          initialProviderAvailable={true}
           selection={{
             role: "generation",
             provider: "ollama",
@@ -446,6 +449,7 @@ describe("dashboard chat", () => {
     const page = (
       <TooltipProvider>
         <DashboardPage
+          initialProviderAvailable={true}
           selection={{
             role: "generation",
             provider: "ollama",
@@ -530,6 +534,7 @@ describe("dashboard chat", () => {
     render(
       <TooltipProvider>
         <DashboardPage
+          initialProviderAvailable={true}
           selection={{
             role: "generation",
             provider: "ollama",
@@ -681,6 +686,7 @@ describe("dashboard chat", () => {
     render(
       <TooltipProvider>
         <DashboardPage
+          initialProviderAvailable={true}
           selection={{
             role: "generation",
             provider: "ollama",
@@ -788,6 +794,7 @@ describe("dashboard chat", () => {
     render(
       <TooltipProvider>
         <DashboardPage
+          initialProviderAvailable={true}
           selection={{
             role: "generation",
             provider: "ollama",
@@ -876,6 +883,7 @@ describe("dashboard chat", () => {
     render(
       <TooltipProvider>
         <DashboardPage
+          initialProviderAvailable={true}
           selection={{
             role: "generation",
             provider: "ollama",
@@ -954,6 +962,7 @@ describe("dashboard chat", () => {
     render(
       <TooltipProvider>
         <DashboardPage
+          initialProviderAvailable={true}
           selection={{
             role: "generation",
             provider: "ollama",
@@ -1017,6 +1026,7 @@ describe("dashboard chat", () => {
       <ThemeProvider>
         <TooltipProvider>
           <DashboardPage
+            initialProviderAvailable={true}
             selection={{
               role: "generation",
               provider: "ollama",
@@ -1120,6 +1130,7 @@ describe("dashboard chat", () => {
     render(
       <TooltipProvider>
         <DashboardPage
+          initialProviderAvailable={true}
           selection={{
             role: "generation",
             provider: "ollama",
@@ -1210,6 +1221,7 @@ describe("dashboard chat", () => {
     const page = (
       <TooltipProvider>
         <DashboardPage
+          initialProviderAvailable={true}
           selection={{
             role: "generation",
             provider: "ollama",

--- a/surfsense_local/frontend/src/features/dashboard/dashboard-page.tsx
+++ b/surfsense_local/frontend/src/features/dashboard/dashboard-page.tsx
@@ -216,7 +216,6 @@ function WorkspaceDashboard({
                 <StudioPanel
                   documents={sources.documents}
                   formats={studio.formats}
-                  isLoading={studio.isLoading}
                   isCreating={studio.isCreating}
                   error={studio.error}
                   onGenerate={studio.create}
@@ -247,6 +246,7 @@ function WorkspaceDashboard({
               artifacts={
                 <ArtifactList
                   artifacts={studio.artifacts}
+                  isLoading={studio.isLoading}
                   onOpen={(artifactId) => {
                     openSources()
                     setInspect({ kind: "artifact", artifactId })

--- a/surfsense_local/frontend/src/features/dashboard/dashboard-page.tsx
+++ b/surfsense_local/frontend/src/features/dashboard/dashboard-page.tsx
@@ -125,7 +125,7 @@ function WorkspaceDashboard({
         </div>
       </div>
       <section className="my-2 mr-2 flex min-h-0 min-w-0 overflow-hidden rounded-[16px] border bg-background shadow-sm">
-        <div className="flex h-full min-h-0 w-[272px] min-w-[232px] shrink-0 flex-col">
+        <div className="flex h-full min-h-0 w-68 min-w-58 shrink-0 flex-col">
           <ThreadList
             threads={chat.threads}
             activeThreadId={chat.activeThreadId}
@@ -288,19 +288,25 @@ function WorkspacesEmpty({
   )
 }
 
+type ProviderStatus = "checking" | "available" | "unavailable"
+
 export function DashboardPage({
   selection,
+  initialProviderAvailable,
   initialWorkspaces,
   onModelUnavailable = () => undefined,
   onModelSelected,
 }: {
   selection: ModelSelection | null
+  initialProviderAvailable: boolean
   initialWorkspaces: Workspace[]
   onModelUnavailable?: () => void
   onModelSelected: (selection: ModelSelection) => void
 }) {
   const workspaces = useWorkspaces(initialWorkspaces)
-  const [providerAvailable, setProviderAvailable] = useState(true)
+  const [providerStatus, setProviderStatus] = useState<ProviderStatus>(() =>
+    initialProviderAvailable ? "available" : "checking"
+  )
   const [settingsOpen, setSettingsOpen] = useState(false)
   const [settingsSection, setSettingsSection] =
     useState<SettingsSectionId>("general")
@@ -329,11 +335,18 @@ export function DashboardPage({
           )
     void availability
       .then((available) => {
-        setProviderAvailable(available)
+        if (controller.signal.aborted) return
+        setProviderStatus(available ? "available" : "unavailable")
       })
-      .catch(() => setProviderAvailable(false))
+      .catch(() => {
+        if (controller.signal.aborted) return
+        setProviderStatus("unavailable")
+      })
     return () => controller.abort()
   }, [selection])
+
+  const providerAvailable =
+    selection !== null && providerStatus !== "unavailable"
 
   const onImported = async (accepted: ImportAccepted) => {
     const first = accepted.workspaces[0]
@@ -366,7 +379,7 @@ export function DashboardPage({
         key={workspaces.activeWorkspace.id}
         workspace={workspaces.activeWorkspace}
         selection={selection}
-        providerAvailable={selection !== null && providerAvailable}
+        providerAvailable={providerAvailable}
         onModelRequired={() => openSettings("models")}
         onModelSelected={onModelSelected}
       />

--- a/surfsense_local/frontend/src/features/dashboard/dashboard-page.tsx
+++ b/surfsense_local/frontend/src/features/dashboard/dashboard-page.tsx
@@ -46,30 +46,18 @@ import { useStudio } from "@/features/studio/use-studio"
 import type { Workspace } from "@/features/workspaces/api"
 import { useWorkspaces } from "@/features/workspaces/use-workspaces"
 import { WorkspaceRail } from "@/features/workspaces/workspace-rail"
+import {
+  readRightRailOpen,
+  readRightTab,
+  writeRightRailOpen,
+  writeRightTab,
+} from "./chrome-prefs"
 import { RightPanel, type RightTab } from "./right-panel"
-
-const SOURCES_PANEL_KEY = "sourcesPanel:v1"
 
 type Inspect =
   | { kind: "citation"; chunkId: number }
   | { kind: "artifact"; artifactId: number }
   | null
-
-function readSourcesOpen() {
-  try {
-    return localStorage.getItem(SOURCES_PANEL_KEY) !== "collapsed"
-  } catch {
-    return true
-  }
-}
-
-function writeSourcesOpen(open: boolean) {
-  try {
-    localStorage.setItem(SOURCES_PANEL_KEY, open ? "open" : "collapsed")
-  } catch {
-    // Private browsing and full disks throw.
-  }
-}
 
 function WorkspaceDashboard({
   workspace,
@@ -84,9 +72,9 @@ function WorkspaceDashboard({
   onModelRequired: () => void
   onModelSelected: (selection: ModelSelection) => void
 }) {
-  const [tab, setTab] = useState<RightTab>("sources")
+  const [tab, setTab] = useState<RightTab>(readRightTab)
   const [inspect, setInspect] = useState<Inspect>(null)
-  const [sourcesOpen, setSourcesOpen] = useState(readSourcesOpen)
+  const [sourcesOpen, setSourcesOpen] = useState(readRightRailOpen)
   const sources = useSources(workspace.id)
   const studio = useStudio(workspace.id)
   const chat = useChatRuntime({
@@ -100,13 +88,13 @@ function WorkspaceDashboard({
   const toggleSources = () => {
     setSourcesOpen((open) => {
       const next = !open
-      writeSourcesOpen(next)
+      writeRightRailOpen(next)
       return next
     })
   }
   const openSources = () => {
     setSourcesOpen(true)
-    writeSourcesOpen(true)
+    writeRightRailOpen(true)
   }
 
   return (
@@ -211,7 +199,10 @@ function WorkspaceDashboard({
                 ) : null
               }
               tab={tab}
-              onTabChange={setTab}
+              onTabChange={(next) => {
+                writeRightTab(next)
+                setTab(next)
+              }}
               studio={
                 <StudioPanel
                   documents={sources.documents}

--- a/surfsense_local/frontend/src/features/license/license-settings.test.tsx
+++ b/surfsense_local/frontend/src/features/license/license-settings.test.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import { cleanup, screen, waitFor } from "@testing-library/react"
+import { cleanup, screen, waitFor, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 
 import { ThemeProvider } from "@/components/theme-provider"
@@ -58,6 +58,13 @@ function stubApi(initial: LicenseStatus, onPut: () => Response) {
   return calls
 }
 
+async function openAddDialog(
+  user: ReturnType<typeof userEvent.setup>
+) {
+  await user.click(await screen.findByRole("button", { name: "Add license" }))
+  return screen.getByRole("dialog", { name: /Add license/ })
+}
+
 function Harness() {
   const [section, setSection] = useState<SettingsSectionId>("license")
   return (
@@ -101,12 +108,14 @@ describe("License settings", () => {
     render(<Harness />)
 
     expect(await screen.findByText("No license on this device")).toBeTruthy()
+    const dialog = await openAddDialog(user)
     await user.upload(
-      screen.getByLabelText("Choose license file"),
+      within(dialog).getByLabelText("Choose license file"),
       new File([CERTIFICATE], "individual.lic", { type: "text/plain" })
     )
 
     expect(await screen.findByText("Individual plan")).toBeTruthy()
+    expect(screen.getByText("Active")).toBeTruthy()
     expect(screen.getByText("ada@example.com")).toBeTruthy()
     expect(
       screen.getByText(/Renews 10 Sept 2027|Renews Sep 10, 2027/)
@@ -121,11 +130,12 @@ describe("License settings", () => {
     const user = userEvent.setup()
     render(<Harness />)
 
+    const dialog = await openAddDialog(user)
     await user.type(
-      await screen.findByLabelText("Paste license file"),
+      within(dialog).getByLabelText("Paste license file"),
       "-----BEGIN LICENSE FILE-----"
     )
-    await user.click(screen.getByRole("button", { name: "Add license" }))
+    await user.click(within(dialog).getByRole("button", { name: "Add" }))
 
     expect(await screen.findByText("Individual plan")).toBeTruthy()
     expect(calls[0]?.body).toEqual({
@@ -149,8 +159,9 @@ describe("License settings", () => {
     const user = userEvent.setup()
     render(<Harness />)
 
+    const dialog = await openAddDialog(user)
     await user.upload(
-      await screen.findByLabelText("Choose license file"),
+      within(dialog).getByLabelText("Choose license file"),
       new File(["nope"], "fake.lic", { type: "text/plain" })
     )
 
@@ -167,6 +178,7 @@ describe("License settings", () => {
     render(<Harness />)
 
     expect(await screen.findByText("Trial plan")).toBeTruthy()
+    expect(screen.getByRole("status").textContent).toContain("Expiring soon")
     expect(screen.getByRole("status").textContent).toContain("9 days")
   })
 
@@ -177,6 +189,20 @@ describe("License settings", () => {
     render(<Harness />)
 
     expect((await screen.findByRole("status")).textContent).toContain("expired")
+  })
+
+  it("opens replace from an active license", async () => {
+    stubApi(ACTIVE, () => Response.json(ACTIVE))
+    const user = userEvent.setup()
+    render(<Harness />)
+
+    await user.click(
+      await screen.findByRole("button", { name: "Replace license" })
+    )
+
+    expect(
+      screen.getByRole("dialog", { name: /Replace license/ })
+    ).toBeTruthy()
   })
 
   it("removes the license from this device", async () => {

--- a/surfsense_local/frontend/src/features/license/license-settings.tsx
+++ b/surfsense_local/frontend/src/features/license/license-settings.tsx
@@ -1,9 +1,21 @@
 import { useEffect, useRef, useState, type ChangeEvent } from "react"
 
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Field, FieldGroup, FieldLabel } from "@/components/ui/field"
 import { CircleAlertIcon } from "@/components/ui/icons"
 import { Input } from "@/components/ui/input"
+import { Skeleton } from "@/components/ui/skeleton"
+import { Spinner } from "@/components/ui/spinner"
 import { SettingsSection } from "@/features/settings/settings-section"
 
 import {
@@ -32,45 +44,56 @@ function dateLabel(iso: string) {
   })
 }
 
-function notice(status: LicenseStatus): string | null {
+function notice(
+  status: LicenseStatus
+): { title: string; description: string } | null {
   if (status.state === "clock_untrusted") {
-    return "This computer's clock is behind the last time SurfSense ran. Set it right to use your license."
+    return {
+      title: "Clock is off",
+      description:
+        "This computer's clock is behind the last time SurfSense ran. Set it right to use your license.",
+    }
   }
   if (status.state === "license_expired") {
-    return "This license has expired. Renew it from your account and add the new file."
+    return {
+      title: "Expired",
+      description:
+        "This license has expired. Renew it from your account and add the new file.",
+    }
   }
   if (status.expiry) {
     const days = Math.ceil((Date.parse(status.expiry) - Date.now()) / DAY)
     if (days <= EXPIRY_NOTICE_DAYS) {
-      return `This license runs out in ${days} ${days === 1 ? "day" : "days"}.`
+      return {
+        title: "Expiring soon",
+        description: `This license runs out in ${days} ${days === 1 ? "day" : "days"}.`,
+      }
     }
   }
   return null
 }
 
-export function LicenseSettings() {
-  const [status, setStatus] = useState<LicenseStatus | null>(null)
+function LicenseFormDialog({
+  replacing,
+  onOpenChange,
+  onImported,
+}: {
+  replacing: boolean
+  onOpenChange: (open: boolean) => void
+  onImported: (status: LicenseStatus) => void
+}) {
+  const fileInput = useRef<HTMLInputElement>(null)
   const [pasted, setPasted] = useState("")
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const fileInput = useRef<HTMLInputElement>(null)
 
-  useEffect(() => {
-    const controller = new AbortController()
-    readLicense(controller.signal)
-      .then(setStatus)
-      .catch((cause: unknown) => {
-        if (!controller.signal.aborted) setError(messageFrom(cause))
-      })
-    return () => controller.abort()
-  }, [])
-
-  const run = async (action: () => Promise<LicenseStatus>) => {
+  const submit = async (certificate: string) => {
+    if (certificate.trim() === "") return
     setBusy(true)
     setError(null)
     try {
-      setStatus(await action())
-      setPasted("")
+      onImported(await importLicense(certificate))
+      onOpenChange(false)
     } catch (cause) {
       setError(messageFrom(cause))
     } finally {
@@ -82,108 +105,204 @@ export function LicenseSettings() {
     const file = event.target.files?.[0]
     event.target.value = ""
     if (!file) return
-    await run(async () => importLicense(await file.text()))
+    await submit(await file.text())
   }
 
-  const remove = () =>
-    run(async () => {
+  return (
+    <Dialog open onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md select-none">
+        <DialogHeader>
+          <DialogTitle>
+            {replacing ? "Replace license" : "Add license"}
+          </DialogTitle>
+          <DialogDescription>
+            Choose a .lic file or paste it below.
+          </DialogDescription>
+        </DialogHeader>
+        <FieldGroup>
+          <Field>
+            <Input
+              ref={fileInput}
+              id="license-file"
+              type="file"
+              accept=".lic"
+              className="sr-only"
+              aria-label="Choose license file"
+              disabled={busy}
+              onChange={importPicked}
+            />
+            <Button
+              type="button"
+              variant="outline"
+              disabled={busy}
+              onClick={() => fileInput.current?.click()}
+            >
+              {busy ? <Spinner data-icon="inline-start" /> : null}
+              Choose license file
+            </Button>
+          </Field>
+          <Field>
+            <FieldLabel htmlFor="license-paste">Or paste the file</FieldLabel>
+            <textarea
+              id="license-paste"
+              aria-label="Paste license file"
+              className="min-h-24 w-full min-w-0 resize-y rounded-lg border border-input bg-transparent px-2.5 py-2 font-mono text-xs transition-colors outline-none placeholder:text-muted-foreground focus-visible:border-ring/70 disabled:pointer-events-none disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 dark:bg-input/30"
+              placeholder="-----BEGIN LICENSE FILE-----"
+              value={pasted}
+              disabled={busy}
+              onChange={(event) => setPasted(event.target.value)}
+            />
+          </Field>
+          {error ? (
+            <p role="alert" className="text-sm text-destructive">
+              {error}
+            </p>
+          ) : null}
+        </FieldGroup>
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            disabled={busy || pasted.trim() === ""}
+            onClick={() => void submit(pasted)}
+          >
+            {busy ? <Spinner data-icon="inline-start" /> : null}
+            Add
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export function LicenseSettings() {
+  const [status, setStatus] = useState<LicenseStatus | null>(null)
+  const [editor, setEditor] = useState<"add" | "replace" | null>(null)
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const controller = new AbortController()
+    readLicense(controller.signal)
+      .then(setStatus)
+      .catch((cause: unknown) => {
+        if (!controller.signal.aborted) setError(messageFrom(cause))
+      })
+    return () => controller.abort()
+  }, [])
+
+  const remove = async () => {
+    setBusy(true)
+    setError(null)
+    try {
       await removeLicense()
-      return readLicense()
-    })
+      setStatus(await readLicense())
+    } catch (cause) {
+      setError(messageFrom(cause))
+    } finally {
+      setBusy(false)
+    }
+  }
 
   const shown = status && status.state !== "none" ? notice(status) : null
+  const loading = status === null && error === null
 
   return (
     <SettingsSection
       title="License"
-      description="Plugins that call paid services need a license file from your SurfSense account. The file is checked on this device; nothing is sent anywhere."
+      description="Paid plugins need a license file from your SurfSense account. It’s verified on this device."
     >
+      {loading ? (
+        <div className="flex flex-col gap-1">
+          <Skeleton className="h-5 w-36" />
+          <Skeleton className="h-4 w-48" />
+        </div>
+      ) : null}
+
       {status?.state === "none" ? (
-        <p className="text-sm text-muted-foreground">
-          No license on this device
-        </p>
+        <div className="flex items-center justify-between gap-8">
+          <p className="text-sm text-pretty text-muted-foreground">
+            No license on this device
+          </p>
+          <Button type="button" onClick={() => setEditor("add")}>
+            Add license
+          </Button>
+        </div>
       ) : null}
 
       {status && status.state !== "none" ? (
         <div className="flex items-start justify-between gap-8">
           <div className="flex flex-col gap-1">
-            <h3 className="text-sm font-medium">
-              {planLabel(status.plan ?? "")}
-            </h3>
-            <p className="text-sm text-muted-foreground">{status.email}</p>
+            <div className="flex items-center gap-2">
+              <h3 className="text-sm font-medium text-balance">
+                {planLabel(status.plan ?? "")}
+              </h3>
+              {status.state === "active" ? (
+                <Badge variant="secondary">Active</Badge>
+              ) : null}
+            </div>
+            <p className="text-sm text-pretty text-muted-foreground">
+              {status.email}
+            </p>
             {status.expiry ? (
-              <p className="text-sm text-muted-foreground">
+              <p className="text-sm text-pretty text-muted-foreground tabular-nums">
                 {status.state === "active" ? "Renews" : "Ended"}{" "}
                 {dateLabel(status.expiry)}
                 {status.max_users ? ` · ${status.max_users} seats` : ""}
               </p>
             ) : null}
           </div>
-          <Button
-            type="button"
-            variant="outline"
-            disabled={busy}
-            onClick={remove}
-          >
-            Remove license
-          </Button>
+          <div className="flex shrink-0 gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              disabled={busy}
+              onClick={() => setEditor("replace")}
+            >
+              Replace license
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              disabled={busy}
+              onClick={() => void remove()}
+            >
+              {busy ? <Spinner data-icon="inline-start" /> : null}
+              Remove license
+            </Button>
+          </div>
         </div>
       ) : null}
 
       {shown ? (
         <Alert role="status" className="mt-6">
           <CircleAlertIcon />
-          <AlertTitle>License</AlertTitle>
-          <AlertDescription>{shown}</AlertDescription>
+          <AlertTitle>{shown.title}</AlertTitle>
+          <AlertDescription>{shown.description}</AlertDescription>
         </Alert>
       ) : null}
 
-      <div className="mt-8 flex flex-col gap-3">
-        <h3 className="text-sm font-medium">
-          {status?.state === "none" ? "Add a license" : "Replace the license"}
-        </h3>
-        <Input
-          ref={fileInput}
-          type="file"
-          accept=".lic"
-          className="sr-only"
-          aria-label="Choose license file"
-          disabled={busy}
-          onChange={importPicked}
+      {error ? (
+        <p role="alert" className="mt-6 text-sm text-destructive">
+          {error}
+        </p>
+      ) : null}
+
+      {editor !== null ? (
+        <LicenseFormDialog
+          replacing={editor === "replace"}
+          onOpenChange={(open) => {
+            if (!open) setEditor(null)
+          }}
+          onImported={setStatus}
         />
-        <div className="flex gap-2">
-          <Button
-            type="button"
-            variant="outline"
-            disabled={busy}
-            onClick={() => fileInput.current?.click()}
-          >
-            Choose license file
-          </Button>
-        </div>
-        <textarea
-          aria-label="Paste license file"
-          className="min-h-24 rounded-md border bg-transparent px-3 py-2 font-mono text-xs"
-          placeholder="-----BEGIN LICENSE FILE-----"
-          value={pasted}
-          disabled={busy}
-          onChange={(event) => setPasted(event.target.value)}
-        />
-        <div>
-          <Button
-            type="button"
-            disabled={busy || pasted.trim() === ""}
-            onClick={() => run(() => importLicense(pasted))}
-          >
-            Add license
-          </Button>
-        </div>
-        {error ? (
-          <p role="alert" className="text-sm text-destructive">
-            {error}
-          </p>
-        ) : null}
-      </div>
+      ) : null}
     </SettingsSection>
   )
 }

--- a/surfsense_local/frontend/src/features/migration/import-bundle.test.tsx
+++ b/surfsense_local/frontend/src/features/migration/import-bundle.test.tsx
@@ -111,10 +111,12 @@ describe("importing a SurfSense cloud export", () => {
       expect(screen.getByRole("button", { name: "Research" })).toBeTruthy()
     })
     expect(screen.getByRole("button", { name: "Empty" })).toBeTruthy()
-    const [, init] = fetchMock.mock.calls.find(
+    const importCall = fetchMock.mock.calls.find(
       ([input]) => String(input) === "/migration/import"
-    )!
-    expect((init?.body as FormData).get("file")).toBe(bundle)
+    )
+    const body = importCall?.[1]?.body
+    expect(body).toBeInstanceOf(FormData)
+    expect((body as FormData).get("file")).toBe(bundle)
   })
 
   it("shows the server's reason when the bundle is refused", async () => {
@@ -149,16 +151,40 @@ describe("importing a SurfSense cloud export", () => {
     const user = userEvent.setup()
     render(
       <ThemeProvider>
-        <SettingsDialog
-          open
-          section="general"
-          onOpenChange={vi.fn()}
-          onSectionChange={vi.fn()}
-          onModelSelected={vi.fn()}
-          onImported={onImported}
-        />
+        <TooltipProvider>
+          <SettingsDialog
+            open
+            section="general"
+            onOpenChange={vi.fn()}
+            onSectionChange={vi.fn()}
+            onModelSelected={vi.fn()}
+            onImported={onImported}
+          />
+        </TooltipProvider>
       </ThemeProvider>
     )
+
+    expect(
+      screen.getByRole("heading", { name: "Import from SurfSense cloud" })
+    ).toBeTruthy()
+    expect(
+      screen.getByRole("button", {
+        name: "More about importing from SurfSense cloud",
+      })
+    ).toBeTruthy()
+    expect(screen.getByRole("button", { name: "Upload" })).toBeTruthy()
+    const openExternal = vi.fn(async () => undefined)
+    vi.stubGlobal("surfsense", {
+      apiUrl: "",
+      platform: "darwin",
+      openDocument: vi.fn(async () => ""),
+      revealDocument: vi.fn(async () => ""),
+      openExternal,
+    })
+    const exportLink = screen.getByRole("link", { name: "SurfSense cloud" })
+    expect(exportLink.getAttribute("href")).toBe("https://surfsense.com/sunset")
+    await user.click(exportLink)
+    expect(openExternal).toHaveBeenCalledWith("https://surfsense.com/sunset")
 
     await user.upload(
       screen.getByLabelText("Import from SurfSense cloud"),

--- a/surfsense_local/frontend/src/features/migration/import-bundle.test.tsx
+++ b/surfsense_local/frontend/src/features/migration/import-bundle.test.tsx
@@ -42,6 +42,7 @@ function renderEmptyDashboard() {
       <TooltipProvider>
         <DashboardPage
           selection={null}
+          initialProviderAvailable={false}
           initialWorkspaces={[]}
           onModelSelected={vi.fn()}
         />

--- a/surfsense_local/frontend/src/features/migration/import-bundle.tsx
+++ b/surfsense_local/frontend/src/features/migration/import-bundle.tsx
@@ -1,7 +1,7 @@
 import { useRef, useState, type ChangeEvent } from "react"
 
 import { Button } from "@/components/ui/button"
-import { DownloadIcon } from "@/components/ui/icons"
+import { Upload01Icon } from "@/components/ui/icons"
 import { Input } from "@/components/ui/input"
 
 import { importBundle, type ImportAccepted } from "./api"
@@ -53,8 +53,8 @@ export function ImportBundleButton({
         disabled={isImporting}
         onClick={() => fileInput.current?.click()}
       >
-        <DownloadIcon />
-        {isImporting ? "Importing…" : "Import from SurfSense cloud"}
+        <Upload01Icon />
+        {isImporting ? "Importing…" : "Upload"}
       </Button>
       {error ? (
         <p role="alert" className="text-sm text-destructive">

--- a/surfsense_local/frontend/src/features/model-selection/connection-card.tsx
+++ b/surfsense_local/frontend/src/features/model-selection/connection-card.tsx
@@ -303,7 +303,7 @@ export function ConnectionCard({
         }}
       >
         <DialogContent
-          className="flex h-[85svh] max-h-[44rem] flex-col overflow-hidden select-none sm:max-w-3xl"
+          className="flex h-[85svh] max-h-[44rem] flex-col gap-0 overflow-hidden select-none sm:max-w-3xl"
           onOpenAutoFocus={(event) => {
             event.preventDefault()
             searchRef.current?.focus()
@@ -316,7 +316,7 @@ export function ConnectionCard({
             </DialogDescription>
           </DialogHeader>
 
-          <Field>
+          <Field className="mt-4">
             <FieldLabel htmlFor={`manual-model-${connection.id}`}>
               Exact model ID
             </FieldLabel>
@@ -355,11 +355,11 @@ export function ConnectionCard({
               </Button>
             </div>
             <FieldDescription>
-              Use this when the endpoint does not list a model.
+              If a model is missing from the list, type its ID and assign it.
             </FieldDescription>
           </Field>
 
-          <div className="flex min-h-0 flex-1 flex-col gap-3 border-t pt-4">
+          <div className="mt-4 flex min-h-0 flex-1 flex-col gap-3 border-t pt-4">
             <div className="relative">
               <SearchIcon className="pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground" />
               <Input
@@ -407,11 +407,11 @@ export function ConnectionCard({
               </div>
             ) : filteredModels.length ? (
               <ScrollShadow className="flex-1" viewportClassName="pr-1">
-                <ul className="flex flex-col gap-2 pb-1">
+                <ul className="divide-y pb-1">
                   {filteredModels.map((model) => (
                     <li
                       key={`${connection.id}\0${model.name}`}
-                      className="flex flex-wrap items-center gap-2 rounded-md border p-3"
+                      className="flex flex-wrap items-center content-start gap-2 py-2"
                     >
                       <div className="min-w-40 flex-1">
                         <p className="truncate text-sm font-medium">
@@ -485,7 +485,7 @@ export function ConnectionCard({
                 </ul>
               </ScrollShadow>
             ) : (
-              <Empty className="min-h-40 border">
+              <Empty className="mb-4 min-h-40 border">
                 <EmptyHeader>
                   <EmptyTitle>
                     {models?.length

--- a/surfsense_local/frontend/src/features/settings/settings-dialog.test.tsx
+++ b/surfsense_local/frontend/src/features/settings/settings-dialog.test.tsx
@@ -4,6 +4,7 @@ import { cleanup, fireEvent, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 
 import { ThemeProvider } from "@/components/theme-provider"
+import { TooltipProvider } from "@/components/ui/tooltip"
 import { render } from "@/test-utils"
 
 import { SettingsDialog, type SettingsSectionId } from "./settings-dialog"
@@ -12,13 +13,15 @@ function SettingsHarness() {
   const [section, setSection] = useState<SettingsSectionId>("general")
   return (
     <ThemeProvider>
-      <SettingsDialog
-        open
-        section={section}
-        onOpenChange={() => undefined}
-        onSectionChange={setSection}
-        onModelSelected={() => undefined}
-      />
+      <TooltipProvider>
+        <SettingsDialog
+          open
+          section={section}
+          onOpenChange={() => undefined}
+          onSectionChange={setSection}
+          onModelSelected={() => undefined}
+        />
+      </TooltipProvider>
     </ThemeProvider>
   )
 }

--- a/surfsense_local/frontend/src/features/settings/settings-dialog.test.tsx
+++ b/surfsense_local/frontend/src/features/settings/settings-dialog.test.tsx
@@ -3,7 +3,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { cleanup, fireEvent, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 
-import { ThemeProvider } from "@/components/theme-provider"
+import {
+  THEME_STORAGE_KEY,
+  ThemeProvider,
+} from "@/components/theme-provider"
 import { TooltipProvider } from "@/components/ui/tooltip"
 import { render } from "@/test-utils"
 
@@ -86,7 +89,7 @@ describe("SettingsDialog", () => {
       screen.getByRole("radio", { name: "Switch to dark theme" })
     )
 
-    expect(localStorage.getItem("theme")).toBe("dark")
+    expect(localStorage.getItem(THEME_STORAGE_KEY)).toBe("dark")
     await waitFor(() =>
       expect(document.documentElement.classList.contains("dark")).toBe(true)
     )

--- a/surfsense_local/frontend/src/features/settings/settings-dialog.tsx
+++ b/surfsense_local/frontend/src/features/settings/settings-dialog.tsx
@@ -11,7 +11,7 @@ import {
 import {
   CpuIcon,
   InformationCircleIcon,
-  KeyRoundIcon,
+  LicenseIcon,
   Settings2Icon,
 } from "@/components/ui/icons"
 import {
@@ -126,7 +126,7 @@ const SETTINGS_SECTIONS = [
   {
     id: "license",
     label: "License",
-    icon: KeyRoundIcon,
+    icon: LicenseIcon,
   },
 ] satisfies SettingsNavItem[]
 

--- a/surfsense_local/frontend/src/features/settings/settings-dialog.tsx
+++ b/surfsense_local/frontend/src/features/settings/settings-dialog.tsx
@@ -1,4 +1,4 @@
-import type { ComponentType } from "react"
+import type { ComponentType, MouseEvent } from "react"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -8,7 +8,17 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
-import { CpuIcon, KeyRoundIcon, Settings2Icon } from "@/components/ui/icons"
+import {
+  CpuIcon,
+  InformationCircleIcon,
+  KeyRoundIcon,
+  Settings2Icon,
+} from "@/components/ui/icons"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
 import { LicenseSettings } from "@/features/license/license-settings"
 import type { ImportAccepted } from "@/features/migration/api"
 import { ImportBundleButton } from "@/features/migration/import-bundle"
@@ -26,6 +36,14 @@ type SettingsNavItem = {
 }
 
 export type SettingsSectionId = "general" | "models" | "license"
+
+const CLOUD_EXPORT_URL = "https://surfsense.com/sunset"
+
+function openCloudExport(event: MouseEvent<HTMLAnchorElement>) {
+  if (!window.surfsense?.openExternal) return
+  event.preventDefault()
+  void window.surfsense.openExternal(CLOUD_EXPORT_URL)
+}
 
 function GeneralSettings({
   onImported,
@@ -48,11 +66,43 @@ function GeneralSettings({
       </div>
       <div className="mt-8 flex items-center justify-between gap-8">
         <div className="flex flex-col gap-1">
-          <h3 className="text-sm font-medium">Import from SurfSense cloud</h3>
-          <p className="text-sm text-pretty text-muted-foreground">
-            Load the export bundle downloaded from your hosted account.
-            Documents arrive as markdown and are indexed in the background;
-            original files and live citation links do not travel.
+          <div className="flex items-center gap-1">
+            <h3 className="text-sm font-medium text-balance">
+              Import from SurfSense cloud
+            </h3>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  className="relative inline-flex size-5 items-center justify-center rounded-sm text-muted-foreground transition-colors duration-150 hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:outline-none before:absolute before:inset-[-10px]"
+                  aria-label="More about importing from SurfSense cloud"
+                >
+                  <InformationCircleIcon
+                    className="size-3.5"
+                    strokeWidth={1.5}
+                  />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent
+                side="top"
+                collisionPadding={12}
+                className="max-w-64 font-normal leading-5"
+              >
+                Your workspaces, folders, and chats come with it. Documents come in as text and get indexed after import. Original files and generated artifacts stay in the cloud.
+              </TooltipContent>
+            </Tooltip>
+          </div>
+          <p className="text-sm text-pretty text-muted-foreground [&_a]:underline [&_a]:underline-offset-3 [&_a]:hover:text-foreground">
+            Upload the ZIP you exported from{" "}
+            <a
+              href={CLOUD_EXPORT_URL}
+              target="_blank"
+              rel="noreferrer"
+              onClick={openCloudExport}
+            >
+              SurfSense cloud
+            </a>
+            .
           </p>
         </div>
         <ImportBundleButton onImported={onImported} />

--- a/surfsense_local/frontend/src/features/sources/sources-panel.tsx
+++ b/surfsense_local/frontend/src/features/sources/sources-panel.tsx
@@ -48,7 +48,7 @@ import {
   EmptyTitle,
 } from "@/components/ui/empty"
 import { ScrollShadow } from "@/components/ui/scroll-shadow"
-import { Skeleton } from "@/components/ui/skeleton"
+import { SkeletonSlabs } from "@/components/ui/skeleton"
 import { SOURCE_FILE_ACCEPT, type WorkspaceDocument } from "./api"
 import { Input } from "@/components/ui/input"
 import { Spinner } from "@/components/ui/spinner"
@@ -359,11 +359,7 @@ export function SourcesPanel({
         {listHeader}
         <ScrollShadow className="min-h-0 flex-1" from="from-background">
           {isLoading ? (
-            <div className="flex flex-col gap-3">
-              {[0, 1, 2].map((item) => (
-                <Skeleton key={item} className="h-20 w-full" />
-              ))}
-            </div>
+            <SkeletonSlabs />
           ) : documents.length > 0 ? (
             <div className="flex flex-col gap-1">
               {documents.map((document) => (

--- a/surfsense_local/frontend/src/features/sources/sources-panel.tsx
+++ b/surfsense_local/frontend/src/features/sources/sources-panel.tsx
@@ -95,7 +95,7 @@ function SelectableSourceRow({
       ref={rowRef}
       aria-current={highlighted ? "true" : undefined}
       className={cn(
-        "group group/source relative flex h-8 w-full min-w-0 items-center gap-1.5 overflow-hidden rounded-lg border border-transparent pr-2 pl-1 hover:bg-muted dark:hover:bg-muted/50",
+        "group group/source relative flex h-8 w-full min-w-0 items-center gap-1.5 overflow-hidden rounded-lg border border-transparent pr-2 pl-1 select-none hover:bg-muted dark:hover:bg-muted/50",
         highlighted && "border-ring",
         selected && "bg-sidebar-accent text-white",
         dropdownOpen && "bg-muted dark:bg-muted/50"

--- a/surfsense_local/frontend/src/features/studio/artifact-list.test.tsx
+++ b/surfsense_local/frontend/src/features/studio/artifact-list.test.tsx
@@ -41,6 +41,15 @@ describe("artifact list", () => {
     expect(screen.getByText("No generated artifacts yet")).toBeTruthy()
   })
 
+  it("shows list skeletons while artifacts load", () => {
+    renderList({ artifacts: [], isLoading: true })
+
+    expect(screen.queryByText("No generated artifacts yet")).toBeNull()
+    expect(
+      document.querySelectorAll("[data-slot=skeleton]").length
+    ).toBeGreaterThan(0)
+  })
+
   it("opens ready artifacts", async () => {
     const onOpen = vi.fn()
     const user = userEvent.setup()

--- a/surfsense_local/frontend/src/features/studio/artifact-list.tsx
+++ b/surfsense_local/frontend/src/features/studio/artifact-list.tsx
@@ -35,6 +35,7 @@ import {
   EmptyTitle,
 } from "@/components/ui/empty"
 import { ScrollShadow } from "@/components/ui/scroll-shadow"
+import { SkeletonSlabs } from "@/components/ui/skeleton"
 import { Spinner } from "@/components/ui/spinner"
 import {
   Tooltip,
@@ -157,10 +158,12 @@ function ArtifactRow({
 
 export function ArtifactList({
   artifacts,
+  isLoading = false,
   onOpen,
   onDelete,
 }: {
   artifacts: Artifact[]
+  isLoading?: boolean
   onOpen: (id: number) => void
   onDelete: (id: number) => void
 }) {
@@ -180,7 +183,9 @@ export function ArtifactList({
         </h3>
       </div>
       <ScrollShadow className="min-h-0 flex-1" from="from-background">
-        {artifacts.length === 0 ? (
+        {isLoading ? (
+          <SkeletonSlabs />
+        ) : artifacts.length === 0 ? (
           <Empty className="min-h-0 border-0 px-2">
             <EmptyHeader>
               <EmptyMedia variant="icon">

--- a/surfsense_local/frontend/src/features/studio/studio-panel.test.tsx
+++ b/surfsense_local/frontend/src/features/studio/studio-panel.test.tsx
@@ -41,13 +41,13 @@ function StudioHarness({
       <StudioPanel
         documents={documents}
         formats={studio.formats}
-        isLoading={studio.isLoading}
         isCreating={studio.isCreating}
         error={studio.error}
         onGenerate={studio.create}
       />
       <ArtifactList
         artifacts={studio.artifacts}
+        isLoading={studio.isLoading}
         onOpen={vi.fn()}
         onDelete={(id) => void studio.remove(id)}
       />
@@ -80,6 +80,24 @@ afterEach(() => {
 })
 
 describe("studio panel", () => {
+  it("shows the catalog cards before formats load", () => {
+    render(
+      <TooltipProvider>
+        <StudioPanel
+          documents={[]}
+          formats={[]}
+          isCreating={false}
+          error={null}
+          onGenerate={async () => false}
+        />
+      </TooltipProvider>
+    )
+
+    expect(screen.getByRole("button", { name: "Summary" })).toBeTruthy()
+    expect(screen.getByRole("button", { name: "Infographic" })).toBeTruthy()
+    expect(document.querySelector("[data-slot=skeleton]")).toBeNull()
+  })
+
   it("submits a job for the chosen format and sources", async () => {
     const fetchMock = vi.fn(
       async (input: RequestInfo | URL, init?: RequestInit) => {

--- a/surfsense_local/frontend/src/features/studio/studio-panel.tsx
+++ b/surfsense_local/frontend/src/features/studio/studio-panel.tsx
@@ -28,7 +28,6 @@ import {
 } from "@/components/ui/dialog"
 import { Input } from "@/components/ui/input"
 import { ScrollArea } from "@/components/ui/scroll-area"
-import { Skeleton } from "@/components/ui/skeleton"
 import { Spinner } from "@/components/ui/spinner"
 import {
   Tooltip,
@@ -68,6 +67,27 @@ export const FORMAT_ICONS: Record<string, ComponentType<{ className?: string }>>
   podcast: PodcastIcon,
   image: Image01Icon,
   infographic: ChartHistogramIcon,
+}
+
+const STUDIO_CATALOG: StudioFormat[] = [
+  { key: "summary", label: "Summary", requires_role: "generation", available: true, unavailable_reason: null },
+  { key: "docx", label: "Document", requires_role: "generation", available: true, unavailable_reason: null },
+  { key: "pptx", label: "Slides", requires_role: "generation", available: true, unavailable_reason: null },
+  { key: "xlsx", label: "Spreadsheet", requires_role: "generation", available: true, unavailable_reason: null },
+  { key: "html", label: "Web page", requires_role: "generation", available: true, unavailable_reason: null },
+  { key: "pdf", label: "PDF", requires_role: "generation", available: true, unavailable_reason: null },
+  { key: "mindmap", label: "Mind map", requires_role: "generation", available: true, unavailable_reason: null },
+  { key: "flashcards", label: "Flashcards", requires_role: "generation", available: true, unavailable_reason: null },
+  { key: "quiz", label: "Quiz", requires_role: "generation", available: true, unavailable_reason: null },
+  { key: "podcast", label: "Podcast", requires_role: "generation", available: true, unavailable_reason: null },
+  { key: "image", label: "Image", requires_role: "image_generation", available: true, unavailable_reason: null },
+  { key: "infographic", label: "Infographic", requires_role: "generation", available: true, unavailable_reason: null },
+]
+
+function catalogFormats(formats: StudioFormat[]) {
+  if (formats.length === 0) return STUDIO_CATALOG
+  const loaded = new Map(formats.map((entry) => [entry.key, entry]))
+  return STUDIO_CATALOG.map((entry) => loaded.get(entry.key) ?? entry)
 }
 
 function unavailableReason(entry: StudioFormat) {
@@ -257,20 +277,19 @@ function FormatCard({
 export function StudioPanel({
   documents,
   formats,
-  isLoading,
   isCreating,
   error,
   onGenerate,
 }: {
   documents: WorkspaceDocument[]
   formats: StudioFormat[]
-  isLoading: boolean
   isCreating: boolean
   error: string | null
   onGenerate: (job: StudioJobCreate) => Promise<boolean>
 }) {
   const [format, setFormat] = useState<string | null>(null)
-  const selectedFormat = formats.find((entry) => entry.key === format)
+  const catalog = catalogFormats(formats)
+  const selectedFormat = catalog.find((entry) => entry.key === format)
 
   return (
     <>
@@ -281,32 +300,24 @@ export function StudioPanel({
         </Alert>
       ) : null}
 
-      {isLoading ? (
+      <section className="space-y-2" aria-labelledby="studio-formats">
+        <h3
+          id="studio-formats"
+          className="text-xs font-medium text-muted-foreground"
+        >
+          Studio
+        </h3>
         <div className="grid grid-cols-3 gap-1.5">
-          {[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11].map((item) => (
-            <Skeleton key={item} className="h-16 w-full" />
+          {catalog.map((entry) => (
+            <FormatCard
+              key={entry.key}
+              entry={entry}
+              selected={format === entry.key}
+              onSelect={() => setFormat(entry.key)}
+            />
           ))}
         </div>
-      ) : (
-        <section className="space-y-2" aria-labelledby="studio-formats">
-          <h3
-            id="studio-formats"
-            className="text-xs font-medium text-muted-foreground"
-          >
-            Studio
-          </h3>
-          <div className="grid grid-cols-3 gap-1.5">
-            {formats.map((entry) => (
-              <FormatCard
-                key={entry.key}
-                entry={entry}
-                selected={format === entry.key}
-                onSelect={() => setFormat(entry.key)}
-              />
-            ))}
-          </div>
-        </section>
-      )}
+      </section>
 
       <Dialog
         open={selectedFormat != null}

--- a/surfsense_local/frontend/src/features/studio/studio-panel.tsx
+++ b/surfsense_local/frontend/src/features/studio/studio-panel.tsx
@@ -235,7 +235,7 @@ function FormatCard({
           aria-disabled={!entry.available || undefined}
           aria-pressed={entry.available ? selected : undefined}
           className={cn(
-            "flex min-w-0 cursor-pointer flex-col items-center gap-1 rounded-lg border bg-muted/40 px-1 py-2 text-center [&_svg]:size-4",
+            "flex min-w-0 cursor-pointer flex-col items-center gap-1 rounded-lg border border-transparent bg-muted/40 px-1 py-2 text-center [&_svg]:size-4",
             entry.available
               ? "hover:bg-accent"
               : "cursor-not-allowed opacity-50",

--- a/surfsense_local/frontend/src/features/workspaces/use-workspaces.ts
+++ b/surfsense_local/frontend/src/features/workspaces/use-workspaces.ts
@@ -8,7 +8,7 @@ import {
   type Workspace,
 } from "./api"
 
-const LAST_WORKSPACE_KEY = "surfsense-local:last-workspace:v1"
+const LAST_WORKSPACE_KEY = "surfsense:last-workspace:v1"
 
 function readLastWorkspaceId(workspaces: Workspace[]): number | null {
   try {

--- a/surfsense_local/frontend/src/features/workspaces/workspace-rail.tsx
+++ b/surfsense_local/frontend/src/features/workspaces/workspace-rail.tsx
@@ -1,4 +1,4 @@
-import { useState, type FormEvent } from "react"
+import { useRef, useState, type FormEvent } from "react"
 import {
   PencilIcon,
   PlusIcon,
@@ -73,6 +73,7 @@ function WorkspaceNameDialog({
   onOpenChange: (open: boolean) => void
   onSubmit: (name: string) => Promise<boolean>
 }) {
+  const inputRef = useRef<HTMLInputElement>(null)
   const [name, setName] = useState(initialName)
   const [isSubmitting, setIsSubmitting] = useState(false)
 
@@ -91,18 +92,26 @@ function WorkspaceNameDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent>
+      <DialogContent
+        onOpenAutoFocus={(event) => {
+          event.preventDefault()
+          const input = inputRef.current
+          if (!input) return
+          input.focus()
+          input.select()
+        }}
+      >
         <form onSubmit={(event) => void submit(event)}>
           <DialogHeader>
             <DialogTitle>{title}</DialogTitle>
             <DialogDescription>{description}</DialogDescription>
           </DialogHeader>
           <Input
+            ref={inputRef}
             className="my-4"
             value={name}
             onChange={(event) => setName(event.target.value)}
             aria-label="Workspace name"
-            autoFocus
             maxLength={200}
           />
           <DialogFooter>

--- a/surfsense_local/frontend/src/features/workspaces/workspace-rail.tsx
+++ b/surfsense_local/frontend/src/features/workspaces/workspace-rail.tsx
@@ -93,6 +93,7 @@ function WorkspaceNameDialog({
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
+        className="select-none"
         onOpenAutoFocus={(event) => {
           event.preventDefault()
           const input = inputRef.current
@@ -282,7 +283,7 @@ export function WorkspaceRail({
           if (!open) setDeleting(null)
         }}
       >
-        <AlertDialogContent>
+        <AlertDialogContent className="select-none">
           <AlertDialogHeader>
             <AlertDialogTitle>Delete {deleting?.name}?</AlertDialogTitle>
             <AlertDialogDescription>

--- a/surfsense_local/frontend/src/lib/api.ts
+++ b/surfsense_local/frontend/src/lib/api.ts
@@ -16,6 +16,7 @@ declare global {
         color: string
         symbolColor: string
       }) => Promise<void>
+      openExternal?: (url: string) => Promise<void>
     }
   }
 }

--- a/surfsense_web/app/(home)/sunset/page.tsx
+++ b/surfsense_web/app/(home)/sunset/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { SunsetExport } from "./sunset-export";
 
 export const metadata: Metadata = {
 	title: "SurfSense is moving | SurfSense",
@@ -7,9 +8,20 @@ export const metadata: Metadata = {
 
 export default function SunsetPage() {
 	return (
-		<div className="container max-w-4xl mx-auto py-12 px-4">
-			<h1 className="text-4xl font-bold mb-8">SurfSense is moving to a local app</h1>
-			<p className="text-lg">Details, export and download steps will appear here soon.</p>
+		<div className="container mx-auto max-w-2xl px-4 pt-28 pb-16">
+			<div className="flex flex-col gap-8">
+				<div className="flex flex-col gap-4">
+					<h1 className="text-4xl font-bold text-balance">
+						SurfSense is moving to a local app
+					</h1>
+					<p className="text-lg text-pretty text-muted-foreground">
+						The hosted app is going away. A free local app will replace it. After launch, this
+						site stays up for 30 days so you can export, then hosted data is deleted. The deletion
+						date will appear here once launch day is set.
+					</p>
+				</div>
+				<SunsetExport />
+			</div>
 		</div>
 	);
 }

--- a/surfsense_web/app/(home)/sunset/sunset-export.tsx
+++ b/surfsense_web/app/(home)/sunset/sunset-export.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { useState } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import {
+	Card,
+	CardContent,
+	CardDescription,
+	CardFooter,
+	CardHeader,
+	CardTitle,
+} from "@/components/ui/card";
+import { Spinner } from "@/components/ui/spinner";
+import { useSession } from "@/hooks/use-session";
+import { authenticatedFetch } from "@/lib/auth-fetch";
+import { redirectToLogin } from "@/lib/auth-utils";
+import { buildBackendUrl } from "@/lib/env-config";
+
+const FALLBACK_FILENAME = "surfsense-export.zip";
+const DISPOSITION_FILENAME = /filename\*?=(?:UTF-8'')?"?([^";]+)/i;
+
+export function filenameFromDisposition(header: string | null): string {
+	if (!header) return FALLBACK_FILENAME;
+	const match = header.match(DISPOSITION_FILENAME);
+	const name = match?.[1]?.trim();
+	return name || FALLBACK_FILENAME;
+}
+
+function triggerDownload(blob: Blob, filename: string) {
+	const url = URL.createObjectURL(blob);
+	const a = document.createElement("a");
+	a.href = url;
+	a.download = filename;
+	document.body.appendChild(a);
+	a.click();
+	a.remove();
+	URL.revokeObjectURL(url);
+}
+
+export function SunsetExport() {
+	const session = useSession();
+	const [isExporting, setIsExporting] = useState(false);
+
+	async function handleExport() {
+		if (isExporting) return;
+		if (session.status !== "authenticated") {
+			redirectToLogin();
+			return;
+		}
+
+		setIsExporting(true);
+		try {
+			const response = await authenticatedFetch(buildBackendUrl("/api/v1/export"), {
+				method: "GET",
+				skipAuthRedirect: true,
+			});
+			if (response.status === 401) {
+				redirectToLogin();
+				return;
+			}
+			if (!response.ok) {
+				const errorData = await response.json().catch(() => ({ detail: "Export failed" }));
+				throw new Error(
+					typeof errorData.detail === "string" ? errorData.detail : "Export failed"
+				);
+			}
+
+			const blob = await response.blob();
+			triggerDownload(blob, filenameFromDisposition(response.headers.get("Content-Disposition")));
+
+			const skipped = response.headers.get("X-Skipped-Documents");
+			toast.success(
+				skipped
+					? `Account exported. ${skipped} document${skipped === "1" ? "" : "s"} skipped.`
+					: "Account exported"
+			);
+		} catch (err) {
+			toast.error(err instanceof Error ? err.message : "Export failed");
+		} finally {
+			setIsExporting(false);
+		}
+	}
+
+	const sessionLoading = session.status === "loading";
+	const busy = sessionLoading || isExporting;
+	const signedIn = session.status === "authenticated";
+
+	return (
+		<Card className="bg-card/80">
+			<CardHeader>
+				<CardTitle className="text-balance">Export your account</CardTitle>
+				<CardDescription className="text-pretty">
+					Downloads every workspace you can access: ready documents as markdown, folder structure,
+					and chat threads.
+				</CardDescription>
+			</CardHeader>
+			<CardContent>
+				<p className="text-pretty text-sm text-muted-foreground">
+					Original uploads, generated artifacts, tool calls, agent steps, and live citation links
+					are not included.
+				</p>
+			</CardContent>
+			<CardFooter>
+				<Button
+					type="button"
+					size="lg"
+					disabled={busy}
+					onClick={() => void handleExport()}
+					className="relative min-h-11 w-fit shrink-0 active:scale-[0.96] transition-transform"
+				>
+					<span className={busy ? "opacity-0" : ""}>
+						{signedIn ? "Export account" : "Sign in to export"}
+					</span>
+					{busy ? <Spinner size="sm" className="absolute" /> : null}
+				</Button>
+			</CardFooter>
+		</Card>
+	);
+}

--- a/surfsense_web/lib/auth-utils.ts
+++ b/surfsense_web/lib/auth-utils.ts
@@ -34,6 +34,7 @@ const PUBLIC_ROUTE_PREFIXES = [
 	"/changelog",
 	"/announcements",
 	"/blog",
+	"/sunset",
 	// Connector marketing pages (see lib/connectors-marketing)
 	"/connectors",
 	"/mcp-server",

--- a/surfsense_web/tests/unit/sunset-export.test.ts
+++ b/surfsense_web/tests/unit/sunset-export.test.ts
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { filenameFromDisposition } from "@/app/(home)/sunset/sunset-export";
+import { isPublicRoute } from "@/lib/auth-utils";
+
+test("sunset is a public route so Zero does not blank the page", () => {
+	assert.equal(isPublicRoute("/sunset"), true);
+});
+
+test("export filename comes from Content-Disposition", () => {
+	assert.equal(
+		filenameFromDisposition('attachment; filename="surfsense-export.zip"'),
+		"surfsense-export.zip"
+	);
+	assert.equal(filenameFromDisposition(null), "surfsense-export.zip");
+});


### PR DESCRIPTION
<!--- Summarize your pull request in a few sentences -->

## Description
<!--- Clearly describe what has changed in this pull request -->
- Implement account export functionality across backend and frontend, enabling users to export workspace data as ZIP archives with documents, chats, and citations
- Enhance Electron app chat experience with thread persistence across sessions, improved conversation view management, and automatic thread/chat creation flow
- Consolidate storage keys under surfsense: prefix for consistency (theme, workspace, thread, dashboard preferences)
- Redesign dashboard with refined skeleton loading states using staggered slab placeholders for better visual feedback on sources, artifacts, and threads
- Eliminate "Reconnect your model provider" flash on page refresh by seeding initial provider availability from bootstrap, and prevent stale verdicts on model switching with tri-state availability tracking
- Add production application menu for packaged Electron app with reload, zoom, and fullscreen controls; disable DevTools access in packaged builds
- Enhance external link handling in Electron with shell.openExternal integration for SurfSense cloud import flows
- Redesign license management UI with modal dialog flow for adding and replacing licenses, and icon updates for visual consistency
- Add select-none classes across UI components and dialogs for improved user experience and prevent accidental text selection
- Implement auto-focus on critical inputs and dialogs (model picker, workspace name, license form) for better accessibility
- Add web frontend sunset page for account export with proper routing and styling

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If this PR relates to an open issue, please link to the issue here: FIX #123 -->
FIX #


## Screenshots
<!-- If applicable, add screenshots or images to demonstrate the changes visually -->

## API Changes
<!-- Document any API changes if applicable -->
- [ ] This PR includes API changes

## Change Type
<!--- Indicate what kind(s) of changes this PR includes: -->
- [x] Bug fix
- [x] New feature
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Documentation
- [ ] Dependency/Build system
- [ ] Breaking change
- [ ] Other (specify):

## Testing Performed
<!--- Briefly describe how you have tested these changes and what verification was performed -->
- [ ] Tested locally
- [ ] Manual/QA verification

## Checklist
<!--- Please confirm the following by marking with an 'x' as appropriate -->
- [ ] Follows project coding standards and conventions
- [ ] Documentation updated as needed
- [ ] Dependencies updated as needed
- [ ] No lint/build errors or new warnings
- [ ] All relevant tests are passing

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR implements a comprehensive account export feature across both backend and frontend, enabling users to export all their workspace data as a ZIP archive. The backend adds a new `build_account_export_zip` function that exports workspaces with documents, chat threads, and citations in a structured format, while the web frontend adds a new `/sunset` page with an export UI. The local Electron app receives numerous UX improvements including chat persistence across sessions, better loading states with skeleton screens, enhanced security restrictions for external links, improved dialog interactions with autofocus, and refined UI polish (select-none classes, updated icons, better spacing). Additionally, storage keys are consolidated with a `surfsense:` prefix for consistency, and the license settings UI is redesigned with a modal dialog flow.

⏱️ Estimated Review Time: 30-90 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `surfsense_backend/app/routes/export_routes.py` |
| 2 | `surfsense_backend/app/services/export_service.py` |
| 3 | `surfsense_backend/tests/unit/services/test_account_export.py` |
| 4 | `surfsense_backend/tests/integration/test_account_export.py` |
| 5 | `surfsense_backend/tests/unit/routes/test_legacy_reports_demolition.py` |
| 6 | `surfsense_web/app/(home)/sunset/page.tsx` |
| 7 | `surfsense_web/app/(home)/sunset/sunset-export.tsx` |
| 8 | `surfsense_web/lib/auth-utils.ts` |
| 9 | `surfsense_web/tests/unit/sunset-export.test.ts` |
| 10 | `surfsense_local/frontend/src/app/app-bootstrap.tsx` |
| 11 | `surfsense_local/frontend/src/features/dashboard/dashboard-page.tsx` |
| 12 | `surfsense_local/frontend/src/features/dashboard/chrome-prefs.ts` |
| 13 | `surfsense_local/frontend/src/features/dashboard/right-panel.tsx` |
| 14 | `surfsense_local/frontend/src/features/chat/use-chat-runtime.ts` |
| 15 | `surfsense_local/frontend/src/features/chat/thread-panel.tsx` |
| 16 | `surfsense_local/frontend/src/features/chat/thread-list.tsx` |
| 17 | `surfsense_local/frontend/src/features/chat/chat-composer.tsx` |
| 18 | `surfsense_local/frontend/src/features/chat/message.tsx` |
| 19 | `surfsense_local/frontend/src/features/chat/model-picker.tsx` |
| 20 | `surfsense_local/frontend/src/features/sources/sources-panel.tsx` |
| 21 | `surfsense_local/frontend/src/features/studio/studio-panel.tsx` |
| 22 | `surfsense_local/frontend/src/features/studio/artifact-list.tsx` |
| 23 | `surfsense_local/frontend/src/features/migration/import-bundle.tsx` |
| 24 | `surfsense_local/frontend/src/features/license/license-settings.tsx` |
| 25 | `surfsense_local/frontend/src/features/settings/settings-dialog.tsx` |
| 26 | `surfsense_local/frontend/src/features/model-selection/connection-card.tsx` |
| 27 | `surfsense_local/frontend/src/features/workspaces/workspace-rail.tsx` |
| 28 | `surfsense_local/frontend/src/features/workspaces/use-workspaces.ts` |
| 29 | `surfsense_local/frontend/src/components/relative-time.tsx` |
| 30 | `surfsense_local/frontend/src/components/theme-provider.tsx` |
| 31 | `surfsense_local/frontend/src/components/ui/icons.tsx` |
| 32 | `surfsense_local/frontend/src/components/ui/skeleton.tsx` |
| 33 | `surfsense_local/electron/src/main/index.ts` |
| 34 | `surfsense_local/electron/src/preload/index.ts` |
| 35 | `surfsense_local/frontend/src/lib/api.ts` |
| 36 | `surfsense_local/frontend/src/features/dashboard/dashboard-page.test.tsx` |
| 37 | `surfsense_local/frontend/src/features/chat/thread-list.test.tsx` |
| 38 | `surfsense_local/frontend/src/features/studio/studio-panel.test.tsx` |
| 39 | `surfsense_local/frontend/src/features/studio/artifact-list.test.tsx` |
| 40 | `surfsense_local/frontend/src/features/migration/import-bundle.test.tsx` |
| 41 | `surfsense_local/frontend/src/features/license/license-settings.test.tsx` |
| 42 | `surfsense_local/frontend/src/features/settings/settings-dialog.test.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->